### PR TITLE
Identifier plastron upload, extra plastron type, folder auto-create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sheets browser — plastron workflows**: Set a first-time identifier plastron for sheet-only turtles (creates `data/<location>/<turtle_id>/` when needed), replace the existing SuperPoint reference (old master archived to `loose_images`), or upload an **extra** underside photo as **Plastron (additional)** in the manifest (does not create or replace `.pt`). New admin API **`POST /api/turtles/images/identifier-plastron`** (`turtle_id`, `file`, `mode`: `set_if_missing` | `replace`, optional `sheet_name`). Additional-image type **`plastron`** is allowed server-side. **`POST /api/turtles/images/additional`** now creates the turtle folder from `sheet_name` when it was missing (same resolver), so microhabitat uploads work for new rows too.
+
+### Testing
+
+- **`backend/tests/test_turtle_plastron_upload.py`**: folder resolution, first identifier, set-if-missing conflict, replace archives old master, additional upload creates folder (brain `process_and_save` mocked to write a dummy `.pt`).
+
 ## [1.2.13] - 2026-04-20 — Review queue candidate filenames with uppercase extensions
 
 ### Fixed

--- a/backend/additional_image_labels.py
+++ b/backend/additional_image_labels.py
@@ -3,7 +3,9 @@
 import json
 from typing import Any, List, Optional
 
-VALID_ADDITIONAL_TYPES = frozenset({'microhabitat', 'condition', 'carapace', 'other'})
+VALID_ADDITIONAL_TYPES = frozenset(
+    {'microhabitat', 'condition', 'carapace', 'plastron', 'other'}
+)
 
 
 def normalize_additional_type(raw: Optional[str]) -> str:

--- a/backend/routes/review.py
+++ b/backend/routes/review.py
@@ -246,7 +246,7 @@ def register_review_routes(app):
                     continue
                 idx = key.replace('file_', '')
                 typ = request.form.get(f'type_{idx}', 'other').strip().lower()
-                if typ not in ('microhabitat', 'condition', 'carapace', 'other'):
+                if typ not in ('microhabitat', 'condition', 'carapace', 'plastron', 'other'):
                     typ = 'other'
                 lbs = parse_labels_from_form(request.form, idx)
                 if not allowed_file(f.filename):

--- a/backend/routes/turtles.py
+++ b/backend/routes/turtles.py
@@ -241,7 +241,8 @@ def register_turtle_routes(app):
     def add_turtle_additional_images():
         """
         Add microhabitat/condition images to an existing turtle folder (Admin only).
-        Form: file_0, type_0, labels_0, ... (type: microhabitat | condition | carapace | other), optional sheet_name.
+        Form: file_0, type_0, labels_0, ... (type: microhabitat | condition | carapace | plastron | other),
+        optional sheet_name. When the folder is missing, sheet_name creates data/<location>/<turtle_id>/ .
         """
         if not manager_service.manager_ready.wait(timeout=5):
             return jsonify({'error': 'TurtleManager is still initializing'}), 503
@@ -261,7 +262,7 @@ def register_turtle_routes(app):
                     continue
                 idx = key.replace('file_', '')
                 typ = (request.form.get(f'type_{idx}') or 'other').strip().lower()
-                if typ not in ('microhabitat', 'condition', 'carapace', 'other'):
+                if typ not in ('microhabitat', 'condition', 'carapace', 'plastron', 'other'):
                     typ = 'other'
                 lbs = parse_labels_from_form(request.form, idx)
                 if not allowed_file(f.filename):
@@ -314,3 +315,65 @@ def register_turtle_routes(app):
                     except OSError:
                         pass
             return jsonify({'error': str(e)}), 500
