### PR TITLE
Admin offline ZIP download from Sheets browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Frontend favicon & attribution**: Turtle favicon from Flaticon (`frontend/public/favicon.png`) with `rel="icon"` and `apple-touch-icon` in `index.html`; global app footer with required Freepik / www.flaticon.com links and a link to the specific icon for license compliance.
+- **Admin offline backup (ZIP)**: `GET /api/admin/backup/archive` (`scope=all` or `scope=sheet&sheet=…`) returns a ZIP mirroring `data/` plus Google Sheets CSV/JSON exports (`require_admin_only`, not staff). **Google Sheets Browser** shows an admin-only “Offline backup (ZIP)” menu (full archive or current tab). Client: `downloadAdminBackupArchive`, `isAdminRole`.
 
 ### Changed
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -35,6 +35,7 @@ from routes.sheets import register_sheets_routes
 from routes.turtles import register_turtle_routes
 from routes.locations import register_locations_routes
 from routes.general_locations import register_general_location_routes
+from routes.admin_backup import register_admin_backup_routes
 
 # Create Flask app
 app = Flask(__name__)
@@ -57,6 +58,7 @@ register_sheets_routes(app)
 register_turtle_routes(app)
 register_locations_routes(app)
 register_general_location_routes(app)
+register_admin_backup_routes(app)
 
 @app.errorhandler(Exception)
 def handle_exception(err):

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -138,3 +138,28 @@ def require_admin(f):
         request.user = user_data
         return f(*args, **kwargs)
     return decorated_function
+
+
+def require_admin_only(f):
+    """Decorator: role must be admin (not staff) — e.g. full data backup download."""
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if request.method == 'OPTIONS':
+            return jsonify({}), 200
+
+        success, user_data, error = get_user_from_request()
+        if not success:
+            return jsonify({'error': error or 'Authentication required'}), 401
+
+        if user_data.get('role') != 'admin':
+            return jsonify({'error': 'Admin access required'}), 403
+
+        auth_header = request.headers.get('Authorization')
+        if auth_header:
+            allowed, revoke_error = check_auth_revocation(auth_header)
+            if not allowed:
+                return jsonify({'error': revoke_error or 'Token has been revoked'}), 403
+
+        request.user = user_data
+        return f(*args, **kwargs)
+    return decorated_function

