### PR TITLE
Correct first-visit mobile tutorial viewport detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **First-visit mobile tutorial viewport**: Fixed a mobile rendering issue where opening the instructions tutorial on a fresh device could initially render the app in desktop-like scale. Mobile media queries now resolve on initial render for home/tutorial flow, and tutorial scroll height uses dynamic viewport sizing for more stable phone layout.
+
 ## [1.2.18] - 2026-04-24 — Review approve research/community sync guard + match-form General Location unlock
 
 ### Fixed

--- a/frontend/src/components/InstructionsModal.tsx
+++ b/frontend/src/components/InstructionsModal.tsx
@@ -36,7 +36,7 @@ export function InstructionsModal({ opened, onClose, onTrainingCompleted }: Inst
   const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
   const [acknowledged, setAcknowledged] = useState(false);
   const viewportRef = useRef<HTMLDivElement>(null);
-  const isMobile = useMediaQuery('(max-width: 768px)', false, { getInitialValueInEffect: false });
+  const isMobile = useMediaQuery('(max-width: 768px)', undefined, { getInitialValueInEffect: false });
 
   // If user already saw instructions before (e.g. reopening as reminder), allow closing freely
   const isReminderMode =

--- a/frontend/src/components/InstructionsModal.tsx
+++ b/frontend/src/components/InstructionsModal.tsx
@@ -36,7 +36,7 @@ export function InstructionsModal({ opened, onClose, onTrainingCompleted }: Inst
   const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
   const [acknowledged, setAcknowledged] = useState(false);
   const viewportRef = useRef<HTMLDivElement>(null);
-  const isMobile = useMediaQuery('(max-width: 576px)');
+  const isMobile = useMediaQuery('(max-width: 768px)', false, { getInitialValueInEffect: false });
 
   // If user already saw instructions before (e.g. reopening as reminder), allow closing freely
   const isReminderMode =
@@ -93,7 +93,7 @@ export function InstructionsModal({ opened, onClose, onTrainingCompleted }: Inst
       }}
     >
       <ScrollArea
-        h={isMobile ? '70vh' : 560}
+        h={isMobile ? 'calc(100dvh - 9rem)' : 560}
         onScrollPositionChange={handleScroll}
         viewportRef={viewportRef}
         type="scroll"

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -87,7 +87,7 @@ export default function HomePage() {
   const { role, isLoggedIn, authChecked } = useUser();
   const isStaff = isStaffRole(role);
   const canUseObserverGamification = authChecked && isLoggedIn;
-  const isMobile = useMediaQuery('(max-width: 768px)');
+  const isMobile = useMediaQuery('(max-width: 768px)', false, { getInitialValueInEffect: false });
   const cameraInputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [instructionsOpened, setInstructionsOpened] = useState(false);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -87,7 +87,7 @@ export default function HomePage() {
   const { role, isLoggedIn, authChecked } = useUser();
   const isStaff = isStaffRole(role);
   const canUseObserverGamification = authChecked && isLoggedIn;
-  const isMobile = useMediaQuery('(max-width: 768px)', false, { getInitialValueInEffect: false });
+  const isMobile = useMediaQuery('(max-width: 768px)', undefined, { getInitialValueInEffect: false });
   const cameraInputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [instructionsOpened, setInstructionsOpened] = useState(false);


### PR DESCRIPTION
### Fixed

- **First-visit mobile tutorial viewport**: Fixed a mobile rendering issue where opening the instructions tutorial on a fresh device could initially render the app in desktop-like scale. Mobile media queries now resolve on initial render for home/tutorial flow, and tutorial scroll height uses dynamic viewport sizing for more stable phone layout.