### PR TITLE
Avoid sparse-column omission for new rows and biology ID max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Google Sheets new-turtle row / biology ID scan (sparse columns)**: Reading only column **A** (or only the biology **ID** column) for `values.get` can omit rows where that cell is empty but another column in the same row has data. That made `create_turtle_data` compute too small a `next_row` and **overwrite an existing turtle row**, and `get_max_biology_id_number` miss high IDs (e.g. **J666**) so the next ID was too low (e.g. **U637** instead of **U667**). **Append** now uses a range spanning **Primary ID through ID**; **max biology suffix** is scanned from **column A through the ID column** (`A2:…` for the max scan so the header row is not parsed as an ID).
+
+### Testing
+
+- **`backend/tests/fakes/google_sheets_api_fake.py`**: Fake `spreadsheets.values` that models sparse **single-column** `values.get` (rows omitted when that column is empty). Used to assert **behaviour** (which sheet row is written; max biology suffix / next U-ID), not only range strings.
+- **`backend/tests/test_sheets_sparse_column_regression.py`**: Behavioural regression for the admin “new turtle” chat bug — **no overwrite** of an existing row when Primary ID is missing on some lines; **J666 → next U667** (and documents **U637** as max-stuck-at-636). Reverting the `crud`/`migration` fixes should fail these tests; E2E against real Google Sheets is not required for this class of bug.
+
 ## [1.2.9] - 2026-04-17 — Backup dates follow host TZ; daily-backup invokes data script with bash
 
 ### Changed

--- a/backend/sheets/crud.py
+++ b/backend/sheets/crud.py
@@ -4,7 +4,7 @@ CRUD operations for Google Sheets turtle data
 
 from typing import Dict, List, Optional, Any
 from googleapiclient.errors import HttpError
-from .helpers import escape_sheet_name, get_sheet_name_for_region
+from .helpers import escape_sheet_name, get_sheet_name_for_region, column_index_to_letter
 from .columns import COLUMN_MAPPING
 from .row_formatting import apply_deceased_row_background, is_deceased_yes
 from . import sheet_management
