### PR TITLE
fix/feat: case-insensitive .pt image lookup + HEIC upload support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Match thumbnails missing for `.JPG` references (Linux)**: Reference images saved with uppercase extensions (e.g. `F128.JPG`) were not resolving on the production Linux server because `convert_pt_to_image_path` and the related candidate-copy / replace-reference paths hard-coded a lowercase extension list (`['.jpg', '.jpeg', '.png']`) combined with `os.path.exists`. Case-sensitive filesystems silently returned the raw `.pt` path, which the frontend then couldn't render. Added case-insensitive helpers `routes.upload.find_image_for_pt`, `turtle_manager._find_image_next_to_pt`, and `turtle_manager._find_image_in_dir` that scan the containing directory and match the file stem against any supported image extension regardless of case. Windows/NTFS was never affected because its filesystem is case-insensitive.
+- **HEIC upload failures without EXIF**: `image_utils.normalize_to_jpeg` previously passed `img.info.get('exif', b'')` to Pillow's JPEG encoder, but some HEIC files store `'exif'` mapped to `None` rather than omitting the key, bypassing the default and crashing the encoder with `TypeError: object of type 'NoneType' has no len()`. Guarded so `exif=` is only passed to `save()` when actual bytes are present.
+
+### Added
+
+- **HEIC/HEIF upload support**: iPhone photos arrive as HEIC by default and Chrome/Firefox cannot render HEIC natively. New `backend/image_utils.py` registers `pillow-heif` at import time and exposes `normalize_to_jpeg()`, which is a no-op for non-HEIC inputs and otherwise converts in-place to a sibling `.jpg` (quality 95, EXIF preserved — including `DateTimeOriginal` for future history-date aggregation — EXIF rotation applied). Called immediately after every `file.save()` in `routes/upload.py`, `routes/review.py`, and `routes/turtles.py` (5 call sites). `heic`/`heif` added to `config.ALLOWED_EXTENSIONS`; `pillow-heif>=0.16.0` added to `backend/requirements.txt`. Frontend `fileValidation.ts` accepts `image/heic` / `image/heif` with an extension fallback (Chrome/Firefox leave `file.type` blank for HEIC), `HomePage.tsx` Dropzone accept list and user-facing "Supported formats" text updated to include HEIC.
+
+### Testing
+
+- **`backend/tests/test_image_lookup.py` (32 tests)**: Regression coverage for the case-insensitive lookup. Parametrised across `.jpg`/`.JPG`/`.jpeg`/`.JPEG`/`.png`/`.PNG`/`.Jpg`/`.JPg` against all three helpers, plus passthrough / missing-sibling / missing-directory / unrelated-file / alias contract cases.
+- **`backend/tests/test_image_utils.py` (13 tests)**: HEIC normalization coverage. Generates HEIC fixtures programmatically via pillow-heif's bundled encoder to exercise real encode → decode round-trips. Verifies sibling `.jpg` creation, original-file deletion, uppercase `.HEIC` / `.heif` handling, EXIF `DateTimeOriginal` preservation, and multi-tag EXIF round-trip.
+
 ## [1.2.5] - 2026-04-13 — Admin offline backup URL (Flask vs Express)
 
 ### Fixed

--- a/backend/config.py
+++ b/backend/config.py
@@ -55,7 +55,9 @@ if 'PORT' not in os.environ:
 
 # Configuration constants
 UPLOAD_FOLDER = tempfile.gettempdir()
-ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'webp'}
+# heic/heif accepted here but normalized to JPEG by image_utils.normalize_to_jpeg
+# before any downstream code sees the file.
+ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'webp', 'heic', 'heif'}
 MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
 
 # JWT Configuration - must match auth-backend JWT_SECRET

--- a/backend/image_utils.py
+++ b/backend/image_utils.py
@@ -27,9 +27,11 @@ def normalize_to_jpeg(src_path):
     dest = os.path.splitext(src_path)[0] + '.jpg'
     with Image.open(src_path) as img:
         img = ImageOps.exif_transpose(img)
-        img.convert('RGB').save(
-            dest, 'JPEG', quality=95, optimize=True,
-            exif=img.info.get('exif', b''),
-        )
+        save_kwargs = {'quality': 95, 'optimize': True}
+        # Only attach EXIF when present — Pillow's JPEG encoder chokes on None.
+        exif_bytes = img.info.get('exif') or b''
+        if exif_bytes:
+            save_kwargs['exif'] = exif_bytes
+        img.convert('RGB').save(dest, 'JPEG', **save_kwargs)
     os.remove(src_path)
     return dest