+
+    @app.route('/api/turtles/images/identifier-plastron', methods=['POST'])
+    @require_admin
+    def upload_turtle_identifier_plastron():
+        """
+        Set or replace the identifier (ref_data) plastron image and regenerate the .pt tensor.
+
+        Form: turtle_id (required), file (required), mode = set_if_missing | replace (required),
+        sheet_name (required when the turtle folder does not exist yet — e.g. sheet-only row).
+
+        set_if_missing: fails if ref_data already has an identifier for this turtle_id.
+        replace: archives the previous master image to loose_images when present, then sets the new one.
+        """
+        if not manager_service.manager_ready.wait(timeout=5):
+            return jsonify({'error': 'TurtleManager is still initializing'}), 503
+        if manager_service.manager is None:
+            return jsonify({'error': 'TurtleManager not available'}), 500
+
+        turtle_id = (request.form.get('turtle_id') or request.args.get('turtle_id') or '').strip()
+        sheet_name = (request.form.get('sheet_name') or request.args.get('sheet_name') or '').strip() or None
+        mode = (request.form.get('mode') or request.args.get('mode') or '').strip().lower()
+        if not turtle_id:
+            return jsonify({'error': 'turtle_id required'}), 400
+        if mode not in ('set_if_missing', 'replace'):
+            return jsonify({'error': 'mode must be set_if_missing or replace'}), 400
+
+        if 'file' not in request.files:
+            return jsonify({'error': 'No file provided'}), 400
+        f = request.files['file']
+        if not f or not f.filename:
+            return jsonify({'error': 'No file provided'}), 400
+        if not allowed_file(f.filename):
+            return jsonify({'error': 'Invalid file type'}), 400
+        f.seek(0, os.SEEK_END)
+        size = f.tell()
+        f.seek(0)
+        if size > MAX_FILE_SIZE:
+            return jsonify({'error': 'File too large'}), 400
+
+        orig_safe = secure_filename(f.filename) or ''
+        ext = os.path.splitext(orig_safe)[1] or '.jpg'
+        temp_path = os.path.join(
+            UPLOAD_FOLDER,
+            f"turtle_idplastron_{turtle_id}_{int(time.time())}{ext}".replace(os.sep, '_'),
+        )
+        try:
+            f.save(temp_path)
+            temp_path = normalize_to_jpeg(temp_path)
+            ok, msg = manager_service.manager.set_identifier_plastron_from_path(
+                turtle_id, temp_path, sheet_name, mode
+            )
+            if not ok:
+                return jsonify({'error': msg or 'Failed to update identifier plastron'}), 400
+            return jsonify({'success': True, 'message': msg or 'Identifier plastron updated'})
+        except Exception as e:
+            return jsonify({'error': str(e)}), 500
+        finally:
+            if os.path.isfile(temp_path):
+                try:
+                    os.remove(temp_path)
+                except OSError:
+                    pass

--- a/backend/tests/test_turtle_plastron_upload.py
+++ b/backend/tests/test_turtle_plastron_upload.py
@@ -1,0 +1,92 @@
+"""Unit tests: identifier plastron upload + sheet-based folder resolution (brain mocked)."""
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+import turtle_manager as tm
+
+
+def _fake_process_and_save(image_path, pt_path):
+    """Real brain writes the tensor file; the mock must create it for file moves to succeed."""
+    with open(pt_path, "wb") as f:
+        f.write(b"fakept")
+    return True
+
+
+@pytest.fixture
+def mgr(tmp_path, monkeypatch):
+    monkeypatch.setattr(tm.brain, "process_and_save", _fake_process_and_save)
+    if hasattr(tm.brain, "load_database_to_vram"):
+        monkeypatch.setattr(tm.brain, "load_database_to_vram", MagicMock())
+    return tm.TurtleManager(base_data_dir=str(tmp_path))
+
+
+def test_resolve_creates_folder_with_sheet(mgr):
+    d = mgr.resolve_turtle_dir_for_sheet_upload("TNEW", "Kansas/Topeka")
+    expected = os.path.join(mgr.base_dir, "Kansas", "Topeka", "TNEW")
+    assert os.path.normpath(d) == os.path.normpath(expected)
+    assert os.path.isdir(os.path.join(d, "ref_data"))
+    assert os.path.isdir(os.path.join(d, "loose_images"))
+
+
+def test_set_identifier_first_plastron(mgr, tmp_path):
+    src = tmp_path / "in.jpg"
+    src.write_bytes(b"\xff\xd8\xff fakejpeg")
+    ok, msg = mgr.set_identifier_plastron_from_path("T1", str(src), "SiteA", "set_if_missing")
+    assert ok is True
+    ref = os.path.join(mgr.base_dir, "SiteA", "T1", "ref_data")
+    assert os.path.isfile(os.path.join(ref, "T1.jpg"))
+    assert os.path.isfile(os.path.join(ref, "T1.pt"))
+
+
+def test_set_if_missing_rejects_when_identifier_exists(mgr, tmp_path):
+    src = tmp_path / "in.jpg"
+    src.write_bytes(b"\xff\xd8\xff fakejpeg")
+    mgr.set_identifier_plastron_from_path("T2", str(src), "LocB", "set_if_missing")
+    ok, msg = mgr.set_identifier_plastron_from_path("T2", str(src), "LocB", "set_if_missing")
+    assert ok is False
+    assert "already has" in (msg or "").lower()
+
+
+def test_replace_archives_old_master(mgr, tmp_path):
+    turtle_dir = os.path.join(mgr.base_dir, "LocC", "T3")
+    ref_dir = os.path.join(turtle_dir, "ref_data")
+    loose_dir = os.path.join(turtle_dir, "loose_images")
+    os.makedirs(ref_dir, exist_ok=True)
+    os.makedirs(loose_dir, exist_ok=True)
+    old_img = os.path.join(ref_dir, "T3.jpg")
+    old_pt = os.path.join(ref_dir, "T3.pt")
+    with open(old_img, "wb") as f:
+        f.write(b"\xff\xd8\xff old")
+    with open(old_pt, "wb") as f:
+        f.write(b"pt")
+
+    src = tmp_path / "new.jpg"
+    src.write_bytes(b"\xff\xd8\xff new")
+    ok, _msg = mgr.set_identifier_plastron_from_path("T3", str(src), "LocC", "replace")
+    assert ok is True
+    loose_files = os.listdir(loose_dir)
+    assert any(n.startswith("Archived_Master_") for n in loose_files)
+    assert os.path.isfile(os.path.join(ref_dir, "T3.jpg"))
+
+
+def test_add_additional_creates_folder_when_only_sheet(mgr, tmp_path):
+    src = tmp_path / "x.jpg"
+    src.write_bytes(b"\xff\xd8\xff x")
+    ok, _ = mgr.add_additional_images_to_turtle(
+        "T4",
+        [
+            {
+                "path": str(src),
+                "type": "microhabitat",
+                "timestamp": "2026-01-01T00:00:00Z",
+                "original_filename": "x.jpg",
+            }
+        ],
+        "StateX/PlaceY",
+    )
+    assert ok is True
+    add_dir = os.path.join(mgr.base_dir, "StateX", "PlaceY", "T4", "additional_images")
+    assert os.path.isdir(add_dir)