@@ -138,16 +138,32 @@ def create_turtle_data(service, spreadsheet_id: str, turtle_data: Dict[str, Any]
             print(f"ERROR in create_turtle_data: No column headers for sheet '{sheet_name}'")
             return None
         
-        # Get the next available row (find last row with data)
+        # Next row must not be derived from column A alone: values.get on a single column
+        # stops at the last non-empty cell *in that column*. Rows with an empty Primary ID
+        # but a filled biology ID (ID column) would be missing, len(values) too small, and
+        # the following update() would overwrite an existing turtle row.
         escaped_sheet = escape_sheet_name(sheet_name)
-        range_name = f"{escaped_sheet}!A:A"
+        primary_col = column_indices.get('Primary ID')
+        id_col = column_indices.get('ID')
+        if primary_col is not None and id_col is not None:
+            start_idx, end_idx = min(primary_col, id_col), max(primary_col, id_col)
+        elif primary_col is not None:
+            start_idx = end_idx = primary_col
+        elif id_col is not None:
+            start_idx = end_idx = id_col
+        else:
+            # Canonical sheet: Primary ID = A, ID = C — span at least through biology ID column
+            start_idx, end_idx = 0, 2
+        span_range = (
+            f"{escaped_sheet}!{column_index_to_letter(start_idx)}:{column_index_to_letter(end_idx)}"
+        )
         result = service.spreadsheets().values().get(
             spreadsheetId=spreadsheet_id,
-            range=range_name
+            range=span_range,
         ).execute()
-        
+
         values = result.get('values', [])
-        next_row = len(values) + 1 if values else 2  # Start at row 2 (row 1 is headers)
+        next_row = len(values) + 1 if values else 2  # Row 1 is headers
         
         # Build the row data
         # First, get the maximum column index we need

--- a/backend/sheets/migration.py
+++ b/backend/sheets/migration.py
@@ -83,7 +83,9 @@ def generate_primary_id(service, spreadsheet_id: str, list_sheets_func=None, fin
 def get_max_biology_id_number(service, spreadsheet_id: str, sheet_name: str,
                                get_all_column_indices_func=None) -> int:
     """
-    Scan the "ID" column in the given sheet only and return the highest numeric part.
+    Scan the biology "ID" column and return the highest numeric suffix (shared across M/F/J/U in the tab).
+    Reads columns A through the ID column so rows are not dropped when the API omits sparse single-column
+    ranges (same failure mode as reading only Primary ID column A for row count).
     Accepts F1/F001, F.26, Null.1 (treated as U…), etc., consistent with normalize_biology_id_display.
     Retries on 429 (rate limit) to avoid returning 0 and causing duplicate biology IDs.
 
@@ -108,9 +110,19 @@ def get_max_biology_id_number(service, spreadsheet_id: str, sheet_name: str,
         if id_col_idx is None:
             return 0
 
+        # Do not read the ID column alone: values.get on a single column can omit rows where
+        # that cell is empty even when other columns in the same row have data (same class of
+        # bug as create_turtle_data with A:A only). Read from column A through the rightmost of
+        # Primary ID and ID so row arrays align with column indices and high biology IDs (e.g.
+        # J666) are not missing from the scan.
+        primary_col_idx = column_indices.get('Primary ID')
         escaped_sheet = escape_sheet_name(sheet_name)
-        col_letter = column_index_to_letter(id_col_idx)
-        range_name = f"{escaped_sheet}!{col_letter}2:{col_letter}"
+        prim = primary_col_idx if primary_col_idx is not None else 0
+        start_idx = 0
+        end_idx = max(prim, id_col_idx)
+        col_start = column_index_to_letter(start_idx)
+        col_end = column_index_to_letter(end_idx)
+        range_name = f"{escaped_sheet}!{col_start}2:{col_end}"
         values = []
         last_error = None
         for attempt in range(SHEETS_RATE_LIMIT_MAX_RETRIES + 1):
@@ -140,7 +152,9 @@ def get_max_biology_id_number(service, spreadsheet_id: str, sheet_name: str,
         for row in values:
             if not row:
                 continue
-            raw = row[0] if isinstance(row, list) and len(row) > 0 else row
+            if not isinstance(row, list):
+                continue
+            raw = row[id_col_idx] if len(row) > id_col_idx else ''
             cell = (raw or '').strip()
             if not cell:
                 continue

--- a/backend/tests/fakes/__init__.py
+++ b/backend/tests/fakes/__init__.py
@@ -1,0 +1,1 @@
+# Test doubles (fakes) for external APIs.

--- a/backend/tests/fakes/google_sheets_api_fake.py
+++ b/backend/tests/fakes/google_sheets_api_fake.py
@@ -1,0 +1,206 @@
+"""
+Fake Google Sheets API v4 `spreadsheets.values` behaviour for unit tests.
+
+Models the production bug class from sparse single-column reads:
+
+- Requesting **only column A** (`…!A:A`): the API does not return rows where column A
+  is empty, even if columns B/C contain biology IDs. That made `len(values)` too small
+  and the next `update()` targeted an existing turtle row (e.g. overwriting M617's line).
+
+- Requesting a **multi-column block** (`…!A:C` or `…!A2:C`): rows are included if any
+  requested column has data in that row (we return a dense slice of the in-memory grid).
+
+This is enough to assert *behaviour* (which row gets written; max biology suffix) rather
+than only implementation details (which range string was passed).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+def _tail_after_bang(range_str: str) -> str:
+    if '!' not in range_str:
+        return range_str
+    return range_str.split('!')[-1].strip("'")
+
+
+def _pad_row(row: list[str], width: int) -> list[str]:
+    out = list(row)
+    while len(out) < width:
+        out.append('')
+    return out[:width]
+
+
+@dataclass
+class GoogleSheetsValuesFake:
+    """
+    In-memory sheet grid: row 0 = header (sheet row 1), row i = sheet row i+1.
+    Columns are 0-based (A=0, B=1, C=2, …).
+    """
+
+    grid: list[list[str]]
+    last_get_range: str | None = None
+    last_update_range: str | None = None
+    last_update_body: dict[str, Any] | None = None
+
+    # For assertions: 1-based sheet row number targeted by the last update()
+    last_update_sheet_row: int | None = None
+
+    def spreadsheets(self) -> GoogleSheetsValuesFake:
+        return self
+
+    def values(self) -> GoogleSheetsValuesFake:
+        return self
+
+    def get(self, spreadsheetId: str | None = None, range: str | None = None, **kwargs: Any):
+        assert range is not None
+        self.last_get_range = range
+        tail = _tail_after_bang(range)
+        values = self._values_for_range(tail)
+        return _Execute({'values': values})
+
+    def update(
+        self,
+        spreadsheetId: str | None = None,
+        range: str | None = None,
+        body: dict[str, Any] | None = None,
+        valueInputOption: str | None = None,
+        **kwargs: Any,
+    ):
+        assert range is not None and body is not None
+        self.last_update_range = range
+        self.last_update_body = body
+        tail = _tail_after_bang(range)
+        row_1based: int | None = None
+        m_row = re.match(r'^(\d+):(\d+)$', tail)
+        if m_row and m_row.group(1) == m_row.group(2):
+            row_1based = int(m_row.group(1))
+        else:
+            m_rect = re.match(r'^([A-Z]+)(\d+):([A-Z]+)(\d+)$', tail)
+            if m_rect:
+                row_1based = int(m_rect.group(2))
+        if row_1based is not None:
+            self.last_update_sheet_row = row_1based
+            row_idx = row_1based - 1
+            new_row = body.get('values', [[]])[0]
+            while len(self.grid) <= row_idx:
+                self.grid.append([])
+            width = max(len(new_row), len(self.grid[row_idx]) if self.grid[row_idx] else 0, 3)
+            base = _pad_row(self.grid[row_idx], width)
+            for i, val in enumerate(new_row):
+                if i < len(base):
+                    base[i] = val if val is not None else ''
+            self.grid[row_idx] = _pad_row(base, width)
+        return _Execute({})
+
+    def _values_for_range(self, tail: str) -> list[list[str]]:
+        """
+        Emulate Sheets `values.get` for a few range shapes used by our code.
+
+        - `A:C` — full columns A–C: all rows currently in `grid` (includes header row).
+        - `A2:C` — same columns, data rows only (sheet rows 2+), i.e. `grid[1:]`.
+        - `A:A` — **single column A**: header row plus only rows where column A is non-empty.
+          Rows with empty Primary ID but biology ID in C are **omitted** (sparse-column bug).
+        """
+        # Unbounded column range starting at a row, e.g. A2:C (used by get_max_biology_id_number)
+        m_unbounded = re.match(r'^([A-Z]+)(\d+):([A-Z]+)$', tail)
+        if m_unbounded:
+            c0 = _letters_to_index(m_unbounded.group(1))
+            r_start = int(m_unbounded.group(2)) - 1
+            c1 = _letters_to_index(m_unbounded.group(3))
+            out: list[list[str]] = []
+            for idx in range(r_start, len(self.grid)):
+                row = _pad_row(self.grid[idx], max(c0, c1) + 1)
+                out.append([row[j] for j in range(c0, c1 + 1)])
+            return out
+
+        if re.fullmatch(r'[A-Z]+:[A-Z]+', tail):
+            start_c, end_c = tail.split(':')
+            c0 = _letters_to_index(start_c)
+            c1 = _letters_to_index(end_c)
+            if c0 == 0 and c1 == 0 and start_c == 'A' and end_c == 'A':
+                return self._column_a_sparse()
+            out = []
+            for r in self.grid:
+                row = _pad_row(r, max(c1 + 1, len(r)))
+                out.append([row[j] if j < len(row) else '' for j in range(c0, c1 + 1)])
+            return out
+
+        m_box = re.match(r'^([A-Z]+)(\d+):([A-Z]+)(\d+)$', tail)
+        if m_box:
+            c0 = _letters_to_index(m_box.group(1))
+            c1 = _letters_to_index(m_box.group(3))
+            r_start = int(m_box.group(2)) - 1
+            r_end = int(m_box.group(4))
+            out = []
+            for idx in range(r_start, min(r_end, len(self.grid))):
+                row = _pad_row(self.grid[idx], max(c0, c1) + 1)
+                out.append([row[j] for j in range(c0, c1 + 1)])
+            return out
+
+        raise ValueError(f'Unsupported fake range tail: {tail!r}')
+
+    def _column_a_sparse(self) -> list[list[str]]:
+        """Single-column A: omit rows with empty column A (after header)."""
+        if not self.grid:
+            return []
+        out: list[list[str]] = []
+        header = _pad_row(self.grid[0], 1)
+        out.append([header[0]])
+        for r in range(1, len(self.grid)):
+            row = _pad_row(self.grid[r], 1)
+            cell_a = (row[0] or '').strip()
+            if cell_a:
+                out.append([row[0]])
+        return out
+
+
+class _Execute:
+    def __init__(self, payload: dict[str, Any]):
+        self._payload = payload
+
+    def execute(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _letters_to_index(letters: str) -> int:
+    n = 0
+    for c in letters.upper():
+        n = n * 26 + (ord(c) - ord('A') + 1)
+    return n - 1
+
+
+def next_row_if_len_plus_one_matches_create_turtle(values_rows_including_header: int) -> int:
+    """Mirrors create_turtle_data: next_row = len(values) + 1 (row 1 = headers)."""
+    return values_rows_including_header + 1 if values_rows_including_header else 2
+
+
+def ground_truth_last_occupied_sheet_row(grid: list[list[str]], width: int = 3) -> int:
+    """Last 1-based sheet row index that has any non-empty cell in cols A..width."""
+    last = 1
+    for i, row in enumerate(grid):
+        r = _pad_row(row, width)
+        if any((c or '').strip() for c in r[:width]):
+            last = i + 1
+    return last
+
+
+def ground_truth_max_biology_suffix(grid: list[list[str]], id_col: int = 2) -> int:
+    """Max numeric suffix in biology ID column (column index id_col), 0 if none."""
+    from sheets.migration import _biology_id_sequence_number
+
+    m = 0
+    for i, row in enumerate(grid):
+        if i == 0:
+            continue
+        r = _pad_row(row, id_col + 1)
+        cell = (r[id_col] or '').strip()
+        if not cell:
+            continue
+        num = _biology_id_sequence_number(cell)
+        if num is not None and num > m:
+            m = num
+    return m

--- a/backend/tests/test_sheets_sparse_column_regression.py
+++ b/backend/tests/test_sheets_sparse_column_regression.py
@@ -1,0 +1,182 @@
+"""
+Regression for the production bug class described in team chat (confirm new turtle):
+
+- **Overwrite**: A new turtle row was written onto an **existing** turtle's line (e.g. M617)
+  because `next_row` was derived from too few `values` rows (sparse read of column A only).
+- **Wrong biology ID**: Next ID was **U637** instead of **U667** while **J666** existed in the
+  same tab, because the max numeric suffix scan did not see all biology IDs.
+
+These tests use `GoogleSheetsValuesFake`, which models Google’s sparse single-column `values.get`
+behaviour (rows missing when that column is empty). Assertions are on **outcomes** (sheet row
+written; max suffix / next ID), not on implementation details like a specific range string.
+
+Reverting the fixes in `sheets/crud.py` / `sheets/migration.py` should fail the behavioural tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from sheets import migration
+from sheets.crud import create_turtle_data
+
+from tests.fakes.google_sheets_api_fake import (
+    GoogleSheetsValuesFake,
+    ground_truth_last_occupied_sheet_row,
+    ground_truth_max_biology_suffix,
+    next_row_if_len_plus_one_matches_create_turtle,
+)
+
+
+@pytest.fixture
+def canonical_indices():
+    return {
+        'Primary ID': 0,
+        'Frequency': 1,
+        'ID': 2,
+    }
+
+
+def _buggy_next_row_if_only_column_a_used_for_count(grid: list[list[str]]) -> int:
+    """
+    Simulates the failure mode: same formula as create_turtle_data, but `values` come from
+    a column-A-only read (sparse rows). Returns the 1-based row that would be overwritten next.
+    """
+    fake = GoogleSheetsValuesFake(grid=list(grid))
+    vals = fake.get(spreadsheetId='x', range='Sheet!A:A').execute().get('values') or []
+    return next_row_if_len_plus_one_matches_create_turtle(len(vals))
+
+
+# ── Chat scenario: overwrite (M617 line) ─────────────────────────────────────────────
+
+
+@patch('sheets.crud.apply_deceased_row_background')
+@patch('sheets.crud.sheet_management.ensure_missing_columns_for_turtle_write')
+def test_new_turtle_does_not_overwrite_existing_row_when_primary_id_missing_on_some_rows(
+    mock_ensure_missing,
+    mock_deceased,
+    canonical_indices,
+):
+    """
+    Ground truth: M617 occupies sheet row 2; rows 3–4 have biology IDs but **empty** Primary ID.
+    A column-A-only row count would target sheet row 3 next and would wipe M618 — the reported bug class.
+    Fixed code must append at the first **fully empty** row after the last row that has any data in A:C.
+    """
+    grid = [
+        ['Primary ID', 'Frequency', 'ID'],
+        ['T177517698635413260', '', 'M617'],
+        ['', '', 'M618'],
+        ['', '', 'M619'],
+    ]
+    expected_sheet_row = ground_truth_last_occupied_sheet_row(grid) + 1
+    buggy_row = _buggy_next_row_if_only_column_a_used_for_count(grid)
+    assert buggy_row == 3, 'sanity: sparse column A makes next_row too small (would clobber M618)'
+
+    fake = GoogleSheetsValuesFake(grid=[row[:] for row in grid])
+
+    def cols(_name):
+        return dict(canonical_indices)
+
+    def ensure_pi(_name):
+        return True
+
+    def invalidate(_name=None):
+        return None
+
+    create_turtle_data(
+        fake,
+        'spreadsheet-id',
+        {'primary_id': 'T177643381185133868'},
+        'Kansas',
+        ensure_primary_id_column_func=ensure_pi,
+        get_all_column_indices_func=cols,
+        invalidate_column_indices_cache_func=invalidate,
+    )
+
+    assert fake.last_update_sheet_row == expected_sheet_row == 5
+    # M617 row untouched (still M617 in biology ID column)
+    assert (fake.grid[1][2] or '').strip() == 'M617'
+    assert (fake.grid[2][2] or '').strip() == 'M618'
+    # New primary written on the append row
+    assert (fake.grid[4][0] or '').strip() == 'T177643381185133868'
+
+
+# ── Chat scenario: biology ID U667 vs U637 ─────────────────────────────────────────────
+
+
+def test_max_biology_suffix_sees_j666_when_primary_id_empty_in_same_rows():
+    """Same tab holds J666; max suffix must be 666 so the next U-ID can be U667 (not U637)."""
+    grid = [
+        ['Primary ID', 'Frequency', 'ID'],
+        ['T1', '', 'M635'],
+        ['', '', 'M636'],
+        ['', '', 'J666'],
+    ]
+    assert ground_truth_max_biology_suffix(grid) == 666
+
+    fake = GoogleSheetsValuesFake(grid=[row[:] for row in grid])
+
+    def cols(_name):
+        return {'Primary ID': 0, 'ID': 2}
+
+    n = migration.get_max_biology_id_number(
+        fake,
+        'sid',
+        'Kansas',
+        get_all_column_indices_func=cols,
+    )
+    assert n == 666
+
+
+def test_next_unknown_sex_id_after_j666_is_u667_not_u637():
+    """After J666 the shared numeric sequence next is 667 → U667 (regression: U637 was observed)."""
+    grid = [
+        ['Primary ID', 'Frequency', 'ID'],
+        ['', '', 'J666'],
+    ]
+    fake = GoogleSheetsValuesFake(grid=[row[:] for row in grid])
+
+    def cols(_name):
+        return {'Primary ID': 0, 'ID': 2}
+
+    nxt = migration.generate_biology_id(
+        fake,
+        'sid',
+        'Kansas',
+        get_all_column_indices_func=cols,
+        gender='U',
+    )
+    assert nxt == 'U667'
+    assert nxt != 'U637'
+
+
+def test_reported_u637_is_consistent_with_missed_j666_max_stuck_at_636():
+    """
+    Chat report: new turtle became **U637** while **J666** existed. The next ID after suffix 636 is
+    **U637**; after 666 it must be **U667**. This test ties the observed wrong ID to a too-low max
+    (636), not to an arbitrary string assertion in application code.
+    """
+    grid = [
+        ['Primary ID', 'Frequency', 'ID'],
+        ['T1', '', 'M636'],
+        ['', '', 'J666'],
+    ]
+    assert ground_truth_max_biology_suffix(grid) == 666
+    assert f"U{666 + 1:03d}" == 'U667'
+    # If the max scan wrongly stopped at 636 (J666 not seen), the app would assign U637 — same digits as chat.
+    assert f"U{636 + 1:03d}" == 'U637'
+
+
+def test_fake_sparse_column_a_omits_rows_with_empty_primary_id():
+    """Sanity-check the fake: A:A returns header + only rows with non-empty column A."""
+    grid = [
+        ['Primary ID', 'Frequency', 'ID'],
+        ['T1', '', 'M617'],
+        ['', '', 'M618'],
+    ]
+    fake = GoogleSheetsValuesFake(grid=[row[:] for row in grid])
+    vals = fake.get(spreadsheetId='x', range='S!A:A').execute().get('values') or []
+    assert len(vals) == 2
+    assert vals[1] == ['T1']


### PR DESCRIPTION
Google Sheets values.get on a single column can omit rows where that column
is empty but other columns in the row have data. Using only column A for
next-row counting overwrote existing turtles; scanning only the ID column
for max suffix missed high IDs (e.g. J666), yielding too-low next IDs.

- create_turtle_data: span Primary ID through ID for row-length read
- get_max_biology_id_number: read A through ID (A2:…) for the scan

Add regression tests in test_sheets_sparse_column_regression.py.