### PR TITLE
Turtle Match General Location unlock + catalog dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Admin Turtle Match — General Location**: On the match sheet form, **General Location** was hard read-only (plain text + “Add new General Location” only, no catalog dropdown). It is now in the same **Unlock editing** flow as other editable match columns; after confirm, the **catalog select** works like elsewhere. Sheets with a **fixed catalog default** (`generalLocationLocked`) still show a disabled control **without** an extra unlock step.
+
+### Testing
+
+- **Playwright** (`frontend/tests/e2e/admin-match.spec.ts`): **Edit matched research turtle** asserts General Location starts locked with **Unlock editing**, then offers catalog options including **West Topeka** after unlock.
+
 ## [1.2.17] - 2026-04-21 — Sheets browser biology ID for disk images + primaries batch
 
 ### Fixed

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -76,7 +76,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1080,7 +1079,6 @@
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.10.tgz",
       "integrity": "sha512-aKQFETN14v6GtM07b/G5yJneMM1yrgf9mNrTah6GVy5DvQM0AeutITT7toHqh5gxxwzdg/DoY+HQsv5zhqnc5g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "clsx": "^2.1.1",
@@ -1115,7 +1113,6 @@
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.10.tgz",
       "integrity": "sha512-bv+yYHl+keTIvakiDzVJMIjW+o8/Px0G3EdpCMFG+U2ux6SwQqluqoq+/kqrTtT6RaLvQ0fMxjpIULF2cu/xAg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -2111,7 +2108,6 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2122,7 +2118,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2188,7 +2183,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2466,7 +2460,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2638,7 +2631,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2937,7 +2929,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4031,7 +4022,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4090,7 +4080,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4143,7 +4132,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4153,7 +4141,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4199,7 +4186,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -4372,8 +4358,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4650,7 +4635,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4833,7 +4817,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/frontend/src/components/TurtleSheetsDataFormFields.tsx