--- a/backend/turtle_manager.py
+++ b/backend/turtle_manager.py
@@ -96,10 +96,40 @@ def _location_dir_from_sheet_name(sheet_name):
     if not sheet_name or not isinstance(sheet_name, str):
         return None
     raw = sheet_name.strip().replace("\\", "/")
-    parts = [_safe_folder_name(p) for p in raw.split("/") if str(p).strip()]
+    parts = []
+    for p in raw.split("/"):
+        if not str(p).strip():
+            continue
+        seg = _safe_folder_name(p)
+        if seg in (".", ".."):
+            continue
+        parts.append(seg)
     if not parts:
         return None
     return os.path.join(*parts)
+
+
+def _resolved_path_under_base(base_dir, *relative_parts):
+    """realpath(join(base_dir, *parts)); return it only if it stays under realpath(base_dir).
+
+    Blocks ``..``, absolute segments in *relative_parts*, and symlink escapes before makedirs.
+    """
+    if not relative_parts:
+        return None
+    if any(p is None or p == "" for p in relative_parts):
+        return None
+    try:
+        candidate = os.path.join(base_dir, *relative_parts)
+    except (TypeError, ValueError):
+        return None
+    real_base = os.path.realpath(base_dir)
+    real_candidate = os.path.realpath(candidate)
+    try:
+        if os.path.commonpath([real_candidate, real_base]) != real_base:
+            return None
+    except ValueError:
+        return None
+    return real_candidate
 
 
 # --- FLASH DRIVE INGEST: Map drive folder names to backend folder names ---