--- a/backend/image_utils.py
+++ b/backend/image_utils.py
@@ -1,0 +1,35 @@
+"""HEIC/HEIF → JPEG normalization for uploaded images.
+
+iPhone photos arrive as HEIC by default. We normalize to JPEG at every
+upload boundary so downstream code (SuperPoint, frontend <img>) only sees
+formats it can handle. EXIF is preserved so the history-date aggregation
+keeps working on iPhone uploads.
+"""
+
+import os
+
+from PIL import Image, ImageOps
+from pillow_heif import register_heif_opener
+
+register_heif_opener()
+
+HEIC_EXTENSIONS = ('.heic', '.heif')
+
+
+def normalize_to_jpeg(src_path):
+    """If ``src_path`` is HEIC/HEIF, convert to a sibling .jpg and delete the original.
+
+    Returns the path downstream code should use — unchanged for non-HEIC inputs.
+    Applies EXIF rotation and preserves EXIF metadata (including DateTimeOriginal).
+    """
+    if not src_path or os.path.splitext(src_path)[1].lower() not in HEIC_EXTENSIONS:
+        return src_path
+    dest = os.path.splitext(src_path)[0] + '.jpg'
+    with Image.open(src_path) as img:
+        img = ImageOps.exif_transpose(img)
+        img.convert('RGB').save(
+            dest, 'JPEG', quality=95, optimize=True,
+            exif=img.info.get('exif', b''),
+        )
+    os.remove(src_path)
+    return dest

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,8 @@
 flask==3.0.0
 flask-cors==4.0.0
 Pillow>=10.0
+# HEIC/HEIF support — iPhone photos upload as HEIC by default
+pillow-heif>=0.16.0
 numpy>=1.26.0
 scikit-learn>=1.3.2
 joblib>=1.3.2

--- a/backend/routes/review.py
+++ b/backend/routes/review.py
@@ -12,6 +12,7 @@ from auth import require_admin
 from services import manager_service
 from services.manager_service import get_sheets_service, get_community_sheets_service
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
+from image_utils import normalize_to_jpeg
 from general_locations_catalog import resolve_general_location_from_sheet_and_value
 
 # Metadata keys to strip when syncing turtle data to community spreadsheet
@@ -248,6 +249,8 @@ def register_review_routes(app):
                 ext = os.path.splitext(secure_filename(f.filename))[1] or '.jpg'
                 temp_path = os.path.join(UPLOAD_FOLDER, f"review_extra_{request_id}_{idx}_{int(time.time())}{ext}")
                 f.save(temp_path)
+                # HEIC/HEIF → JPEG (no-op for other formats)
+                temp_path = normalize_to_jpeg(temp_path)
                 files_with_types.append({'path': temp_path, 'type': typ, 'timestamp': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())})
             if not files_with_types:
                 return jsonify({'error': 'No valid image files provided'}), 400

--- a/backend/routes/turtles.py
+++ b/backend/routes/turtles.py
@@ -9,6 +9,7 @@ from flask import request, jsonify
 from werkzeug.utils import secure_filename
 from auth import require_admin
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
+from image_utils import normalize_to_jpeg
 from services import manager_service
 
 
@@ -219,6 +220,8 @@ def register_turtle_routes(app):
                     f"turtle_extra_{turtle_id}_{idx}_{int(time.time())}{ext}".replace(os.sep, '_'),
                 )
                 f.save(temp_path)