--- a/backend/routes/admin_backup.py
+++ b/backend/routes/admin_backup.py
@@ -1,0 +1,199 @@
+"""
+Admin-only backup download: ZIP with a mirror of backend data/ plus Google Sheets CSV/JSON exports.
+"""
+
+import csv
+import io
+import json
+import os
+import posixpath
+import re
+import zipfile
+from datetime import datetime, timezone
+
+from flask import Response, jsonify, request
+
+from auth import require_admin_only
+from backup.run import _safe_filename
+from services import manager_service
+from services.manager_service import get_community_sheets_service, get_sheets_service
+
+
+def _safe_folder_name(sheet_name: str) -> str:
+    """Match turtle_manager._safe_folder_name for on-disk paths."""
+    invalid = r'\/:*?"<>|'
+    if not sheet_name or not isinstance(sheet_name, str):
+        return "_"
+    out = sheet_name.strip()
+    for c in invalid:
+        out = out.replace(c, "_")
+    return out or "_"
+
+
+def _zip_add_tree(zipf: zipfile.ZipFile, source_root: str, arc_prefix: str) -> None:
+    """Add all files under source_root into the zip under arc_prefix (forward slashes)."""
+    source_root = os.path.abspath(source_root)
+    if not os.path.isdir(source_root):
+        return
+    arc_prefix = arc_prefix.strip("/").replace("\\", "/")
+    for dirpath, _, filenames in os.walk(source_root):
+        for fn in filenames:
+            full = os.path.join(dirpath, fn)
+            if not os.path.isfile(full):
+                continue
+            rel = os.path.relpath(full, source_root)
+            rel_posix = rel.replace("\\", "/")
+            if rel_posix.startswith(".."):
+                continue
+            arcname = posixpath.join(arc_prefix, rel_posix)
+            zipf.write(full, arcname, compress_type=zipfile.ZIP_DEFLATED, compresslevel=6)
+
+
+def _csv_bytes(rows: list) -> bytes:
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    for row in rows or []:
+        writer.writerow([str(c) if c is not None else "" for c in row])
+    return buf.getvalue().encode("utf-8")
+
+
+def _build_backup_zip(scope: str, sheet_name: str | None) -> tuple[bytes, str]:
+    """
+    scope: 'all' | 'sheet'
+    sheet_name: required for scope=sheet (Google Sheet tab name).
+    Returns (zip_bytes, suggested_filename).
+    """
+    if not manager_service.manager_ready.wait(timeout=30):
+        raise RuntimeError("Data manager not ready")
+    mgr = manager_service.manager
+    if mgr is None:
+        raise RuntimeError("Data manager unavailable")
+
+    base_dir = os.path.abspath(mgr.base_dir)
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+    admin_svc = get_sheets_service()
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zipf:
+        if scope == "all":
+            _zip_add_tree(zipf, base_dir, "data")
+            if admin_svc:
+                sheet_names = admin_svc.list_sheets() or []
+                all_data = {}
+                for sn in sheet_names:
+                    safe = _safe_filename(sn)
+                    values = admin_svc.get_sheet_rows(sn)
+                    if values is None:
+                        continue
+                    zipf.writestr(
+                        f"sheets_export/admin_{safe}.csv",
+                        _csv_bytes(values),
+                        compress_type=zipfile.ZIP_DEFLATED,
+                    )
+                    all_data[sn] = values
+                if all_data:
+                    zipf.writestr(
+                        "sheets_export/admin.json",
+                        json.dumps(all_data, ensure_ascii=False, indent=2).encode("utf-8"),
+                        compress_type=zipfile.ZIP_DEFLATED,
+                    )
+            comm = get_community_sheets_service()
+            if comm:
+                sheet_names = comm.list_sheets() or []
+                all_comm = {}
+                for sn in sheet_names:
+                    safe = _safe_filename(sn)
+                    values = comm.get_sheet_rows(sn)
+                    if values is None:
+                        continue
+                    zipf.writestr(
+                        f"sheets_export/community_{safe}.csv",
+                        _csv_bytes(values),
+                        compress_type=zipfile.ZIP_DEFLATED,
+                    )
+                    all_comm[sn] = values
+                if all_comm:
+                    zipf.writestr(
+                        "sheets_export/community.json",
+                        json.dumps(all_comm, ensure_ascii=False, indent=2).encode("utf-8"),
+                        compress_type=zipfile.ZIP_DEFLATED,
+                    )
+            readme = (
+                "TurtleTracker offline backup (admin download)\n"
+                "=============================================\n"
+                "data/     — mirror of the server backend data directory for this scope.\n"
+                "sheets_export/ — CSV + JSON snapshots from Google Sheets (research + community).\n"
+                "\n"
+                "Restore: copy contents of data/ over the backend data folder. "
+                "If spreadsheets are lost, recreate tabs and import the matching CSV files.\n"
+            )
+            zipf.writestr("sheets_export/README.txt", readme.encode("utf-8"), compress_type=zipfile.ZIP_DEFLATED)
+            fname = f"turtle-backup-all-{stamp}.zip"
+        elif scope == "sheet":
+            sn = (sheet_name or "").strip()
+            if not sn:
+                raise ValueError("sheet parameter required for scope=sheet")
+            if not admin_svc:
+                raise RuntimeError("Google Sheets service not configured")
+            valid = admin_svc.list_sheets() or []
+            if sn not in valid:
+                raise ValueError(f"Unknown sheet tab: {sn!r}")
+            folder = os.path.join(base_dir, _safe_folder_name(sn))
+            _zip_add_tree(zipf, folder, posixpath.join("data", _safe_folder_name(sn)))
+            values = admin_svc.get_sheet_rows(sn)
+            if values is None:
+                raise RuntimeError(f"Could not read sheet tab {sn!r}")
+            safe = _safe_filename(sn)
+            zipf.writestr(
+                f"sheets_export/admin_{safe}.csv",
+                _csv_bytes(values),
+                compress_type=zipfile.ZIP_DEFLATED,
+            )
+            zipf.writestr(
+                "sheets_export/admin_sheet.json",
+                json.dumps({sn: values}, ensure_ascii=False, indent=2).encode("utf-8"),
+                compress_type=zipfile.ZIP_DEFLATED,
+            )
+            readme = (
+                "TurtleTracker offline backup (single spreadsheet tab)\n"
+                "======================================================\n"
+                f"Sheet tab: {sn}\n"
+                "data/ contains only the on-disk folder for this tab (as under backend/data).\n"
+                "sheets_export/ has CSV + JSON for this tab.\n"
+            )
+            zipf.writestr("sheets_export/README.txt", readme.encode("utf-8"), compress_type=zipfile.ZIP_DEFLATED)
+            safe_stub = re.sub(r"[^a-zA-Z0-9._-]+", "_", sn).strip("_") or "sheet"
+            fname = f"turtle-backup-sheet-{safe_stub}-{stamp}.zip"
+        else:
+            raise ValueError("scope must be 'all' or 'sheet'")
+
+    return buf.getvalue(), fname
+
+
+def register_admin_backup_routes(app):
+    @app.route("/api/admin/backup/archive", methods=["GET", "OPTIONS"])
+    @require_admin_only
+    def download_admin_backup_archive():
+        if request.method == "OPTIONS":
+            return "", 200
+        scope = (request.args.get("scope") or "").strip().lower()
+        sheet_name = (request.args.get("sheet") or "").strip() or None
+        if not scope:
+            return jsonify({"error": "Missing query parameter: scope (all or sheet)"}), 400
+        try:
+            data, filename = _build_backup_zip(scope, sheet_name)
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+        except RuntimeError as e:
+            return jsonify({"error": str(e)}), 503
+        except Exception as e:
+            return jsonify({"error": f"Backup failed: {e}"}), 500
+
+        return Response(
+            data,
+            mimetype="application/zip",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Length": str(len(data)),
+            },
+        )