@@ -756,20 +786,25 @@ class TurtleManager:
         returns the existing folder (same behaviour as a plain search). If nothing exists,
         creates ``data/<sheet...>/<turtle_id>/`` with ``ref_data`` and ``loose_images``.
         """
-        if not turtle_id:
+        if not turtle_id or not isinstance(turtle_id, str):
+            return None
+        tid = turtle_id.strip()
+        if not tid or os.path.isabs(tid) or "/" in tid or "\\" in tid or tid in (".", ".."):
             return None
         rel = _location_dir_from_sheet_name(sheet_name) if sheet_name else None
         if rel:
-            explicit = os.path.join(self.base_dir, rel, turtle_id)
+            explicit = _resolved_path_under_base(self.base_dir, rel, tid)
+            if not explicit:
+                return None
             if os.path.isdir(explicit):
                 return explicit
             for root, dirs, files in os.walk(self.base_dir):
-                if os.path.basename(root) == turtle_id:
+                if os.path.basename(root) == tid:
                     return root
             os.makedirs(os.path.join(explicit, "ref_data"), exist_ok=True)
             os.makedirs(os.path.join(explicit, "loose_images"), exist_ok=True)
             return explicit
-        return self._get_turtle_folder(turtle_id, None)
+        return self._get_turtle_folder(tid, None)
 
     def _create_identifier_plastron(self, turtle_id, query_image, ref_dir, loose_dir):
         """Write first ref_data/<turtle_id>.* + .pt from an image file (caller ensures no identifier)."""

--- a/backend/turtle_manager.py
+++ b/backend/turtle_manager.py
@@ -91,6 +91,17 @@ def _safe_folder_name(sheet_name):
     return out or "_"
 
 
+def _location_dir_from_sheet_name(sheet_name):
+    """Turn a sheet/location string (e.g. Kansas/Topeka) into a relative path under data/."""
+    if not sheet_name or not isinstance(sheet_name, str):
+        return None
+    raw = sheet_name.strip().replace("\\", "/")
+    parts = [_safe_folder_name(p) for p in raw.split("/") if str(p).strip()]
+    if not parts:
+        return None
+    return os.path.join(*parts)
+
+
 # --- FLASH DRIVE INGEST: Map drive folder names to backend folder names ---
 # When folder names on the flash drive don't match backend/Google Sheets, add mappings here.
 # Ingest will route files to the correct backend State/Location based on these maps.
@@ -736,6 +747,125 @@ class TurtleManager:
                 return root
         return None
 
+    def resolve_turtle_dir_for_sheet_upload(self, turtle_id, sheet_name):
+        """
+        Resolve or create the on-disk turtle folder for admin uploads from the Sheets browser.
+
+        When ``sheet_name`` is set (e.g. Kansas/Topeka), prefers ``data/<sheet...>/<turtle_id>/``.
+        If that path does not exist but another folder named ``turtle_id`` is found elsewhere,
+        returns the existing folder (same behaviour as a plain search). If nothing exists,
+        creates ``data/<sheet...>/<turtle_id>/`` with ``ref_data`` and ``loose_images``.
+        """
+        if not turtle_id:
+            return None
+        rel = _location_dir_from_sheet_name(sheet_name) if sheet_name else None
+        if rel:
+            explicit = os.path.join(self.base_dir, rel, turtle_id)
+            if os.path.isdir(explicit):
+                return explicit
+            for root, dirs, files in os.walk(self.base_dir):
+                if os.path.basename(root) == turtle_id:
+                    return root
+            os.makedirs(os.path.join(explicit, "ref_data"), exist_ok=True)
+            os.makedirs(os.path.join(explicit, "loose_images"), exist_ok=True)
+            return explicit
+        return self._get_turtle_folder(turtle_id, None)
+
+    def _create_identifier_plastron(self, turtle_id, query_image, ref_dir, loose_dir):
+        """Write first ref_data/<turtle_id>.* + .pt from an image file (caller ensures no identifier)."""
+        os.makedirs(ref_dir, exist_ok=True)
+        os.makedirs(loose_dir, exist_ok=True)
+        new_ext = os.path.splitext(query_image)[1] or ".jpg"
+        dest_image = os.path.join(ref_dir, f"{turtle_id}{new_ext}")
+        dest_pt = os.path.join(ref_dir, f"{turtle_id}.pt")
+        if os.path.exists(dest_pt):
+            try:
+                os.remove(dest_pt)
+            except OSError:
+                pass
+        if os.path.exists(dest_image):
+            try:
+                os.remove(dest_image)
+            except OSError:
+                pass
+        shutil.copy2(query_image, dest_image)
+        if not brain.process_and_save(dest_image, dest_pt):
+            try:
+                if os.path.isfile(dest_image):
+                    os.remove(dest_image)
+            except OSError:
+                pass
+            return False, "Failed to extract features for identifier image"
+        self.refresh_database_index()
+        return True, "Identifier plastron set"
+
+    def _replace_identifier_plastron(self, turtle_id, query_image, ref_dir, loose_dir):
+        """Archive old master image, replace .pt + master image (same staging flow as review approve)."""
+        os.makedirs(ref_dir, exist_ok=True)
+        os.makedirs(loose_dir, exist_ok=True)
+        old_pt_path = os.path.join(ref_dir, f"{turtle_id}.pt")
+        old_img_path = _find_image_in_dir(ref_dir, turtle_id)
+        op_ts = int(time.time() * 1000)
+        new_ext = os.path.splitext(query_image)[1] or ".jpg"
+        staged_master_path = os.path.join(ref_dir, f"{turtle_id}_staged_{op_ts}{new_ext}")
+        staged_pt_path = os.path.join(ref_dir, f"{turtle_id}_staged_{op_ts}.pt")
+        shutil.copy2(query_image, staged_master_path)
+        staged_ok = brain.process_and_save(staged_master_path, staged_pt_path)
+        if not staged_ok:
+            try:
+                if os.path.exists(staged_master_path):
+                    os.remove(staged_master_path)
+                if os.path.exists(staged_pt_path):
+                    os.remove(staged_pt_path)
+            except OSError:
+                pass
+            return False, f"Failed to extract features for replacement image of {turtle_id}"
+        if old_img_path:
+            archive_name = f"Archived_Master_{op_ts}{os.path.splitext(old_img_path)[1]}"
+            shutil.move(old_img_path, os.path.join(loose_dir, archive_name))
+        if os.path.exists(old_pt_path):
+            os.remove(old_pt_path)
+        new_master_path = os.path.join(ref_dir, f"{turtle_id}{new_ext}")
+        new_pt_path = os.path.join(ref_dir, f"{turtle_id}.pt")
+        if os.path.exists(new_master_path):
+            os.remove(new_master_path)
+        shutil.move(staged_master_path, new_master_path)
+        shutil.move(staged_pt_path, new_pt_path)
+        obs_name = f"Obs_{int(time.time())}_{os.path.basename(query_image)}"
+        shutil.copy2(query_image, os.path.join(loose_dir, obs_name))
+        self.refresh_database_index()
+        return True, "Identifier plastron replaced"
+
+    def set_identifier_plastron_from_path(self, turtle_id, query_image, sheet_name, mode):
+        """
+        Set or replace the SuperPoint identifier (ref_data master image + .pt).
+
+        ``mode``: ``set_if_missing`` (error if already present) or ``replace`` (create or upgrade).
+        ``sheet_name`` should be the turtle's location path when the folder may not exist yet.
+        """
+        if mode not in ("set_if_missing", "replace"):
+            return False, "Invalid mode"
+        turtle_dir = self.resolve_turtle_dir_for_sheet_upload(turtle_id, sheet_name)
+        if not turtle_dir:
+            return False, (
+                "Turtle folder not found. For a new sheet-only row, pass sheet_name (location) "
+                "so the backend can create data/<location>/<turtle_id>/."
+            )
+        ref_dir = os.path.join(turtle_dir, "ref_data")
+        loose_dir = os.path.join(turtle_dir, "loose_images")
+        os.makedirs(ref_dir, exist_ok=True)
+        os.makedirs(loose_dir, exist_ok=True)
+        has_id = os.path.isfile(os.path.join(ref_dir, f"{turtle_id}.pt")) or bool(
+            _find_image_in_dir(ref_dir, turtle_id)
+        )
+        if mode == "set_if_missing" and has_id:
+            return False, (
+                "This turtle already has an identifier plastron. Use replace mode, or upload "
+                "a non-identifier plastron under Additional photos as type Plastron (additional)."
+            )
+        if not has_id:
+            return self._create_identifier_plastron(turtle_id, query_image, ref_dir, loose_dir)
+        return self._replace_identifier_plastron(turtle_id, query_image, ref_dir, loose_dir)
 
     def add_additional_images_to_packet(self, request_id, files_with_types):
         packet_dir = self._resolve_packet_dir(request_id)
@@ -872,8 +1002,9 @@ class TurtleManager:
             return False, str(e)
 
     def add_additional_images_to_turtle(self, turtle_id, files_with_types, sheet_name=None):
-        turtle_dir = self._get_turtle_folder(turtle_id, sheet_name)
-        if not turtle_dir or not os.path.isdir(turtle_dir): return False, "Turtle folder not found"
+        turtle_dir = self.resolve_turtle_dir_for_sheet_upload(turtle_id, sheet_name)
+        if not turtle_dir or not os.path.isdir(turtle_dir):
+            return False, "Turtle folder not found"
         today_str = time.strftime('%Y-%m-%d')
         date_dir = os.path.join(turtle_dir, 'additional_images', today_str)
         os.makedirs(date_dir, exist_ok=True)

--- a/frontend/src/components/AdditionalImagesSection.tsx
+++ b/frontend/src/components/AdditionalImagesSection.tsx
@@ -60,7 +60,10 @@ const KIND_OPTIONS = [
   { value: 'microhabitat', label: 'Microhabitat' },
   { value: 'condition', label: 'Condition' },
   { value: 'other', label: 'Other' },
-];
+] as const;
+
+/** Turtle-record additional photos support plastron-extra in manifest; review packets use a narrower type set. */
+const KIND_OPTIONS_REVIEW_PACKET = KIND_OPTIONS.filter((o) => o.value !== 'plastron');
 
 function normalizeKind(t: string): AdditionalPhotoKind {
   const s = (t || 'other').toLowerCase();
@@ -109,8 +112,10 @@ export function AdditionalImagesSection({
 
   const isPacket = !!requestId;
   const isTurtle = !!turtleId;
+  const supportsPlastronExtra = !isPacket;
   const canEdit = (isPacket || isTurtle) && !disabled;
   const canEditLabels = isTurtle && !disabled;
+  const stagingKindOptions = supportsPlastronExtra ? KIND_OPTIONS : KIND_OPTIONS_REVIEW_PACKET;
 
   useEffect(() => {
     return () => {
@@ -277,9 +282,15 @@ export function AdditionalImagesSection({
         </Text>
         {!embedded && (
           <Text size="xs" c="dimmed">
-            Add photos first, set type and tags per image, then upload. Plastron (additional) keeps an extra
-            underside shot in the manifest only (it does not replace the SuperPoint .pt reference). Tags are
-            searchable under Admin → Turtle records → Sheets → Photo tags.
+            Add photos first, set type and tags per image, then upload.
+            {supportsPlastronExtra ? (
+              <>
+                {' '}
+                Plastron (additional) keeps an extra underside shot in the manifest only (it does not replace
+                the SuperPoint .pt reference).
+              </>
+            ) : null}{' '}
+            Tags are searchable under Admin → Turtle records → Sheets → Photo tags.
           </Text>
         )}
 
@@ -308,25 +319,27 @@ export function AdditionalImagesSection({
                   }}
                 />
               </Button>
-              <Button
-                size="sm"
-                variant="light"
-                leftSection={<IconPhotoPlus size={14} />}
-                component="label"
-                disabled={disabled || uploading}
-              >
-                Plastron (extra)
-                <input
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  hidden
-                  onChange={(e) => {
-                    addFilesToStaging('plastron', e.target.files);
-                    e.target.value = '';
-                  }}
-                />
-              </Button>
+              {supportsPlastronExtra && (
+                <Button
+                  size="sm"
+                  variant="light"
+                  leftSection={<IconPhotoPlus size={14} />}
+                  component="label"
+                  disabled={disabled || uploading}
+                >
+                  Plastron (extra)
+                  <input
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    hidden
+                    onChange={(e) => {
+                      addFilesToStaging('plastron', e.target.files);
+                      e.target.value = '';
+                    }}
+                  />
+                </Button>
+              )}
               <Button
                 size="sm"
                 variant="light"
@@ -426,7 +439,7 @@ export function AdditionalImagesSection({
                           <Select
                             size="xs"
                             label="Type"
-                            data={KIND_OPTIONS}
+                            data={[...stagingKindOptions]}
                             value={row.type}
                             onChange={(v) =>
                               v && updateStaged(row.id, { type: v as StagedRow['type'] })

--- a/frontend/src/components/AdditionalImagesSection.tsx
+++ b/frontend/src/components/AdditionalImagesSection.tsx
@@ -30,7 +30,7 @@ import {
 } from '../services/api';
 import { notifications } from '@mantine/notifications';
 
-export type AdditionalPhotoKind = 'microhabitat' | 'condition' | 'carapace' | 'other';
+export type AdditionalPhotoKind = 'microhabitat' | 'condition' | 'carapace' | 'plastron' | 'other';
 
 /** Single additional image for display (packet or turtle). */
 export interface AdditionalImageDisplay {
@@ -52,10 +52,11 @@ interface AdditionalImagesSectionProps {
   hideAddButtons?: boolean;
 }
 
-const TYPE_ORDER: AdditionalPhotoKind[] = ['carapace', 'microhabitat', 'condition', 'other'];
+const TYPE_ORDER: AdditionalPhotoKind[] = ['carapace', 'plastron', 'microhabitat', 'condition', 'other'];
 
 const KIND_OPTIONS = [
   { value: 'carapace', label: 'Carapace' },
+  { value: 'plastron', label: 'Plastron (additional)' },
   { value: 'microhabitat', label: 'Microhabitat' },
   { value: 'condition', label: 'Condition' },
   { value: 'other', label: 'Other' },
@@ -63,12 +64,20 @@ const KIND_OPTIONS = [
 
 function normalizeKind(t: string): AdditionalPhotoKind {
   const s = (t || 'other').toLowerCase();
-  if (s === 'microhabitat' || s === 'condition' || s === 'carapace' || s === 'other') return s;
+  if (
+    s === 'microhabitat' ||
+    s === 'condition' ||
+    s === 'carapace' ||
+    s === 'plastron' ||
+    s === 'other'
+  )
+    return s;
   return 'other';
 }
 
 function kindSectionLabel(k: AdditionalPhotoKind): string {
   if (k === 'other') return 'Other';
+  if (k === 'plastron') return 'Plastron (additional)';
   return k;
 }
 
@@ -76,7 +85,7 @@ type StagedRow = {
   id: string;
   file: File;
   previewUrl: string;
-  type: 'carapace' | 'microhabitat' | 'condition' | 'other';
+  type: 'carapace' | 'plastron' | 'microhabitat' | 'condition' | 'other';
   labels: string[];
 };
 
@@ -268,7 +277,8 @@ export function AdditionalImagesSection({
         </Text>
         {!embedded && (
           <Text size="xs" c="dimmed">
-            Add photos first, set type and tags per image, then upload. Click a thumbnail to enlarge. Tags are
+            Add photos first, set type and tags per image, then upload. Plastron (additional) keeps an extra
+            underside shot in the manifest only (it does not replace the SuperPoint .pt reference). Tags are
             searchable under Admin → Turtle records → Sheets → Photo tags.
           </Text>
         )}
@@ -294,6 +304,25 @@ export function AdditionalImagesSection({
                   hidden
                   onChange={(e) => {
                     addFilesToStaging('carapace', e.target.files);
+                    e.target.value = '';
+                  }}
+                />
+              </Button>
+              <Button
+                size="sm"
+                variant="light"
+                leftSection={<IconPhotoPlus size={14} />}
+                component="label"
+                disabled={disabled || uploading}
+              >
+                Plastron (extra)
+                <input
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  hidden
+                  onChange={(e) => {
+                    addFilesToStaging('plastron', e.target.files);
                     e.target.value = '';
                   }}
                 />

--- a/frontend/src/pages/AdminTurtleRecords/SheetsBrowserTab.tsx
+++ b/frontend/src/pages/AdminTurtleRecords/SheetsBrowserTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActionIcon,
   Badge,
@@ -37,6 +37,7 @@ import {
   getTurtleImages,
   getTurtlePrimariesBatch,
   isAdminRole,
+  uploadTurtleIdentifierPlastron,
   searchTurtleImagesByLabel,
   type TurtleAdditionalLabelSearchMatch,
   type TurtleImageAdditional,
@@ -47,6 +48,7 @@ import { useUser } from '../../hooks/useUser';
 import { TurtleSheetsDataForm } from '../../components/TurtleSheetsDataForm';
 import { AdditionalImagesSection } from '../../components/AdditionalImagesSection';
 import { formatSingleDateTokenToUs } from '../../utils/usDateFormat';
+import { validateFile } from '../../utils/fileValidation';
 import { useAdminTurtleRecordsContext } from './AdminTurtleRecordsContext';
 
 function turtleKey(turtle: { primary_id?: string | null; id?: string | null; sheet_name?: string | null }) {
@@ -108,6 +110,8 @@ export function SheetsBrowserTab() {
   const [selectedMatchPath, setSelectedMatchPath] = useState<string | null>(null);
   const [tagSearchLightbox, setTagSearchLightbox] = useState<string | null>(null);
   const [backupLoading, setBackupLoading] = useState(false);
+  const [identifierSubmitting, setIdentifierSubmitting] = useState(false);
+  const identifierFileInputRef = useRef<HTMLInputElement>(null);
   const {
     selectedSheetFilter,
     sheetsListLoading,
@@ -675,6 +679,126 @@ export function SheetsBrowserTab() {
       <Grid.Col span={{ base: 12, md: 8 }}>
         {selectedTurtle ? (
           <Stack gap='md'>
+            {turtleId && (
+              <Paper shadow='sm' p='md' radius='md' withBorder>
+                <Stack gap='sm'>
+                  <Text fw={600} size='sm'>
+                    Identifier plastron (SuperPoint reference)
+                  </Text>
+                  <Text size='xs' c='dimmed'>
+                    Matching uses ref_data with this turtle id (image plus .pt tensor). Replace archives the
+                    previous master into loose_images. A second underside photo only: use Plastron (extra) under
+                    additional photos below.
+                  </Text>
+                  {!sheetName && !turtleImages?.primary ? (
+                    <Text size='xs' c='orange'>
+                      This row has no sheet/location path yet. Set the first identifier after the turtle has a
+                      location so the backend can create{' '}
+                      <code>{'data/<location>/<turtle id>/'}</code> on disk.
+                    </Text>
+                  ) : null}
+                  <Group align='flex-start' wrap='wrap' gap='md'>
+                    <Box
+                      style={{
+                        width: 160,
+                        borderRadius: 8,
+                        overflow: 'hidden',
+                        border: '1px solid var(--mantine-color-default-border)',
+                        minHeight: 100,
+                        backgroundColor: 'var(--mantine-color-gray-0)',
+                      }}
+                    >
+                      {turtleImages?.primary ? (
+                        <Image
+                          src={getImageUrl(turtleImages.primary)}
+                          alt='Identifier plastron'
+                          fit='contain'
+                          style={{ width: '100%', height: 'auto', display: 'block' }}
+                        />
+                      ) : (
+                        <Center p='md' style={{ minHeight: 100 }}>
+                          <Text size='xs' c='dimmed' ta='center'>
+                            No identifier image yet — typical for a new sheet-only row.
+                          </Text>
+                        </Center>
+                      )}
+                    </Box>
+                    <Stack gap='xs' style={{ flex: '1 1 12rem' }}>
+                      <input
+                        ref={identifierFileInputRef}
+                        type='file'
+                        accept='image/*'
+                        style={{ display: 'none' }}
+                        onChange={(e) => {
+                          const file = e.target.files?.[0];
+                          e.currentTarget.value = '';
+                          if (!file || !turtleId) return;
+                          const check = validateFile(file);
+                          if (!check.isValid) {
+                            if (check.error) {
+                              notifications.show({
+                                title: 'Invalid file',
+                                message: check.error,
+                                color: 'red',
+                              });
+                            }
+                            return;
+                          }
+                          void (async () => {
+                            setIdentifierSubmitting(true);
+                            try {
+                              await uploadTurtleIdentifierPlastron(
+                                turtleId,
+                                file,
+                                sheetName,
+                                turtleImages?.primary ? 'replace' : 'set_if_missing',
+                              );
+                              notifications.show({
+                                title: 'Saved',
+                                message: turtleImages?.primary
+                                  ? 'Identifier plastron replaced; search index updated.'
+                                  : 'Identifier plastron set; search index updated.',
+                                color: 'green',
+                              });
+                              const res = await getTurtleImages(turtleId, sheetName);
+                              setTurtleImages(res);
+                              if (selectedTurtle) {
+                                const pr = await getTurtlePrimariesBatch([
+                                  { turtle_id: turtleId, sheet_name: sheetName },
+                                ]);
+                                const p = pr.images[0]?.primary ?? null;
+                                setPrimaryImages((prev) => ({
+                                  ...prev,
+                                  [turtleKey(selectedTurtle)]: p,
+                                }));
+                              }
+                            } catch (err) {
+                              notifications.show({
+                                title: 'Error',
+                                message: err instanceof Error ? err.message : 'Upload failed',
+                                color: 'red',
+                              });
+                            } finally {
+                              setIdentifierSubmitting(false);
+                            }
+                          })();
+                        }}
+                      />
+                      <Button
+                        size='sm'
+                        variant='light'
+                        leftSection={<IconPhoto size={16} />}
+                        loading={identifierSubmitting}
+                        disabled={!turtleId || (!sheetName && !turtleImages?.primary)}
+                        onClick={() => identifierFileInputRef.current?.click()}
+                      >
+                        {turtleImages?.primary ? 'Replace identifier…' : 'Set identifier…'}
+                      </Button>
+                    </Stack>
+                  </Group>
+                </Stack>
+              </Paper>
+            )}
             {turtleId &&
               additionalGroups.map(({ label, items }) => (
                 <AdditionalImagesSection

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -59,6 +59,7 @@ export {
   getTurtleImages,
   getTurtlePrimariesBatch,
   uploadTurtleAdditionalImages,
+  uploadTurtleIdentifierPlastron,
   deleteTurtleAdditionalImage,
   searchTurtleImagesByLabel,
   updateTurtleAdditionalImageLabels,

--- a/frontend/src/services/api/turtle.ts
+++ b/frontend/src/services/api/turtle.ts
@@ -506,11 +506,38 @@ export const getTurtlePrimariesBatch = async (
   return await response.json();
 };
 
-/** Add microhabitat/condition/carapace images to a turtle folder (Admin only). */
+/** Set or replace ref_data identifier plastron (.pt + master image). Admin only. */
+export const uploadTurtleIdentifierPlastron = async (
+  turtleId: string,
+  file: File,
+  sheetName: string | null | undefined,
+  mode: 'set_if_missing' | 'replace',
+): Promise<{ success: boolean; message?: string }> => {
+  const token = getToken();
+  const headers: Record<string, string> = {};
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  const formData = new FormData();
+  formData.append('turtle_id', turtleId);
+  formData.append('file', file);
+  formData.append('mode', mode);
+  if (sheetName) formData.append('sheet_name', sheetName);
+  const response = await fetch(`${TURTLE_API_BASE_URL}/turtles/images/identifier-plastron`, {
+    method: 'POST',
+    headers,
+    body: formData,
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({ error: 'Failed to update identifier plastron' }));
+    throw new Error(err.error || 'Failed to update identifier plastron');
+  }
+  return await response.json();
+};
+
+/** Add microhabitat/condition/carapace/plastron (additional) images to a turtle folder (Admin only). */
 export const uploadTurtleAdditionalImages = async (
   turtleId: string,
   files: Array<{
-    type: 'microhabitat' | 'condition' | 'carapace' | 'other';
+    type: 'microhabitat' | 'condition' | 'carapace' | 'plastron' | 'other';
     file: File;
     /** Applied to this file only (comma-separated sent as labels_i) */
     labels?: string[];

--- a/frontend/src/services/api/turtle.ts
+++ b/frontend/src/services/api/turtle.ts
@@ -227,7 +227,7 @@ export const getReviewQueue = async (): Promise<ReviewQueueResponse> => {
 export const uploadReviewPacketAdditionalImages = async (
   requestId: string,
   files: Array<{
-    type: 'microhabitat' | 'condition' | 'carapace' | 'other';
+    type: 'microhabitat' | 'condition' | 'carapace' | 'plastron' | 'other';
     file: File;
     labels?: string[];
   }>,


### PR DESCRIPTION
- POST /api/turtles/images/identifier-plastron (set_if_missing | replace)
- resolve_turtle_dir_for_sheet_upload for sheet-only rows + additional images
- Sheets browser: native file picker for set/replace identifier; plastron (additional) UI
- tests: backend/tests/test_turtle_plastron_upload.py