+                # HEIC/HEIF → JPEG (no-op for other formats)
+                temp_path = normalize_to_jpeg(temp_path)
                 files_with_types.append({
                     'path': temp_path,
                     'type': typ,

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -16,25 +16,42 @@ from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
 from auth import optional_auth, check_auth_revocation
 from services import manager_service
 
-# ARCHITECT NOTE: Kept .pt conversion for SuperPoint integration
-def convert_pt_to_image_path(pt_path):
-    """
-    Convert a .pt file path to the corresponding image file path.
-    Tries common image extensions (.jpg, .jpeg, .png).
-    Returns the image path if found, otherwise returns the original pt_path.
+_IMAGE_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.gif', '.webp')
+
+
+def find_image_for_pt(pt_path):
+    """Find the image file next to a .pt file, matching the extension case-insensitively.
+
+    The filesystem on Linux is case-sensitive, so a hard-coded lowercase extension
+    list would miss files named e.g. ``F128.JPG`` (uppercase). This helper scans
+    the containing directory for any file with the same stem and a supported
+    image extension regardless of case.
+
+    Returns the discovered image path, or ``pt_path`` unchanged when no image is
+    found (callers already treat that as "no image").
     """
     if not pt_path or not pt_path.endswith('.pt'):
         return pt_path
-
-    base_path = pt_path[:-3]  # Remove .pt extension
-    image_extensions = ['.jpg', '.jpeg', '.png', '.gif', '.webp']
-
-    for ext in image_extensions:
-        image_path = base_path + ext
-        if os.path.exists(image_path) and os.path.isfile(image_path):
-            return image_path
-
+    base = pt_path[:-3]
+    dir_path = os.path.dirname(base) or '.'
+    base_name = os.path.basename(base)
+    if not os.path.isdir(dir_path):
+        return pt_path
+    try:
+        entries = os.listdir(dir_path)
+    except OSError:
+        return pt_path
+    for fname in entries:
+        stem, ext = os.path.splitext(fname)
+        if stem == base_name and ext.lower() in _IMAGE_EXTENSIONS:
+            return os.path.join(dir_path, fname)
     return pt_path
+
+
+# ARCHITECT NOTE: Kept .pt conversion for SuperPoint integration
+def convert_pt_to_image_path(pt_path):
+    """Backwards-compatible wrapper — delegates to case-insensitive lookup."""
+    return find_image_for_pt(pt_path)
 
 def register_upload_routes(app):
     """Register upload routes"""
@@ -173,18 +190,17 @@ def register_upload_routes(app):
 
                     # Write candidate images to disk so the Review Queue can
                     # display them if the admin backs out of the match page.
+                    # Uses case-insensitive lookup so .JPG files are handled.
                     os.makedirs(candidates_dir, exist_ok=True)
                     for rank, match in enumerate(matches, start=1):
                         pt_path = match.get('file_path', '') or ''
-                        if pt_path and pt_path.endswith('.pt'):
-                            base_path = pt_path[:-3]
-                            for ext in ['.jpg', '.jpeg', '.png']:
-                                if os.path.exists(base_path + ext):
-                                    turtle_id = match.get('site_id', 'Unknown')
-                                    conf_int = int(round(match.get('confidence', 0.0) * 100))
-                                    cand_filename = f"Rank{rank}_ID{turtle_id}_Conf{conf_int}{ext}"
-                                    shutil.copy2(base_path + ext, os.path.join(candidates_dir, cand_filename))
-                                    break
+                        img_src = find_image_for_pt(pt_path)
+                        if img_src and img_src != pt_path and os.path.isfile(img_src):
+                            ext = os.path.splitext(img_src)[1]
+                            turtle_id = match.get('site_id', 'Unknown')
+                            conf_int = int(round(match.get('confidence', 0.0) * 100))
+                            cand_filename = f"Rank{rank}_ID{turtle_id}_Conf{conf_int}{ext}"
+                            shutil.copy2(img_src, os.path.join(candidates_dir, cand_filename))
 
                     formatted_matches = []
                     for match in matches:

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -14,6 +14,7 @@ from flask import request, jsonify
 from werkzeug.utils import secure_filename
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
 from auth import optional_auth, check_auth_revocation
+from image_utils import normalize_to_jpeg
 from services import manager_service
 
 _IMAGE_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.gif', '.webp')
@@ -109,6 +110,9 @@ def register_upload_routes(app):
             filename = secure_filename(file.filename)
             temp_path = os.path.join(UPLOAD_FOLDER, filename)
             file.save(temp_path)
+            # HEIC/HEIF → JPEG so SuperPoint + frontend can handle it
+            temp_path = normalize_to_jpeg(temp_path)
+            filename = os.path.basename(temp_path)
 
             if not os.path.exists(temp_path):
                 return jsonify({'error': 'Failed to save file'}), 500
@@ -162,6 +166,8 @@ def register_upload_routes(app):
                                 ext = os.path.splitext(secure_filename(f.filename))[1] or '.jpg'
                                 extra_temp = os.path.join(UPLOAD_FOLDER, f"extra_{request_id}_{typ}_{int(time.time())}{ext}")
                                 f.save(extra_temp)
+                                # HEIC/HEIF → JPEG (no-op for other formats)
+                                extra_temp = normalize_to_jpeg(extra_temp)
                                 files_with_types.append({'path': extra_temp, 'type': typ, 'timestamp': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())})
 
                 if files_with_types:
@@ -289,6 +295,8 @@ def register_upload_routes(app):
                                 ext = os.path.splitext(secure_filename(f.filename))[1] or '.jpg'
                                 extra_temp = os.path.join(UPLOAD_FOLDER, f"extra_{request_id}_{typ}_{int(time.time())}{ext}")
                                 f.save(extra_temp)
+                                # HEIC/HEIF → JPEG (no-op for other formats)
+                                extra_temp = normalize_to_jpeg(extra_temp)
                                 files_with_types.append({'path': extra_temp, 'type': typ, 'timestamp': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())})
 
                 # Run matching and packet creation in the background so the

--- a/backend/tests/test_image_lookup.py
+++ b/backend/tests/test_image_lookup.py
@@ -1,0 +1,158 @@
+"""Tests for case-insensitive .pt → image file lookup.
+
+Regression coverage for the production bug where reference images saved with
+uppercase extensions (``F128.JPG``) were not resolving on Linux. The broken
+code used a hard-coded ``['.jpg', '.jpeg', '.png']`` list combined with
+``os.path.exists(base + ext)``, which only finds lowercase files on a
+case-sensitive filesystem.
+
+Exercises three helpers that share the same contract:
+
+- ``routes.upload.find_image_for_pt``  (also aliased as ``convert_pt_to_image_path``)
+- ``turtle_manager._find_image_next_to_pt``
+- ``turtle_manager._find_image_in_dir``
+"""
+
+import os
+
+import pytest
+
+from routes.upload import find_image_for_pt, convert_pt_to_image_path
+from turtle_manager import _find_image_next_to_pt, _find_image_in_dir
+
+
+# ---- find_image_for_pt (upload.py) + _find_image_next_to_pt (turtle_manager) ----
+#
+# These two helpers take a .pt path and return either the sibling image
+# or a no-image signal. upload.py returns the original pt_path when no
+# image exists; turtle_manager returns None. Both are tested under the
+# same parametrisation so the coverage stays symmetric.
+
+
+def _write_empty_file(path):
+    with open(path, 'wb') as f:
+        f.write(b'')
+
+
+@pytest.mark.parametrize('case_ext', ['.jpg', '.JPG', '.jpeg', '.JPEG', '.png', '.PNG', '.Jpg', '.JPg'])
+def test_upload_find_image_for_pt_matches_any_case(tmp_path, case_ext):
+    pt = tmp_path / 'F128.pt'
+    _write_empty_file(pt)
+    img = tmp_path / f'F128{case_ext}'
+    _write_empty_file(img)
+
+    result = find_image_for_pt(str(pt))
+    assert result == str(img)
+
+
+@pytest.mark.parametrize('case_ext', ['.jpg', '.JPG', '.jpeg', '.JPEG', '.png', '.PNG', '.Jpg', '.JPg'])
+def test_turtle_manager_find_image_next_to_pt_matches_any_case(tmp_path, case_ext):
+    pt = tmp_path / 'F128.pt'
+    _write_empty_file(pt)
+    img = tmp_path / f'F128{case_ext}'
+    _write_empty_file(img)
+
+    result = _find_image_next_to_pt(str(pt))
+    assert result == str(img)
+
+
+def test_upload_find_image_for_pt_returns_original_when_no_sibling(tmp_path):
+    pt = tmp_path / 'F128.pt'
+    _write_empty_file(pt)
+
+    # Callers in upload.py treat "path unchanged" as "no image found"
+    assert find_image_for_pt(str(pt)) == str(pt)
+
+
+def test_turtle_manager_find_image_next_to_pt_returns_none_when_no_sibling(tmp_path):
+    pt = tmp_path / 'F128.pt'
+    _write_empty_file(pt)
+
+    # Callers in turtle_manager.py treat None as "no image found"
+    assert _find_image_next_to_pt(str(pt)) is None
+
+
+def test_upload_find_image_for_pt_non_pt_input_passthrough():
+    assert find_image_for_pt('/tmp/foo.jpg') == '/tmp/foo.jpg'
+    assert find_image_for_pt('') == ''
+    assert find_image_for_pt(None) is None
+
+
+def test_turtle_manager_find_image_next_to_pt_non_pt_input_returns_none():
+    assert _find_image_next_to_pt('/tmp/foo.jpg') is None
+    assert _find_image_next_to_pt('') is None
+    assert _find_image_next_to_pt(None) is None
+
+
+def test_find_image_ignores_unrelated_files_in_dir(tmp_path):
+    pt = tmp_path / 'F128.pt'
+    _write_empty_file(pt)
+    # Sibling PT and unrelated files should not be returned.
+    _write_empty_file(tmp_path / 'F200.jpg')
+    _write_empty_file(tmp_path / 'notes.txt')
+    _write_empty_file(tmp_path / 'F128.pt.bak')
+
+    # No matching stem → returns original (upload) or None (turtle_manager)
+    assert find_image_for_pt(str(pt)) == str(pt)
+    assert _find_image_next_to_pt(str(pt)) is None
+
+    # Add the matching image and re-check
+    match = tmp_path / 'F128.JPG'
+    _write_empty_file(match)
+    assert find_image_for_pt(str(pt)) == str(match)
+    assert _find_image_next_to_pt(str(pt)) == str(match)
+
+
+def test_find_image_handles_missing_parent_directory():
+    # Directory doesn't exist → should not raise
+    assert find_image_for_pt('/nonexistent/directory/F128.pt') == '/nonexistent/directory/F128.pt'
+    assert _find_image_next_to_pt('/nonexistent/directory/F128.pt') is None
+
+
+def test_convert_pt_to_image_path_is_alias_of_find_image_for_pt(tmp_path):
+    pt = tmp_path / 'F128.pt'
+    _write_empty_file(pt)
+    img = tmp_path / 'F128.JPG'
+    _write_empty_file(img)
+
+    assert convert_pt_to_image_path(str(pt)) == find_image_for_pt(str(pt)) == str(img)
+
+
+# ---- _find_image_in_dir (turtle_manager) ----
+#
+# Different contract: given a directory and a stem, return the image path
+# (case-insensitive extension match). Used by approve_review_packet's
+# replace-reference old-image lookup.
+
+
+@pytest.mark.parametrize('case_ext', ['.jpg', '.JPG', '.jpeg', '.JPEG', '.png', '.PNG'])
+def test_find_image_in_dir_matches_any_case(tmp_path, case_ext):
+    img = tmp_path / f'F128{case_ext}'
+    _write_empty_file(img)
+
+    assert _find_image_in_dir(str(tmp_path), 'F128') == str(img)
+
+
+def test_find_image_in_dir_returns_none_when_stem_missing(tmp_path):
+    _write_empty_file(tmp_path / 'F200.jpg')  # different stem
+    _write_empty_file(tmp_path / 'notes.txt')  # different type
+
+    assert _find_image_in_dir(str(tmp_path), 'F128') is None
+
+
+def test_find_image_in_dir_handles_missing_directory():
+    assert _find_image_in_dir('/nonexistent/directory', 'F128') is None
+
+
+def test_find_image_in_dir_ignores_pt_and_other_extensions(tmp_path):
+    # Shouldn't match .pt, .txt, etc.
+    _write_empty_file(tmp_path / 'F128.pt')
+    _write_empty_file(tmp_path / 'F128.txt')
+    _write_empty_file(tmp_path / 'F128.bak')
+
+    assert _find_image_in_dir(str(tmp_path), 'F128') is None
+
+    # Add an actual image and confirm it's now found
+    img = tmp_path / 'F128.JPG'
+    _write_empty_file(img)
+    assert _find_image_in_dir(str(tmp_path), 'F128') == str(img)

--- a/backend/tests/test_image_utils.py
+++ b/backend/tests/test_image_utils.py
@@ -1,0 +1,167 @@
+"""Tests for HEIC/HEIF → JPEG normalization.
+
+Covers the ``image_utils.normalize_to_jpeg`` helper used at every upload
+save boundary. Test HEIC fixtures are generated programmatically via
+``pillow-heif``'s encoder (bundled with the pip package) rather than
+committed binary files, so the tests exercise a real end-to-end encode
+→ decode round-trip.
+
+Critical coverage:
+- Non-HEIC inputs pass through untouched (no wasted re-encode).
+- HEIC files are converted to a sibling .jpg and the original deleted.
+- EXIF DateTimeOriginal survives the conversion — the history-date
+  aggregation in routes/turtles.py depends on this.
+- Uppercase ``.HEIC`` is handled case-insensitively.
+"""
+
+import os
+
+import pytest
+from PIL import Image
+
+from image_utils import HEIC_EXTENSIONS, normalize_to_jpeg
+
+
+# ---------- Passthrough cases (no re-encoding) ----------
+
+
+def test_none_passthrough():
+    assert normalize_to_jpeg(None) is None
+
+
+def test_empty_string_passthrough():
+    assert normalize_to_jpeg('') == ''
+
+
+def test_jpg_passthrough(tmp_path):
+    path = tmp_path / 'already.jpg'
+    Image.new('RGB', (8, 8)).save(str(path), 'JPEG')
+    result = normalize_to_jpeg(str(path))
+    assert result == str(path)
+    assert os.path.exists(str(path))  # untouched
+
+
+def test_png_passthrough(tmp_path):
+    path = tmp_path / 'other.png'
+    Image.new('RGB', (8, 8)).save(str(path), 'PNG')
+    result = normalize_to_jpeg(str(path))
+    assert result == str(path)
+    assert os.path.exists(str(path))
+
+
+def test_unknown_extension_passthrough(tmp_path):
+    path = tmp_path / 'data.bin'
+    path.write_bytes(b'not an image')
+    result = normalize_to_jpeg(str(path))
+    assert result == str(path)
+    assert os.path.exists(str(path))  # untouched
+
+
+def test_nonexistent_non_heic_path_passthrough():
+    # Non-HEIC inputs return unchanged even if the file doesn't exist,
+    # because callers may pass paths that were cleaned up upstream.
+    assert normalize_to_jpeg('/tmp/does-not-exist.jpg') == '/tmp/does-not-exist.jpg'
+
+
+# ---------- HEIC → JPEG conversion ----------
+
+
+def _make_heic(path, color='red', exif=None):
+    """Helper: create a small HEIC file at ``path``, returning the saved path as str."""
+    img = Image.new('RGB', (16, 16), color=color)
+    save_kwargs = {}
+    if exif is not None:
+        save_kwargs['exif'] = exif
+    img.save(str(path), 'HEIF', **save_kwargs)
+    return str(path)
+
+
+def test_heic_converts_to_sibling_jpg(tmp_path):
+    heic = _make_heic(tmp_path / 'photo.heic')
+
+    result = normalize_to_jpeg(heic)
+
+    assert result == str(tmp_path / 'photo.jpg')
+    assert os.path.exists(result)
+    # Original HEIC has been deleted
+    assert not os.path.exists(heic)
+
+
+def test_heic_uppercase_extension_handled(tmp_path):
+    heic = _make_heic(tmp_path / 'photo.HEIC')
+
+    result = normalize_to_jpeg(heic)
+
+    # Destination preserves the original stem but switches the extension
+    assert result == str(tmp_path / 'photo.jpg')
+    assert os.path.exists(result)
+    assert not os.path.exists(heic)
+
+
+def test_heif_extension_handled(tmp_path):
+    heic = _make_heic(tmp_path / 'photo.heif')
+
+    result = normalize_to_jpeg(heic)
+
+    assert result == str(tmp_path / 'photo.jpg')
+    assert os.path.exists(result)
+    assert not os.path.exists(heic)
+
+
+def test_converted_jpeg_is_a_valid_image(tmp_path):
+    heic = _make_heic(tmp_path / 'photo.heic', color='blue')
+
+    result = normalize_to_jpeg(heic)
+
+    # Pillow can reopen the converted file and it matches the source dimensions
+    with Image.open(result) as img:
+        assert img.format == 'JPEG'
+        assert img.mode in ('RGB', 'RGBA', 'L')
+        assert img.size == (16, 16)
+
+
+# ---------- EXIF preservation (critical for history-date aggregation) ----------
+
+
+def test_exif_datetime_original_survives_conversion(tmp_path):
+    # Build EXIF with DateTimeOriginal set
+    img = Image.new('RGB', (16, 16), color='green')
+    exif = img.getexif()
+    exif[36867] = '2024:07:12 14:30:00'  # ExifTag.DateTimeOriginal
+    heic_path = str(tmp_path / 'iphone.heic')
+    img.save(heic_path, 'HEIF', exif=exif.tobytes())
+
+    result = normalize_to_jpeg(heic_path)
+
+    # Re-read the JPEG and confirm the DateTimeOriginal is still there
+    with Image.open(result) as jpg:
+        jpg_exif = dict(jpg.getexif())
+        assert 36867 in jpg_exif, 'DateTimeOriginal must survive HEIC → JPEG conversion'
+        assert jpg_exif[36867] == '2024:07:12 14:30:00'
+
+
+def test_multiple_exif_tags_preserved(tmp_path):
+    img = Image.new('RGB', (16, 16), color='yellow')
+    exif = img.getexif()
+    exif[36867] = '2024:07:12 14:30:00'  # DateTimeOriginal
+    exif[272] = 'TestCamera'              # Model
+    exif[271] = 'TestMake'                # Make
+    heic_path = str(tmp_path / 'shot.heic')
+    img.save(heic_path, 'HEIF', exif=exif.tobytes())
+
+    result = normalize_to_jpeg(heic_path)
+
+    with Image.open(result) as jpg:
+        out = dict(jpg.getexif())
+        assert out.get(36867) == '2024:07:12 14:30:00'
+        assert out.get(272) == 'TestCamera'
+        assert out.get(271) == 'TestMake'
+
+
+# ---------- Module exports ----------
+
+
+def test_heic_extensions_constant():
+    # Contract that callers rely on — including the frontend error message
+    assert '.heic' in HEIC_EXTENSIONS
+    assert '.heif' in HEIC_EXTENSIONS

--- a/backend/turtle_manager.py
+++ b/backend/turtle_manager.py
@@ -27,6 +27,50 @@ except ImportError as e1:
 # --- CONFIGURATION ---
 BASE_DATA_DIR = 'data'
 
+_IMAGE_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.gif', '.webp')
+
+
+def _find_image_next_to_pt(pt_path):
+    """Case-insensitive lookup: return the actual image file next to a .pt path.
+
+    Linux is case-sensitive, so a hardcoded lowercase-only extension list fails
+    for files named e.g. ``F128.JPG``. Scan the directory and match the stem
+    with any supported image extension regardless of case.
+
+    Returns the discovered image path, or ``None`` when no image is found.
+    """
+    if not pt_path or not pt_path.endswith('.pt'):
+        return None
+    base = pt_path[:-3]
+    dir_path = os.path.dirname(base) or '.'
+    base_name = os.path.basename(base)
+    if not os.path.isdir(dir_path):
+        return None
+    try:
+        entries = os.listdir(dir_path)
+    except OSError:
+        return None
+    for fname in entries:
+        stem, ext = os.path.splitext(fname)
+        if stem == base_name and ext.lower() in _IMAGE_EXTENSIONS:
+            return os.path.join(dir_path, fname)
+    return None
+
+
+def _find_image_in_dir(dir_path, stem):
+    """Case-insensitive sibling: find ``<stem>.<ext>`` in ``dir_path`` for any image ext."""
+    if not os.path.isdir(dir_path):
+        return None
+    try:
+        entries = os.listdir(dir_path)
+    except OSError:
+        return None
+    for fname in entries:
+        fstem, ext = os.path.splitext(fname)
+        if fstem == stem and ext.lower() in _IMAGE_EXTENSIONS:
+            return os.path.join(dir_path, fname)
+    return None
+
 # Characters invalid in folder names (Windows + common Unix); replaced with _ when syncing sheet names to disk
 _FOLDER_NAME_INVALID = r'\/:*?"<>|'
 
@@ -398,14 +442,8 @@ class TurtleManager:
                 score = int(match.get('score', 0))
                 pt_path = match.get('file_path', '')
 
-                # Resolve original image
-                ref_img_path = None
-                if pt_path and pt_path.endswith('.pt'):
-                    base_path = pt_path[:-3]
-                    for ext in ['.jpg', '.jpeg', '.png']:
-                        if os.path.exists(base_path + ext):
-                            ref_img_path = base_path + ext
-                            break
+                # Resolve original image — case-insensitive so .JPG works on Linux
+                ref_img_path = _find_image_next_to_pt(pt_path)
 
                 if ref_img_path:
                     ext = os.path.splitext(ref_img_path)[1]
@@ -487,12 +525,8 @@ class TurtleManager:
             if replace_reference:
                 print(f"✨ UPGRADING REFERENCE for {match_turtle_id}...")
                 old_pt_path = os.path.join(ref_dir, f"{match_turtle_id}.pt")
-                old_img_path = None
-                for ext in ['.jpg', '.jpeg', '.png']:
-                    possible = os.path.join(ref_dir, f"{match_turtle_id}{ext}")
-                    if os.path.exists(possible):
-                        old_img_path = possible
-                        break
+                # Case-insensitive lookup so .JPG old references are found on Linux
+                old_img_path = _find_image_in_dir(ref_dir, match_turtle_id)
 
                 op_ts = int(time.time() * 1000)
                 new_ext = os.path.splitext(query_image)[1]

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -221,7 +221,7 @@ export default function HomePage() {
     if (rejection.errors[0]?.code === 'file-too-large') {
       message = 'File is too large. Maximum: 5MB';
     } else if (rejection.errors[0]?.code === 'file-invalid-type') {
-      message = 'Invalid file type. Allowed: PNG, JPG, JPEG, GIF, WEBP';
+      message = 'Invalid file type. Allowed: PNG, JPG, JPEG, GIF, WEBP, HEIC';
     }
 
     notifications.show({
@@ -391,7 +391,7 @@ export default function HomePage() {
                 Upload Photo
               </Button>
               <Text size='sm' c='dimmed' ta='center' mt='xs'>
-                Supported formats: PNG, JPG, JPEG, GIF, WEBP (max. 5MB)
+                Supported formats: PNG, JPG, JPEG, GIF, WEBP, HEIC (max. 5MB)
               </Text>
             </Stack>
           ) : (
@@ -400,7 +400,7 @@ export default function HomePage() {
               onReject={handleReject}
               maxSize={5 * 1024 * 1024} // 5MB
               accept={{
-                'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.webp'],
+                'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.heic', '.heif'],
               }}
               multiple={false}
               disabled={uploadState === 'uploading'}
@@ -433,7 +433,7 @@ export default function HomePage() {
                     ta='center'
                     style={{ display: 'block' }}
                   >
-                    Supported formats: PNG, JPG, JPEG, GIF, WEBP (max. 5MB)
+                    Supported formats: PNG, JPG, JPEG, GIF, WEBP, HEIC (max. 5MB)
                   </Text>
                 </div>
               </Group>

--- a/frontend/src/utils/fileValidation.ts
+++ b/frontend/src/utils/fileValidation.ts
@@ -10,7 +10,12 @@ const VALID_TYPES = [
   'image/png',
   'image/gif',
   'image/webp',
+  'image/heic',
+  'image/heif',
 ];
+// Chrome/Firefox often leave file.type empty for HEIC since they can't read it;
+// fall back to the extension so iPhone uploads are accepted on any browser.
+const VALID_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'heic', 'heif'];
 
 export function validateFile(file: File): { isValid: boolean; error?: string } {
   if (file.size > MAX_SIZE) {
@@ -19,10 +24,13 @@ export function validateFile(file: File): { isValid: boolean; error?: string } {
       error: `File is too large. Maximum: ${(MAX_SIZE / 1024 / 1024).toFixed(0)}MB`,
     };
   }
-  if (!VALID_TYPES.includes(file.type)) {
+  const typeOk = VALID_TYPES.includes(file.type);
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  const extOk = VALID_EXTENSIONS.includes(ext);
+  if (!typeOk && !extOk) {
     return {
       isValid: false,
-      error: 'Invalid file type. Allowed: JPEG, PNG, GIF, WEBP',
+      error: 'Invalid file type. Allowed: JPEG, PNG, GIF, WEBP, HEIC',
     };
   }
   return { isValid: true };


### PR DESCRIPTION
Two production-critical fixes that travel together since they share a branch.

## 1. Case-insensitive image extension lookup (commit e103216)

On the Linux production server, turtle reference images saved with uppercase extensions (e.g. `F128.JPG`) weren't resolving — match results returned the raw `.pt` path and the frontend showed blank thumbnails.

**Root cause:** hardcoded `['.jpg', '.jpeg', '.png']` lookups in `routes/upload.py` and `turtle_manager.py`. Case-sensitive filesystem → miss. Windows dev machines never hit it because NTFS is case-insensitive.

**Fix:** small directory-scanning helpers that match the stem against any supported image extension case-insensitively.

- `backend/routes/upload.py` — new `find_image_for_pt` helper. `convert_pt_to_image_path` delegates to it. Candidate-copy loop uses it too.
- `backend/turtle_manager.py` — module-level `_find_image_next_to_pt` + `_find_image_in_dir` helpers. Used in `create_review_packet` (community-upload candidate copy) and `approve_review_packet` (replace-reference old-image lookup).

## 2. HEIC/HEIF upload support (commit 1947214)

iPhone photos arrive as HEIC by default. Chrome and Firefox can't render HEIC natively, OpenCV (used by SuperPoint/LightGlue) can't read it, and we don't want to maintain two representations on disk. So we convert HEIC → JPEG at every file-save boundary.

- `backend/image_utils.py` (new) — registers `pillow-heif` at import, exposes `normalize_to_jpeg(path)` that's a no-op for non-HEIC inputs and otherwise converts in-place: EXIF-rotates, re-saves as JPEG quality 95 with EXIF preserved (so `DateTimeOriginal` survives for history-date aggregation), then deletes the original HEIC.
- `backend/requirements.txt` — `pillow-heif>=0.16.0` added.
- `backend/config.py` — `heic`/`heif` added to `ALLOWED_EXTENSIONS` so werkzeug accepts the upload before normalization rewrites it.
- `backend/routes/{upload,review,turtles}.py` — `normalize_to_jpeg` called after every `file.save()` of a user-uploaded image (5 call sites).
- `frontend/src/utils/fileValidation.ts` — accepts `image/heic`/`image/heif`, with an extension fallback because Chrome/Firefox leave `file.type` blank for HEIC.
- `frontend/src/pages/HomePage.tsx` — Dropzone accept list and user-facing "supported formats" text updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)