--- a/frontend/src/pages/AdminTurtleRecords/SheetsBrowserTab.tsx
+++ b/frontend/src/pages/AdminTurtleRecords/SheetsBrowserTab.tsx
@@ -9,6 +9,7 @@ import {
   Grid,
   Group,
   Image,
+  Menu,
   Paper,
   ScrollArea,
   Select,
@@ -16,8 +17,17 @@ import {
   Text,
   TextInput,
 } from '@mantine/core';
-import { IconDatabase, IconMapPin, IconPhoto, IconSearch, IconSkull } from '@tabler/icons-react';
-import { getImageUrl, getTurtleImages, getTurtlePrimariesBatch, type TurtleImagesResponse } from '../../services/api';
+import { notifications } from '@mantine/notifications';
+import { IconDatabase, IconDownload, IconMapPin, IconPhoto, IconSearch, IconSkull } from '@tabler/icons-react';
+import {
+  downloadAdminBackupArchive,
+  getImageUrl,
+  getTurtleImages,
+  getTurtlePrimariesBatch,
+  isAdminRole,
+  type TurtleImagesResponse,
+} from '../../services/api';
+import { useUser } from '../../hooks/useUser';
 import { TurtleSheetsDataForm } from '../../components/TurtleSheetsDataForm';
 import { AdditionalImagesSection } from '../../components/AdditionalImagesSection';
 import { useAdminTurtleRecordsContext } from './AdminTurtleRecordsContext';
@@ -34,9 +44,11 @@ function isSheetsDeceasedYes(v?: string | null): boolean {
 }
 
 export function SheetsBrowserTab() {
+  const { role } = useUser();
   const ctx = useAdminTurtleRecordsContext();
   const [turtleImages, setTurtleImages] = useState<TurtleImagesResponse | null>(null);
   const [primaryImages, setPrimaryImages] = useState<Record<string, string | null>>({});
+  const [backupLoading, setBackupLoading] = useState(false);
   const {
     selectedSheetFilter,
     sheetsListLoading,
@@ -150,6 +162,81 @@ export function SheetsBrowserTab() {
             <Button onClick={() => loadAllTurtles()} loading={turtlesLoading} fullWidth>
               Refresh
             </Button>
+            {isAdminRole(role) && (
+              <>
+                <Menu shadow='md' width={320} withinPortal>
+                  <Menu.Target>
+                    <Button
+                      variant='light'
+                      color='teal'
+                      fullWidth
+                      leftSection={<IconDownload size={16} />}
+                      loading={backupLoading}
+                    >
+                      Offline backup (ZIP)
+                    </Button>
+                  </Menu.Target>
+                  <Menu.Dropdown>
+                    <Menu.Label>Server data folder + Google Sheets</Menu.Label>
+                    <Menu.Item
+                      onClick={async () => {
+                        setBackupLoading(true);
+                        try {
+                          await downloadAdminBackupArchive({ scope: 'all' });
+                          notifications.show({
+                            title: 'Download started',
+                            message: 'Save the ZIP from your browser downloads folder.',
+                            color: 'teal',
+                          });
+                        } catch (e) {
+                          notifications.show({
+                            title: 'Backup failed',
+                            message: e instanceof Error ? e.message : 'Unknown error',
+                            color: 'red',
+                          });
+                        } finally {
+                          setBackupLoading(false);
+                        }
+                      }}
+                    >
+                      Full archive — entire data directory and all sheet tabs
+                    </Menu.Item>
+                    <Menu.Item
+                      disabled={!selectedSheetFilter}
+                      onClick={async () => {
+                        const sheet = selectedSheetFilter;
+                        if (!sheet) return;
+                        setBackupLoading(true);
+                        try {
+                          await downloadAdminBackupArchive({ scope: 'sheet', sheet });
+                          notifications.show({
+                            title: 'Download started',
+                            message: `Backup for tab "${sheet}" is saving to your downloads folder.`,
+                            color: 'teal',
+                          });
+                        } catch (e) {
+                          notifications.show({
+                            title: 'Backup failed',
+                            message: e instanceof Error ? e.message : 'Unknown error',
+                            color: 'red',
+                          });
+                        } finally {
+                          setBackupLoading(false);
+                        }
+                      }}
+                    >
+                      Current location tab only
+                      {selectedSheetFilter
+                        ? ` (${selectedSheetFilter})`
+                        : ' — pick a location above'}
+                    </Menu.Item>
+                  </Menu.Dropdown>
+                </Menu>
+                <Text size='xs' c='dimmed'>
+                  Admin only. ZIP includes on-disk data and CSV/JSON sheet snapshots for disaster recovery.
+                </Text>
+              </>
+            )}
             <Divider />
             <Text size='sm' c='dimmed'>
               {filteredTurtles.length} of {allTurtles.length} turtles

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -26,6 +26,7 @@ export {
   setUserRole,
   deleteUser,
   isStaffRole,
+  isAdminRole,
 } from './api/auth';
 export { fetchCommunityGameState, saveCommunityGameState } from './api/communityGame';
 export type {
@@ -87,6 +88,7 @@ export {
   createSheet,
   getTurtleNames,
   listAllTurtlesFromSheets,
+  downloadAdminBackupArchive,
 } from './api/sheets';
 export type {
   TurtleSheetsData,

--- a/frontend/src/services/api/auth.ts
+++ b/frontend/src/services/api/auth.ts
@@ -25,6 +25,11 @@ export function isStaffRole(role: string | undefined): role is UserRole {
   return role === 'staff' || role === 'admin';
 }
 
+/** True only for full admin (user management, offline backup download). */
+export function isAdminRole(role: string | undefined): boolean {
+  return role === 'admin';
+}
+
 export interface AuthResponse {
   success: boolean;
   token: string;

--- a/frontend/src/services/api/sheets.ts
+++ b/frontend/src/services/api/sheets.ts
@@ -669,3 +669,64 @@ export const listAllTurtlesFromSheets = async (
 
   return await response.json();
 };
+
+/**
+ * Admin-only: download ZIP with backend data/ mirror + Google Sheets CSV/JSON exports.
+ * Triggers a browser file download.
+ */
+export async function downloadAdminBackupArchive(
+  options: { scope: 'all' } | { scope: 'sheet'; sheet: string },
+  timeoutMs = 600000,
+): Promise<void> {
+  const token = getToken();
+  if (!token) {
+    throw new Error('Not authenticated');
+  }
+
+  const params = new URLSearchParams({ scope: options.scope });
+  if (options.scope === 'sheet') {
+    params.set('sheet', options.sheet);
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(
+      `${TURTLE_API_BASE_URL}/admin/backup/archive?${params.toString()}`,
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${token}` },
+        signal: controller.signal,
+      },
+    );
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      throw new Error((err as { error?: string }).error || 'Backup download failed');
+    }
+
+    const blob = await response.blob();
+    const cd = response.headers.get('Content-Disposition');
+    let filename = 'turtle-backup.zip';
+    const m = cd && /filename="([^"]+)"/.exec(cd);
+    if (m) {
+      filename = m[1];
+    }
+
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  } catch (e) {
+    clearTimeout(timeoutId);
+    if (e instanceof Error && e.name === 'AbortError') {
+      throw new Error(`Request timed out after ${timeoutMs}ms`);
+    }
+    throw e;
+  }
+}


### PR DESCRIPTION
Add require_admin_only auth, GET /api/admin/backup/archive (full data + sheet exports), and admin-only UI in Google Sheets Browser.