+++ b/frontend/src/components/TurtleSheetsDataFormFields.tsx
@@ -69,6 +69,8 @@ export function TurtleSheetsDataFormFields({
     if (!useMatchEditLocks) return effectiveRestrictedForField(field);
     if (requireNewSheetForCommunityMatch && field === 'general_location') return false;
     if (field === 'id') return false;
+    // Sheet default pins General Location (catalog): keep disabled control without an unlock step.
+    if (field === 'general_location' && generalLocationLocked) return false;
     if (mode === 'create') return true;
     return TURTLE_MATCH_PAGE_UNLOCKABLE_FIELDS.has(field);
   };

--- a/frontend/src/components/turtleSheetsFormLayout.ts
+++ b/frontend/src/components/turtleSheetsFormLayout.ts
@@ -62,7 +62,9 @@ export const FULL_SHEET_FORM_FIELD_ORDER: TurtleFormOrderKey[] = [
  *   all other visible fields (e.g. **freq**, **species**, **name**) are read-only with no unlock.
  * - **Create** new turtle (Match page modal): the same “non-unlockable on edit” fields use
  *   unlock-to-edit so they can be filled; biology **id** stays auto/disabled; **general_location**
- *   may stay open when moving from community (`requireNewSheetForCommunityMatch`).
+ *   uses unlock-then-catalog-dropdown when editable, or stays disabled when the sheet has a
+ *   fixed default (`generalLocationLocked`); **general_location** may stay open when moving from
+ *   community (`requireNewSheetForCommunityMatch`).
  */
 export const TURTLE_MATCH_PAGE_FORM_ORDER: TurtleFormOrderKey[] = [
   'freq',
@@ -98,12 +100,16 @@ export const TURTLE_MATCH_PAGE_FORM_ORDER: TurtleFormOrderKey[] = [
   'dome_height_mm',
 ];
 
-/** On Match **edit**, these fields use unlock + confirm; others in the match column set are hard read-only. */
+/**
+ * On Match **edit**, these fields use unlock + confirm; others in the match column set are hard read-only.
+ * **general_location** uses the same unlock flow so the catalog dropdown appears after confirm (not read-only text + “Add new” only).
+ */
 export const TURTLE_MATCH_PAGE_UNLOCKABLE_FIELDS = new Set<keyof TurtleSheetsData>([
   'dna_extracted',
   'last_assay_date',
   'dates_refound',
   'specific_location',
+  'general_location',
   'location',
   'cow_interactions',
   'health_status',

--- a/frontend/tests/e2e/admin-community-to-admin.spec.ts
+++ b/frontend/tests/e2e/admin-community-to-admin.spec.ts
@@ -197,9 +197,9 @@ test.describe('Admin Community turtle move to admin', () => {
       .or(page.getByRole('combobox', { name: 'Sheet / Location' }));
     await expect(sheetLocationInput).toBeVisible({ timeout: 15_000 });
     // Form fields live in a Paper above the action bar; Save is in a sibling Paper (no shared Grid.Col).
-    const sheetsFormCard = page.locator('.mantine-Paper-root').filter({
-      has: page.getByRole('heading', { name: /Turtle Data - Google Sheets/ }),
-    });
+    const sheetsFormCard = page
+      .getByRole('heading', { name: /Turtle Data - Google Sheets/ })
+      .locator('xpath=ancestor::div[contains(@class,"mantine-Paper-root")][1]');
     const generalLocationInput = sheetsFormCard
       .getByRole('textbox', { name: /General Location/ })
       .or(sheetsFormCard.getByRole('combobox', { name: /General Location/ }));

--- a/frontend/tests/e2e/admin-match.spec.ts
+++ b/frontend/tests/e2e/admin-match.spec.ts
@@ -8,6 +8,7 @@ import {
   selectSheetInCreateTurtleDialog,
   unlockUntilFieldEditable,
   GENERAL_LOCATION_LABEL,
+  registerKansasGeneralLocationsCatalogMock,
 } from './fixtures';
 
 test.describe('Admin Turtle Match', () => {
@@ -213,6 +214,144 @@ test.describe('Admin Turtle Match', () => {
       await expect(listbox).toBeVisible({ timeout: 5000 });
       const optionTexts = await listbox.getByRole('option').allTextContents();
       expect(optionTexts).toContain('North Topeka');
+      await page.keyboard.press('Escape');
+    }
+  });
+
+  test('Edit matched research turtle: General Location requires unlock, then catalog dropdown (e.g. West Topeka)', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    const REQUEST_ID = 'e2e-match-edit-gl-research';
+
+    await page.route('**/api/upload**', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          request_id: REQUEST_ID,
+          uploaded_image_path: `Review_Queue/${REQUEST_ID}/query.jpg`,
+          matches: [
+            {
+              turtle_id: 'F501',
+              location: 'Kansas',
+              distance: 0.12,
+              file_path: 'Review_Queue/Req_1/candidate_matches/rank1.jpg',
+              filename: 'rank1.jpg',
+            },
+          ],
+          message: 'Uploaded',
+        }),
+      });
+    });
+
+    const reviewSuffix = `/api/review-queue/${encodeURIComponent(REQUEST_ID)}`;
+    await page.route('**/api/review-queue/**', async (route) => {
+      const path = new URL(route.request().url()).pathname;
+      if (path !== reviewSuffix || route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          item: {
+            request_id: REQUEST_ID,
+            uploaded_image: `Review_Queue/${REQUEST_ID}/query.jpg`,
+            metadata: {},
+            additional_images: [],
+            candidates: [],
+            status: 'pending',
+          },
+        }),
+      });
+    });
+
+    await page.route('**/api/sheets/sheets**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, sheets: ['Kansas', 'NebraskaCPBS'] }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.route('**/api/sheets/turtle/F501**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            exists: true,
+            data: {
+              primary_id: '10042',
+              id: 'F501',
+              name: 'E2E Match Turtle',
+              sheet_name: 'Kansas',
+              general_location: 'North Topeka',
+              sex: 'M',
+            },
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await registerKansasGeneralLocationsCatalogMock(page);
+
+    await loginAsAdmin(page);
+    await page.getByText('Successfully logged in!').waitFor({ state: 'hidden', timeout: 8000 }).catch(() => {});
+
+    const fileInput = page.locator('input[type="file"]:not([capture])').first();
+    await fileInput.setInputFiles({
+      name: 'match-edit-gl-e2e.png',
+      mimeType: 'image/png',
+      buffer: getTestImageBuffer(),
+    });
+    await page.waitForSelector('button:has-text("Upload Photo")', { timeout: 5000 });
+    await clickUploadPhotoButton(page);
+
+    await expect(page).toHaveURL(new RegExp(`/admin/turtle-match/${REQUEST_ID}`), { timeout: 30_000 });
+    await expect(page.getByRole('heading', { name: /Turtle Match Review/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.locator('.mantine-Card-root').filter({ hasText: 'F501' }).first().click();
+
+    const sheetsFormCard = page.locator('.mantine-Paper-root').filter({
+      has: page.getByRole('heading', { name: /Turtle Data - Google Sheets/ }),
+    });
+    await expect(sheetsFormCard).toBeVisible({ timeout: 15_000 });
+
+    await registerKansasGeneralLocationsCatalogMock(page);
+
+    const glField = sheetsFormCard.getByLabel(GENERAL_LOCATION_LABEL);
+    await expect(glField).toBeVisible({ timeout: 15_000 });
+    await expect(glField).toBeDisabled();
+    const glCell = glField.locator('xpath=ancestor::div[contains(@class,"Grid-col")][1]');
+    await expect(glCell.getByRole('button', { name: 'Unlock editing' })).toBeVisible();
+
+    await unlockUntilFieldEditable(page, sheetsFormCard, GENERAL_LOCATION_LABEL);
+
+    const isNativeSelect = await glField.evaluate((el) => el.tagName === 'SELECT');
+    if (isNativeSelect) {
+      const options = await glField.locator('option').allTextContents();
+      expect(options).toContain('West Topeka');
+    } else {
+      await glField.click();
+      const listbox = page.getByRole('listbox', { name: GENERAL_LOCATION_LABEL });
+      await expect(listbox).toBeVisible({ timeout: 5000 });
+      const optionTexts = await listbox.getByRole('option').allTextContents();
+      expect(optionTexts).toContain('West Topeka');
       await page.keyboard.press('Escape');
     }
   });

--- a/frontend/tests/e2e/admin-match.spec.ts
+++ b/frontend/tests/e2e/admin-match.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import {
   loginAsAdmin,
   loginAsCommunity,
@@ -10,6 +10,21 @@ import {
   GENERAL_LOCATION_LABEL,
   registerKansasGeneralLocationsCatalogMock,
 } from './fixtures';
+
+/**
+ * After opening the General Location Mantine dropdown, resolves the portaled listbox.
+ * WebKit often omits the accessible name on that listbox; same strategy as `selectGeneralLocationInCreateTurtleDialog` in fixtures.ts.
+ */
+async function waitForGeneralLocationListbox(page: Page, visibilityTimeoutMs: number) {
+  const namedListbox = page.getByRole('listbox', { name: GENERAL_LOCATION_LABEL });
+  const useNamed = await namedListbox
+    .waitFor({ state: 'visible', timeout: 2500 })
+    .then(() => true)
+    .catch(() => false);
+  const listbox = useNamed ? namedListbox : page.getByRole('listbox').last();
+  await listbox.waitFor({ state: 'visible', timeout: visibilityTimeoutMs });
+  return listbox;
+}
 
 test.describe('Admin Turtle Match', () => {
   test.beforeEach(async ({ page }) => {
@@ -210,8 +225,7 @@ test.describe('Admin Turtle Match', () => {
       expect(options).toContain('North Topeka');
     } else {
       await generalLocationField.click();
-      const listbox = page.getByRole('listbox');
-      await expect(listbox).toBeVisible({ timeout: 5000 });
+      const listbox = await waitForGeneralLocationListbox(page, 5000);
       const optionTexts = await listbox.getByRole('option').allTextContents();
       expect(optionTexts).toContain('North Topeka');
       await page.keyboard.press('Escape');
@@ -349,8 +363,7 @@ test.describe('Admin Turtle Match', () => {
       expect(options).toContain('West Topeka');
     } else {
       await glField.click();
-      const listbox = page.getByRole('listbox', { name: GENERAL_LOCATION_LABEL });
-      await expect(listbox).toBeVisible({ timeout: 5000 });
+      const listbox = await waitForGeneralLocationListbox(page, 5000);
       const optionTexts = await listbox.getByRole('option').allTextContents();
       expect(optionTexts).toContain('West Topeka');
       await page.keyboard.press('Escape');

--- a/frontend/tests/e2e/admin-match.spec.ts
+++ b/frontend/tests/e2e/admin-match.spec.ts
@@ -327,9 +327,10 @@ test.describe('Admin Turtle Match', () => {
 
     await page.locator('.mantine-Card-root').filter({ hasText: 'F501' }).first().click();
 
-    const sheetsFormCard = page.locator('.mantine-Paper-root').filter({
-      has: page.getByRole('heading', { name: /Turtle Data - Google Sheets/ }),
-    });
+    // Closest Paper only: nested Mantine Papers both match filter({ has: heading }), which breaks strict mode.
+    const sheetsFormCard = page
+      .getByRole('heading', { name: /Turtle Data - Google Sheets/ })
+      .locator('xpath=ancestor::div[contains(@class,"mantine-Paper-root")][1]');
     await expect(sheetsFormCard).toBeVisible({ timeout: 15_000 });
 
     await registerKansasGeneralLocationsCatalogMock(page);


### PR DESCRIPTION
### Fixed

- **Admin Turtle Match — General Location**: On the match sheet form, **General Location** was hard read-only (plain text + “Add new General Location” only, no catalog dropdown). It is now in the same **Unlock editing** flow as other editable match columns; after confirm, the **catalog select** works like elsewhere. Sheets with a **fixed catalog default** (`generalLocationLocked`) still show a disabled control **without** an extra unlock step.

### Testing

- **Playwright** (`frontend/tests/e2e/admin-match.spec.ts`): **Edit matched research turtle** asserts General Location starts locked with **Unlock editing**, then offers catalog options including **West Topeka** after unlock.