### PR TITLE
Expand categories, type filter search, drag-drop uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Additional turtle photo categories** shared across homepage upload (PreviewCard), Admin Sheets browser, Review Queue, and Admin Match: anterior, posterior, left/right side, people, injury, and existing types (carapace, plastron, microhabitat, condition, other). Filenames continue to encode the category (e.g. `right-side_…`).
+- **Drag-and-drop** onto each category button to stage additional photos (same UX pattern on homepage and admin additional-photo sections).
+- **Sheets browser — Photo tags**: optional **Photo category** filter; search supports **category only**, **tags only**, or **combined** tag + category. **`GET /api/turtles/images/search-labels`** accepts `q` and/or `type` (at least one required).
+
+### Changed
+
+- **Legacy labels**: `head` / `tail` are no longer offered as buttons; stored values still normalize to **anterior** / **posterior** for backward compatibility.
+- **Review queue** additional-image uploads use the same normalized category set as turtle records.
+- **Admin token validation** (`backend/auth.py`): if **`AUTH_URL`** uses `localhost` and validation fails, retry once against **`127.0.0.1`** to avoid Windows/dev hostname resolution mismatches.
+
+### Testing
+
+- Backend integration tests for **`search-labels`** type-only and combined filters and for **`right-side`** on review packet additional-images.
+- Playwright: Sheets browser type-only search; homepage extended category buttons and drag-and-drop staging (mobile/WebKit skipped where event simulation is unreliable).
+
 ## [1.2.19] - 2026-04-27 — Mobile tutorial viewport + Specific Property label and Location reminder
 
 ### Fixed

--- a/backend/additional_image_labels.py
+++ b/backend/additional_image_labels.py
@@ -1,16 +1,48 @@
 """Shared parsing/normalization for additional image types and labels (manifest.json)."""
 
 import json
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
-VALID_ADDITIONAL_TYPES = frozenset(
-    {'microhabitat', 'condition', 'carapace', 'plastron', 'other'}
-)
+ADDITIONAL_TYPE_ALIASES: Dict[str, str] = {
+    'microhabitat': 'microhabitat',
+    'condition': 'condition',
+    'carapace': 'carapace',
+    'plastron': 'plastron',
+    'anterior': 'anterior',
+    'posterior': 'posterior',
+    'leftside': 'left-side',
+    'rightside': 'right-side',
+    # Legacy aliases kept for backwards compatibility with older clients/buttons.
+    'head': 'anterior',
+    'tail': 'posterior',
+    'people': 'people',
+    'injury': 'injury',
+    'other': 'other',
+}
+
+VALID_ADDITIONAL_TYPES = frozenset(ADDITIONAL_TYPE_ALIASES.values())
+
+
+def _type_key(raw: Optional[str]) -> str:
+    return ''.join(ch for ch in (raw or '').strip().lower() if ch.isalnum())
 
 
 def normalize_additional_type(raw: Optional[str]) -> str:
-    t = (raw or 'other').strip().lower()
-    return t if t in VALID_ADDITIONAL_TYPES else 'other'
+    return ADDITIONAL_TYPE_ALIASES.get(_type_key(raw), 'other')
+
+
+def parse_additional_type_filter(raw: Optional[str]) -> Optional[str]:
+    """Return canonical type or None (for empty). Raise ValueError for invalid non-empty input."""
+    if raw is None:
+        return None
+    stripped = str(raw).strip()
+    if not stripped:
+        return None
+    key = _type_key(stripped)
+    parsed = ADDITIONAL_TYPE_ALIASES.get(key)
+    if not parsed:
+        raise ValueError('Invalid additional image type filter')
+    return parsed
 
 
 def normalize_label_list(labels: Any) -> List[str]:

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -5,6 +5,7 @@ JWT Authentication utilities and decorators
 import json
 import ssl
 import urllib.error
+import urllib.parse
 import urllib.request
 
 import jwt
@@ -58,26 +59,49 @@ def check_auth_revocation(auth_header):
     """
     if not AUTH_URL:
         return False, 'AUTH_URL must be set to verify staff/admin tokens (revocation check)'
-    url = f'{AUTH_URL}/auth/validate'
-    try:
-        req = urllib.request.Request(url, method='POST', headers={'Authorization': auth_header})
-        # Optional: don't verify SSL in dev if auth uses self-signed cert
-        ctx = ssl.create_default_context()
-        with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
-            if resp.status != 200:
-                return False, 'Token validation failed'
-            return True, None
-    except urllib.error.HTTPError as e:
-        if e.code == 403:
+
+    def validate_against(auth_base_url):
+        url = f'{auth_base_url.rstrip("/")}/auth/validate'
+        try:
+            req = urllib.request.Request(url, method='POST', headers={'Authorization': auth_header})
+            # Optional: don't verify SSL in dev if auth uses self-signed cert
+            ctx = ssl.create_default_context()
+            with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
+                if resp.status != 200:
+                    return False, f'Auth validation failed (HTTP {resp.status})'
+                return True, None
+        except urllib.error.HTTPError as e:
+            error_message = None
             try:
                 body = json.loads(e.read().decode())
-                return False, body.get('error', 'Token has been revoked')
+                error_message = body.get('error')
             except (ValueError, AttributeError):
-                pass
-        return False, 'Token has been revoked'
-    except (urllib.error.URLError, OSError, TimeoutError):
-        # Fail closed: if we can't reach auth service, deny access
-        return False, 'Unable to verify token; try again later'
+                error_message = None
+
+            if e.code == 403:
+                return False, error_message or 'Token has been revoked'
+            return False, error_message or f'Auth validation failed (HTTP {e.code})'
+        except (urllib.error.URLError, OSError, TimeoutError):
+            # Fail closed: if we can't reach auth service, deny access
+            return False, 'Unable to verify token; try again later'
+
+    allowed, revoke_error = validate_against(AUTH_URL)
+    if allowed:
+        return True, None
+
+    # Windows/dev environments can resolve "localhost" to a different service than 127.0.0.1.
+    # If primary AUTH_URL uses localhost and validation failed, retry once against 127.0.0.1.
+    parsed = urllib.parse.urlparse(AUTH_URL)
+    if parsed.hostname == 'localhost':
+        fallback_netloc = parsed.netloc.replace('localhost', '127.0.0.1', 1)
+        fallback_url = urllib.parse.urlunparse(parsed._replace(netloc=fallback_netloc))
+        if fallback_url != AUTH_URL:
+            retry_allowed, retry_error = validate_against(fallback_url)
+            if retry_allowed:
+                return True, None
+            revoke_error = retry_error or revoke_error
+
+    return False, revoke_error
 
 
 def require_auth(f):

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -61,6 +61,12 @@ def check_auth_revocation(auth_header):
         return False, 'AUTH_URL must be set to verify staff/admin tokens (revocation check)'
 
     def validate_against(auth_base_url):
+        """Returns (allowed, error, connectivity_failure).
+
+        connectivity_failure is True only when the auth service could not be reached
+        (no HTTP response). Used to decide whether a localhost → 127.0.0.1 fallback
+        is safe: never retry after a definitive HTTP outcome (e.g. 403 revocation).
+        """
         url = f'{auth_base_url.rstrip("/")}/auth/validate'
         try:
             req = urllib.request.Request(url, method='POST', headers={'Authorization': auth_header})
@@ -68,8 +74,8 @@ def check_auth_revocation(auth_header):
             ctx = ssl.create_default_context()
             with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
                 if resp.status != 200:
-                    return False, f'Auth validation failed (HTTP {resp.status})'
-                return True, None
+                    return False, f'Auth validation failed (HTTP {resp.status})', False
+                return True, None, False
         except urllib.error.HTTPError as e:
             error_message = None
             try:
@@ -79,24 +85,25 @@ def check_auth_revocation(auth_header):
                 error_message = None
 
             if e.code == 403:
-                return False, error_message or 'Token has been revoked'
-            return False, error_message or f'Auth validation failed (HTTP {e.code})'
+                return False, error_message or 'Token has been revoked', False
+            return False, error_message or f'Auth validation failed (HTTP {e.code})', False
         except (urllib.error.URLError, OSError, TimeoutError):
             # Fail closed: if we can't reach auth service, deny access
-            return False, 'Unable to verify token; try again later'
+            return False, 'Unable to verify token; try again later', True
 
-    allowed, revoke_error = validate_against(AUTH_URL)
+    allowed, revoke_error, primary_unreachable = validate_against(AUTH_URL)
     if allowed:
         return True, None
 
     # Windows/dev environments can resolve "localhost" to a different service than 127.0.0.1.
-    # If primary AUTH_URL uses localhost and validation failed, retry once against 127.0.0.1.
+    # Retry once against 127.0.0.1 only when the primary host could not be reached — not after
+    # a definitive HTTP response (403 revocation, 401, etc.), which would weaken revocation.
     parsed = urllib.parse.urlparse(AUTH_URL)
-    if parsed.hostname == 'localhost':
+    if parsed.hostname == 'localhost' and primary_unreachable:
         fallback_netloc = parsed.netloc.replace('localhost', '127.0.0.1', 1)
         fallback_url = urllib.parse.urlunparse(parsed._replace(netloc=fallback_netloc))
         if fallback_url != AUTH_URL:
-            retry_allowed, retry_error = validate_against(fallback_url)
+            retry_allowed, retry_error, _ = validate_against(fallback_url)
             if retry_allowed:
                 return True, None
             revoke_error = retry_error or revoke_error

--- a/backend/routes/review.py
+++ b/backend/routes/review.py
@@ -14,7 +14,7 @@ from services.manager_service import get_sheets_service, get_community_sheets_se
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
 from image_utils import normalize_to_jpeg
 from general_locations_catalog import resolve_general_location_from_sheet_and_value
-from additional_image_labels import normalize_label_list, parse_labels_from_form
+from additional_image_labels import normalize_additional_type, normalize_label_list, parse_labels_from_form
 
 def format_review_packet_item(packet_dir, request_id):
     """Build one queue item dict from packet_dir (used by get_review_queue and get_review_packet)."""
@@ -174,7 +174,7 @@ def register_review_routes(app):
     @app.route('/api/review-queue/<request_id>/additional-images', methods=['POST'])
     @require_admin
     def add_review_packet_additional_images(request_id):
-        """Add microhabitat/condition images to an existing review packet (Admin only)."""
+        """Add additional images to an existing review packet (Admin only)."""
         if not manager_service.manager_ready.wait(timeout=30):
             return jsonify({'error': 'TurtleManager is still initializing.'}), 503
         if manager_service.manager is None:
@@ -188,9 +188,7 @@ def register_review_routes(app):
                 if not f or not f.filename:
                     continue
                 idx = key.replace('file_', '')
-                typ = request.form.get(f'type_{idx}', 'other').strip().lower()
-                if typ not in ('microhabitat', 'condition', 'carapace', 'plastron', 'other'):
-                    typ = 'other'
+                typ = normalize_additional_type(request.form.get(f'type_{idx}'))
                 lbs = parse_labels_from_form(request.form, idx)
                 if not allowed_file(f.filename):
                     continue

--- a/backend/routes/turtles.py
+++ b/backend/routes/turtles.py
@@ -12,8 +12,10 @@ from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
 from image_utils import normalize_to_jpeg
 from services import manager_service
 from additional_image_labels import (
+    normalize_additional_type,
     normalize_label_list,
     parse_labels_from_form,
+    parse_additional_type_filter,
 )
 
 
@@ -132,17 +134,24 @@ def register_turtle_routes(app):
     @require_admin
     def search_turtle_images_by_label():
         """
-        Find additional images whose labels match query (substring, case-insensitive).
-        Query: q (required)
+        Find additional images by label substring and/or additional-image category.
+        Query: q (optional), type (optional). At least one is required.
         """
         if not manager_service.manager_ready.wait(timeout=5):
             return jsonify({'error': 'TurtleManager is still initializing'}), 503
         if manager_service.manager is None:
             return jsonify({'error': 'TurtleManager not available'}), 500
         q = (request.args.get('q') or '').strip()
-        if not q:
-            return jsonify({'error': 'q required'}), 400
-        matches = manager_service.manager.search_additional_images_by_label(q)
+        try:
+            image_type = parse_additional_type_filter(request.args.get('type'))
+        except ValueError:
+            return jsonify({'error': 'Invalid type filter'}), 400
+        if not q and not image_type:
+            return jsonify({'error': 'q or type required'}), 400
+        matches = manager_service.manager.search_additional_images(
+            query=q,
+            photo_type=image_type,
+        )
         return jsonify({'matches': matches})
 
     @app.route('/api/turtles/images/additional-labels', methods=['PATCH'])
@@ -240,8 +249,8 @@ def register_turtle_routes(app):
     @require_admin
     def add_turtle_additional_images():
         """
-        Add microhabitat/condition images to an existing turtle folder (Admin only).
-        Form: file_0, type_0, labels_0, ... (type: microhabitat | condition | carapace | plastron | other),
+        Add additional images to an existing turtle folder (Admin only).
+        Form: file_0, type_0, labels_0, ... (type normalized server-side),
         optional sheet_name. When the folder is missing, sheet_name creates data/<location>/<turtle_id>/ .
         """
         if not manager_service.manager_ready.wait(timeout=5):
@@ -261,9 +270,7 @@ def register_turtle_routes(app):
                 if not f or not f.filename:
                     continue
                 idx = key.replace('file_', '')
-                typ = (request.form.get(f'type_{idx}') or 'other').strip().lower()
-                if typ not in ('microhabitat', 'condition', 'carapace', 'plastron', 'other'):
-                    typ = 'other'
+                typ = normalize_additional_type(request.form.get(f'type_{idx}'))
                 lbs = parse_labels_from_form(request.form, idx)
                 if not allowed_file(f.filename):
                     continue

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -20,7 +20,7 @@ from services import manager_service
 from additional_image_labels import normalize_additional_type, parse_labels_from_form
 
 _EXTRA_UPLOAD_KEY = re.compile(
-    r'^extra_(microhabitat|condition|carapace|other)_(\d+)$', re.IGNORECASE
+    r'^extra_([a-z0-9_-]+)_(\d+)$', re.IGNORECASE
 )
 
 

--- a/backend/tests/integration/test_review_additional_images.py
+++ b/backend/tests/integration/test_review_additional_images.py
@@ -152,6 +152,33 @@ def test_add_additional_images_carapace_with_labels(client, review_packet_dir, t
     assert any("e2e_review_label" in str(x) for x in labels)
 
 
+def test_add_additional_images_right_side_type(client, review_packet_dir, tmp_path):
+    """POST with new category (right-side) is accepted and persisted in packet manifest output."""
+    request_id, _ = review_packet_dir
+    img_path = str(tmp_path / "right_side.jpg")
+    _make_dummy_image(img_path)
+    with open(img_path, "rb") as f:
+        file_data = f.read()
+    r = client.post(
+        f"/api/review-queue/{request_id}/additional-images",
+        data={
+            "file_0": ("right_side.jpg", BytesIO(file_data)),
+            "type_0": "right-side",
+            "labels_0": "burned, right_side_e2e",
+        },
+    )
+    assert r.status_code == 200
+    assert r.json().get("success") is True
+
+    r2 = client.get(f"/api/review-queue/{request_id}")
+    assert r2.status_code == 200
+    item = r2.json()["item"]
+    right_side = next((a for a in item["additional_images"] if a.get("type") == "right-side"), None)
+    assert right_side is not None
+    labels = right_side.get("labels") or []
+    assert any("right_side_e2e" in str(x) for x in labels)
+
+
 def test_remove_additional_image_no_filename(client, review_packet_dir):
     """DELETE additional-images with no filename in body returns 400."""
     request_id, _ = review_packet_dir

--- a/backend/tests/integration/test_turtles_routes.py
+++ b/backend/tests/integration/test_turtles_routes.py
@@ -316,3 +316,42 @@ def test_patch_additional_labels(client, turtle_with_images):
     row = next((a for a in rows if os.path.basename(a.get("path", "")) == fn), None)
     assert row is not None
     assert "patch_test_tag" in (row.get("labels") or [])
+
+
+def test_search_labels_with_type_filter_and_combo(client, turtle_with_images):
+    """Search endpoint supports category-only and combined category+label filtering."""
+    tid = turtle_with_images["turtle_id"]
+    loc = turtle_with_images["location"]
+    img_bytes = _dummy_image_bytes()
+
+    r_add = client.post(
+        "/api/turtles/images/additional",
+        data={
+            "turtle_id": tid,
+            "sheet_name": loc,
+            "file_0": ("combo_right.jpg", BytesIO(img_bytes)),
+            "type_0": "right-side",
+            "labels_0": "burned, combo_filter_smoke",
+            "file_1": ("combo_left.jpg", BytesIO(img_bytes)),
+            "type_1": "left-side",
+            "labels_1": "burned, combo_filter_smoke",
+        },
+    )
+    assert r_add.status_code == 200
+
+    r_type = client.get("/api/turtles/images/search-labels?type=right-side")
+    assert r_type.status_code == 200
+    type_matches = r_type.json().get("matches") or []
+    assert any(m.get("type") == "right-side" for m in type_matches)
+    assert not any(
+        m.get("filename", "").find("combo_left") >= 0 and m.get("type") == "left-side"
+        for m in type_matches
+    )
+
+    r_combo = client.get("/api/turtles/images/search-labels?q=burned&type=right-side")
+    assert r_combo.status_code == 200
+    combo_matches = r_combo.json().get("matches") or []
+    combo_hit = next((m for m in combo_matches if "combo_right" in (m.get("filename") or "")), None)
+    assert combo_hit is not None
+    assert combo_hit.get("type") == "right-side"
+    assert any("burn" in str(x).lower() for x in (combo_hit.get("labels") or []))

--- a/backend/turtle_manager.py
+++ b/backend/turtle_manager.py
@@ -1266,13 +1266,15 @@ class TurtleManager:
                 return True, None
         return False, "Image not found in manifest"
 
-    def search_additional_images_by_label(self, query):
+    def search_additional_images(self, query=None, photo_type=None):
         """
-        Scan all turtle additional_images manifests for entries whose labels match query (substring, case-insensitive).
-        Excludes Review_Queue. Returns list of dicts with turtle_id, sheet_name (folder path), path, filename, type, labels, timestamp.
+        Scan all turtle additional_images manifests for entries that match label query and/or image type.
+        Excludes Review_Queue. Returns list of dicts with turtle_id, sheet_name (folder path), path,
+        filename, type, labels, timestamp.
         """
         q = (query or '').strip()
-        if not q:
+        kind_filter = normalize_additional_type(photo_type) if photo_type else None
+        if not q and not kind_filter:
             return []
         matches = []
         skip_top = {'Review_Queue', 'benchmarks'}
@@ -1302,13 +1304,15 @@ class TurtleManager:
                     fn = entry.get('filename')
                     if not fn:
                         continue
+                    kind = normalize_additional_type(entry.get('type'))
+                    if kind_filter and kind != kind_filter:
+                        continue
                     labels = entry.get('labels')
-                    if not label_query_matches(labels, q):
+                    if q and not label_query_matches(labels, q):
                         continue
                     p = os.path.join(dir_path, fn)
                     if not os.path.isfile(p):
                         continue
-                    kind = normalize_additional_type(entry.get('type'))
                     matches.append({
                         'turtle_id': turtle_id,
                         'sheet_name': sheet_name.replace(os.sep, '/'),
@@ -1327,6 +1331,10 @@ class TurtleManager:
 
         matches.sort(key=lambda m: (m.get('sheet_name') or '', m.get('turtle_id') or '', m.get('filename') or ''))
         return matches
+
+    def search_additional_images_by_label(self, query):
+        """Backward-compatible wrapper for label-only search."""
+        return self.search_additional_images(query=query, photo_type=None)
 
     def remove_additional_image_from_turtle(self, turtle_id, filename, sheet_name=None):
         turtle_dir = self._get_turtle_folder(turtle_id, sheet_name)

--- a/frontend/src/components/AdditionalImagesSection.tsx
+++ b/frontend/src/components/AdditionalImagesSection.tsx
@@ -18,7 +18,7 @@ import {
   IconZoomIn,
   IconUpload,
 } from '@tabler/icons-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type DragEvent } from 'react';
 import { getImageUrl } from '../services/api';
 import { validateFile } from '../utils/fileValidation';
 import {
@@ -29,8 +29,12 @@ import {
   updateTurtleAdditionalImageLabels,
 } from '../services/api';
 import { notifications } from '@mantine/notifications';
-
-export type AdditionalPhotoKind = 'microhabitat' | 'condition' | 'carapace' | 'plastron' | 'other';
+import {
+  ADDITIONAL_PHOTO_KIND_OPTIONS,
+  additionalPhotoKindLabel,
+  normalizeAdditionalPhotoKind,
+  type AdditionalPhotoKind,
+} from '../constants/additionalPhotoKinds';
 
 /** Single additional image for display (packet or turtle). */
 export interface AdditionalImageDisplay {
@@ -52,45 +56,84 @@ interface AdditionalImagesSectionProps {
   hideAddButtons?: boolean;
 }
 
-const TYPE_ORDER: AdditionalPhotoKind[] = ['carapace', 'plastron', 'microhabitat', 'condition', 'other'];
-
-const KIND_OPTIONS = [
-  { value: 'carapace', label: 'Carapace' },
-  { value: 'plastron', label: 'Plastron (additional)' },
-  { value: 'microhabitat', label: 'Microhabitat' },
-  { value: 'condition', label: 'Condition' },
-  { value: 'other', label: 'Other' },
-] as const;
-
-/** Turtle-record additional photos support plastron-extra in manifest; review packets use a narrower type set. */
-const KIND_OPTIONS_REVIEW_PACKET = KIND_OPTIONS.filter((o) => o.value !== 'plastron');
-
-function normalizeKind(t: string): AdditionalPhotoKind {
-  const s = (t || 'other').toLowerCase();
-  if (
-    s === 'microhabitat' ||
-    s === 'condition' ||
-    s === 'carapace' ||
-    s === 'plastron' ||
-    s === 'other'
-  )
-    return s;
-  return 'other';
-}
-
-function kindSectionLabel(k: AdditionalPhotoKind): string {
-  if (k === 'other') return 'Other';
-  if (k === 'plastron') return 'Plastron (additional)';
-  return k;
-}
+const TYPE_ORDER: AdditionalPhotoKind[] = [
+  'carapace',
+  'plastron',
+  'anterior',
+  'posterior',
+  'left-side',
+  'right-side',
+  'people',
+  'microhabitat',
+  'condition',
+  'injury',
+  'other',
+];
 
 type StagedRow = {
   id: string;
   file: File;
   previewUrl: string;
-  type: 'carapace' | 'plastron' | 'microhabitat' | 'condition' | 'other';
+  type: AdditionalPhotoKind;
   labels: string[];
 };
+
+interface UploadTypeButtonProps {
+  kind: AdditionalPhotoKind;
+  disabled: boolean;
+  onFiles: (kind: AdditionalPhotoKind, files: FileList | null) => void;
+}
+
+function UploadTypeButton({ kind, disabled, onFiles }: UploadTypeButtonProps) {
+  const [dragOver, setDragOver] = useState(false);
+
+  const onDropFiles = (event: DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setDragOver(false);
+    if (disabled) return;
+    onFiles(kind, event.dataTransfer.files);
+  };
+
+  return (
+    <Button
+      size="sm"
+      variant={dragOver ? 'filled' : 'light'}
+      leftSection={<IconPhotoPlus size={14} />}
+      component="label"
+      disabled={disabled}
+      onDragOver={(event) => {
+        event.preventDefault();
+        if (!disabled) setDragOver(true);
+      }}
+      onDragEnter={(event) => {
+        event.preventDefault();
+        if (!disabled) setDragOver(true);
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={onDropFiles}
+      style={
+        dragOver
+          ? {
+              border: '1px dashed var(--mantine-color-blue-filled)',
+            }
+          : undefined
+      }
+    >
+      {additionalPhotoKindLabel(kind)}
+      <input
+        type="file"
+        accept="image/*"
+        multiple
+        hidden
+        onChange={(e) => {
+          onFiles(kind, e.target.files);
+          e.target.value = '';
+        }}
+      />
+    </Button>
+  );
+}
 
 export function AdditionalImagesSection({
   title = 'Additional photos',
@@ -112,10 +155,9 @@ export function AdditionalImagesSection({
 
   const isPacket = !!requestId;
   const isTurtle = !!turtleId;
-  const supportsPlastronExtra = !isPacket;
   const canEdit = (isPacket || isTurtle) && !disabled;
   const canEditLabels = isTurtle && !disabled;
-  const stagingKindOptions = supportsPlastronExtra ? KIND_OPTIONS : KIND_OPTIONS_REVIEW_PACKET;
+  const stagingKindOptions = ADDITIONAL_PHOTO_KIND_OPTIONS;
 
   useEffect(() => {
     return () => {
@@ -179,10 +221,7 @@ export function AdditionalImagesSection({
     }
   };
 
-  const addFilesToStaging = (
-    type: StagedRow['type'],
-    files: FileList | null,
-  ) => {
+  const addFilesToStaging = (type: AdditionalPhotoKind, files: FileList | null) => {
     if (!files?.length) return;
     const next: StagedRow[] = [];
     for (let i = 0; i < files.length; i++) {
@@ -272,7 +311,8 @@ export function AdditionalImagesSection({
     }
   };
 
-  const byKind = (k: AdditionalPhotoKind) => images.filter((img) => normalizeKind(img.type) === k);
+  const byKind = (k: AdditionalPhotoKind) =>
+    images.filter((img) => normalizeAdditionalPhotoKind(img.type) === k);
 
   const content = (
     <>
@@ -283,13 +323,9 @@ export function AdditionalImagesSection({
         {!embedded && (
           <Text size="xs" c="dimmed">
             Add photos first, set type and tags per image, then upload.
-            {supportsPlastronExtra ? (
-              <>
-                {' '}
-                Plastron (additional) keeps an extra underside shot in the manifest only (it does not replace
-                the SuperPoint .pt reference).
-              </>
-            ) : null}{' '}
+            {' '}
+            Plastron (additional) keeps an extra underside shot in the manifest only (it does not replace
+            the SuperPoint .pt reference).{' '}
             Tags are searchable under Admin → Turtle records → Sheets → Photo tags.
           </Text>
         )}
@@ -297,106 +333,17 @@ export function AdditionalImagesSection({
         {canEdit && !hideAddButtons && (
           <>
             <Text size="xs" fw={500}>
-              1. Choose photos (grouped by suggested type — you can change type per row below)
+              1. Choose or drag photos onto a category (you can change type per row below)
             </Text>
             <Group gap="xs">
-              <Button
-                size="sm"
-                variant="light"
-                leftSection={<IconPhotoPlus size={14} />}
-                component="label"
-                disabled={disabled || uploading}
-              >
-                Carapace
-                <input
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  hidden
-                  onChange={(e) => {
-                    addFilesToStaging('carapace', e.target.files);
-                    e.target.value = '';
-                  }}
-                />
-              </Button>
-              {supportsPlastronExtra && (
-                <Button
-                  size="sm"
-                  variant="light"
-                  leftSection={<IconPhotoPlus size={14} />}
-                  component="label"
+              {TYPE_ORDER.map((kind) => (
+                <UploadTypeButton
+                  key={kind}
+                  kind={kind}
                   disabled={disabled || uploading}
-                >
-                  Plastron (extra)
-                  <input
-                    type="file"
-                    accept="image/*"
-                    multiple
-                    hidden
-                    onChange={(e) => {
-                      addFilesToStaging('plastron', e.target.files);
-                      e.target.value = '';
-                    }}
-                  />
-                </Button>
-              )}
-              <Button
-                size="sm"
-                variant="light"
-                leftSection={<IconPhotoPlus size={14} />}
-                component="label"
-                disabled={disabled || uploading}
-              >
-                Microhabitat
-                <input
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  hidden
-                  onChange={(e) => {
-                    addFilesToStaging('microhabitat', e.target.files);
-                    e.target.value = '';
-                  }}
+                  onFiles={addFilesToStaging}
                 />
-              </Button>
-              <Button
-                size="sm"
-                variant="light"
-                leftSection={<IconPhotoPlus size={14} />}
-                component="label"
-                disabled={disabled || uploading}
-              >
-                Condition
-                <input
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  hidden
-                  onChange={(e) => {
-                    addFilesToStaging('condition', e.target.files);
-                    e.target.value = '';
-                  }}
-                />
-              </Button>
-              <Button
-                size="sm"
-                variant="light"
-                leftSection={<IconPhotoPlus size={14} />}
-                component="label"
-                disabled={disabled || uploading}
-              >
-                Other
-                <input
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  hidden
-                  onChange={(e) => {
-                    addFilesToStaging('other', e.target.files);
-                    e.target.value = '';
-                  }}
-                />
-              </Button>
+              ))}
             </Group>
 
             {staged.length > 0 && (
@@ -499,9 +446,8 @@ export function AdditionalImagesSection({
                         size="xs"
                         fw={500}
                         c="dimmed"
-                        tt={k === 'other' ? undefined : 'capitalize'}
                       >
-                        {kindSectionLabel(k)}
+                        {additionalPhotoKindLabel(k)}
                       </Text>
                       <Group gap="md" wrap="wrap" align="flex-start">
                         {list.map((img) => (

--- a/frontend/src/components/PreviewCard.tsx
+++ b/frontend/src/components/PreviewCard.tsx
@@ -34,12 +34,17 @@ import {
   IconPhotoPlus,
   IconZoomIn,
 } from '@tabler/icons-react';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, type DragEvent } from 'react';
 import type { FileWithPath } from '@mantine/dropzone';
 import type { LocationHint, UploadExtraFile } from '../services/api';
 import { MapPicker } from './MapPicker';
 import { validateFile } from '../utils/fileValidation';
 import { notifications } from '@mantine/notifications';
+import {
+  ADDITIONAL_PHOTO_KIND_OPTIONS,
+  additionalPhotoKindLabel,
+  type AdditionalPhotoKind,
+} from '../constants/additionalPhotoKinds';
 
 interface PreviewCardProps {
   preview: string | null;
@@ -64,7 +69,7 @@ interface PreviewCardProps {
   /** Admin: physical flag at position (when taken to lab) */
   physicalFlag?: 'yes' | 'no' | 'no_flag' | null;
   setPhysicalFlag?: (v: 'yes' | 'no' | 'no_flag' | null) => void;
-  /** Optional extra images (microhabitat, condition) */
+  /** Optional extra images (all additional-photo categories) */
   extraFiles?: UploadExtraFile[];
   setExtraFiles?: (files: UploadExtraFile[] | ((prev: UploadExtraFile[]) => UploadExtraFile[])) => void;
   onUpload: () => void;
@@ -100,7 +105,39 @@ export function PreviewCard({
   const [manualLon, setManualLon] = useState('');
   const [extraPreviewUrls, setExtraPreviewUrls] = useState<string[]>([]);
   const [lightboxObjectUrl, setLightboxObjectUrl] = useState<string | null>(null);
+  const [activeDropKind, setActiveDropKind] = useState<AdditionalPhotoKind | null>(null);
   const isMobile = useMediaQuery('(max-width: 576px)');
+
+  const addExtraFilesByType = (type: AdditionalPhotoKind, list: FileList | null) => {
+    if (!setExtraFiles || !list?.length) return;
+    const valid: UploadExtraFile[] = [];
+    for (let i = 0; i < list.length; i++) {
+      const file = list[i];
+      const validation = validateFile(file);
+      if (validation.isValid) {
+        valid.push({
+          type,
+          file,
+          labels: [],
+          localId: crypto.randomUUID(),
+        });
+      } else if (validation.error) {
+        notifications.show({
+          title: 'Invalid file',
+          message: validation.error,
+          color: 'red',
+        });
+      }
+    }
+    if (valid.length) setExtraFiles((prev) => [...prev, ...valid]);
+  };
+
+  const handleDropOnKind = (event: DragEvent<HTMLLabelElement>, type: AdditionalPhotoKind) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setActiveDropKind(null);
+    addExtraFilesByType(type, event.dataTransfer.files);
+  };
 
   const prevStillAtLocation = useRef<'yes' | 'no' | null>(null);
   // When user selects "I'm still at the turtle's location", request GPS immediately (once per switch to 'yes')
@@ -182,142 +219,48 @@ export function PreviewCard({
                   upload with your main photo.
                 </Text>
                 <Group gap='xs' mb='sm'>
-                  <Button size='sm' variant='light' leftSection={<IconPhotoPlus size={14} />} component='label'>
-                    Carapace
-                    <input
-                      type='file'
-                      accept='image/*'
-                      multiple
-                      hidden
-                      onChange={(e) => {
-                        const list = e.target.files;
-                        if (!list?.length) return;
-                        const valid: UploadExtraFile[] = [];
-                        for (let i = 0; i < list.length; i++) {
-                          const file = list[i];
-                          const validation = validateFile(file);
-                          if (validation.isValid) {
-                            valid.push({
-                              type: 'carapace',
-                              file,
-                              labels: [],
-                              localId: crypto.randomUUID(),
-                            });
-                          } else if (validation.error) {
-                            notifications.show({
-                              title: 'Invalid file',
-                              message: validation.error,
-                              color: 'red',
-                            });
-                          }
-                        }
-                        if (valid.length) setExtraFiles((prev) => [...prev, ...valid]);
-                        e.target.value = '';
+                  {ADDITIONAL_PHOTO_KIND_OPTIONS.map((kindOpt) => (
+                    <Button
+                      key={kindOpt.value}
+                      size='sm'
+                      variant={activeDropKind === kindOpt.value ? 'filled' : 'light'}
+                      leftSection={<IconPhotoPlus size={14} />}
+                      component='label'
+                      onDragOver={(event) => {
+                        event.preventDefault();
+                        setActiveDropKind(kindOpt.value as AdditionalPhotoKind);
                       }}
-                    />
-                  </Button>
-                  <Button size='sm' variant='light' leftSection={<IconPhotoPlus size={14} />} component='label'>
-                    Microhabitat
-                    <input
-                      type='file'
-                      accept='image/*'
-                      multiple
-                      hidden
-                      onChange={(e) => {
-                        const list = e.target.files;
-                        if (!list?.length) return;
-                        const valid: UploadExtraFile[] = [];
-                        for (let i = 0; i < list.length; i++) {
-                          const file = list[i];
-                          const validation = validateFile(file);
-                          if (validation.isValid) {
-                            valid.push({
-                              type: 'microhabitat',
-                              file,
-                              labels: [],
-                              localId: crypto.randomUUID(),
-                            });
-                          } else if (validation.error) {
-                            notifications.show({
-                              title: 'Invalid file',
-                              message: validation.error,
-                              color: 'red',
-                            });
-                          }
-                        }
-                        if (valid.length) setExtraFiles((prev) => [...prev, ...valid]);
-                        e.target.value = '';
+                      onDragEnter={(event) => {
+                        event.preventDefault();
+                        setActiveDropKind(kindOpt.value as AdditionalPhotoKind);
                       }}
-                    />
-                  </Button>
-                  <Button size='sm' variant='light' leftSection={<IconPhotoPlus size={14} />} component='label'>
-                    Condition
-                    <input
-                      type='file'
-                      accept='image/*'
-                      multiple
-                      hidden
-                      onChange={(e) => {
-                        const list = e.target.files;
-                        if (!list?.length) return;
-                        const valid: UploadExtraFile[] = [];
-                        for (let i = 0; i < list.length; i++) {
-                          const file = list[i];
-                          const validation = validateFile(file);
-                          if (validation.isValid) {
-                            valid.push({
-                              type: 'condition',
-                              file,
-                              labels: [],
-                              localId: crypto.randomUUID(),
-                            });
-                          } else if (validation.error) {
-                            notifications.show({
-                              title: 'Invalid file',
-                              message: validation.error,
-                              color: 'red',
-                            });
-                          }
-                        }
-                        if (valid.length) setExtraFiles((prev) => [...prev, ...valid]);
-                        e.target.value = '';
+                      onDragLeave={() => {
+                        setActiveDropKind((prev) =>
+                          prev === kindOpt.value ? null : prev,
+                        );
                       }}
-                    />
-                  </Button>
-                  <Button size='sm' variant='light' leftSection={<IconPhotoPlus size={14} />} component='label'>
-                    Other
-                    <input
-                      type='file'
-                      accept='image/*'
-                      multiple
-                      hidden
-                      onChange={(e) => {
-                        const list = e.target.files;
-                        if (!list?.length) return;
-                        const valid: UploadExtraFile[] = [];
-                        for (let i = 0; i < list.length; i++) {
-                          const file = list[i];
-                          const validation = validateFile(file);
-                          if (validation.isValid) {
-                            valid.push({
-                              type: 'other',
-                              file,
-                              labels: [],
-                              localId: crypto.randomUUID(),
-                            });
-                          } else if (validation.error) {
-                            notifications.show({
-                              title: 'Invalid file',
-                              message: validation.error,
-                              color: 'red',
-                            });
-                          }
-                        }
-                        if (valid.length) setExtraFiles((prev) => [...prev, ...valid]);
-                        e.target.value = '';
-                      }}
-                    />
-                  </Button>
+                      onDrop={(event) =>
+                        handleDropOnKind(event, kindOpt.value as AdditionalPhotoKind)
+                      }
+                      style={
+                        activeDropKind === kindOpt.value
+                          ? { border: '1px dashed var(--mantine-color-blue-filled)' }
+                          : undefined
+                      }
+                    >
+                      {kindOpt.label}
+                      <input
+                        type='file'
+                        accept='image/*'
+                        multiple
+                        hidden
+                        onChange={(e) => {
+                          addExtraFilesByType(kindOpt.value as AdditionalPhotoKind, e.target.files);
+                          e.target.value = '';
+                        }}
+                      />
+                    </Button>
+                  ))}
                 </Group>
                 {extraFiles.length > 0 && (
                   <Stack gap='md'>
@@ -348,12 +291,7 @@ export function PreviewCard({
                               <Select
                                 size='xs'
                                 label='Type'
-                                data={[
-                                  { value: 'carapace', label: 'Carapace' },
-                                  { value: 'microhabitat', label: 'Microhabitat' },
-                                  { value: 'condition', label: 'Condition' },
-                                  { value: 'other', label: 'Other' },
-                                ]}
+                                data={ADDITIONAL_PHOTO_KIND_OPTIONS}
                                 value={ef.type}
                                 onChange={(v) => {
                                   if (!v) return;
@@ -378,6 +316,9 @@ export function PreviewCard({
                               <Text size='xs' c='dimmed' lineClamp={1}>
                                 {ef.file.name}
                               </Text>
+                              <Badge size='xs' variant='light' color='gray' style={{ width: 'fit-content' }}>
+                                {additionalPhotoKindLabel(ef.type)}
+                              </Badge>
                             </Stack>
                             <Stack gap={4}>
                               <Button

--- a/frontend/src/constants/additionalPhotoKinds.ts
+++ b/frontend/src/constants/additionalPhotoKinds.ts
@@ -1,0 +1,62 @@
+export const ADDITIONAL_PHOTO_KINDS = [
+  'carapace',
+  'plastron',
+  'anterior',
+  'posterior',
+  'left-side',
+  'right-side',
+  'people',
+  'microhabitat',
+  'condition',
+  'injury',
+  'other',
+] as const;
+
+export type AdditionalPhotoKind = (typeof ADDITIONAL_PHOTO_KINDS)[number];
+
+export const ADDITIONAL_PHOTO_KIND_LABELS: Record<AdditionalPhotoKind, string> = {
+  carapace: 'Carapace',
+  plastron: 'Plastron (additional)',
+  anterior: 'Anterior',
+  posterior: 'Posterior',
+  'left-side': 'Left side',
+  'right-side': 'Right side',
+  people: 'People',
+  microhabitat: 'Microhabitat',
+  condition: 'Condition',
+  injury: 'Injury',
+  other: 'Other',
+};
+
+export const ADDITIONAL_PHOTO_KIND_OPTIONS = ADDITIONAL_PHOTO_KINDS.map((value) => ({
+  value,
+  label: ADDITIONAL_PHOTO_KIND_LABELS[value],
+}));
+
+export function normalizeAdditionalPhotoKind(raw: string): AdditionalPhotoKind {
+  const key = (raw || '').trim().toLowerCase().replace(/[_\s]+/g, '-');
+  // Legacy aliases: treat head/tail as anterior/posterior.
+  if (key === 'head') return 'anterior';
+  if (key === 'tail') return 'posterior';
+  if (
+    key === 'carapace' ||
+    key === 'plastron' ||
+    key === 'anterior' ||
+    key === 'posterior' ||
+    key === 'left-side' ||
+    key === 'right-side' ||
+    key === 'people' ||
+    key === 'microhabitat' ||
+    key === 'condition' ||
+    key === 'injury' ||
+    key === 'other'
+  ) {
+    return key;
+  }
+  return 'other';
+}
+
+export function additionalPhotoKindLabel(kind: string): string {
+  const normalized = normalizeAdditionalPhotoKind(kind);
+  return ADDITIONAL_PHOTO_KIND_LABELS[normalized];
+}

--- a/frontend/src/hooks/usePhotoUpload.tsx
+++ b/frontend/src/hooks/usePhotoUpload.tsx
@@ -54,7 +54,7 @@ interface UsePhotoUploadReturn {
   setCollectedToLab: (v: 'yes' | 'no' | null) => void;
   physicalFlag: 'yes' | 'no' | 'no_flag' | null;
   setPhysicalFlag: (v: 'yes' | 'no' | 'no_flag' | null) => void;
-  /** Optional extra images (microhabitat, condition) – community upload */
+  /** Optional extra images (all additional-photo categories) – upload with main photo */
   extraFiles: UploadExtraFile[];
   setExtraFiles: (files: UploadExtraFile[] | ((prev: UploadExtraFile[]) => UploadExtraFile[])) => void;
   handleDrop: (acceptedFiles: FileWithPath[]) => void;

--- a/frontend/src/pages/AdminTurtleMatchPage.tsx
+++ b/frontend/src/pages/AdminTurtleMatchPage.tsx
@@ -681,7 +681,7 @@ export default function AdminTurtleMatchPage() {
                 <Stack gap='md'>
                   <div>
                     <Text fw={600} size='sm' mb={4}>
-                      Microhabitat / Condition photos
+                      Additional photos
                     </Text>
                     <Text size='xs' c='dimmed' mb='sm'>
                       From this upload and already stored for this turtle.

--- a/frontend/src/pages/AdminTurtleRecords/ReviewQueueTab.tsx
+++ b/frontend/src/pages/AdminTurtleRecords/ReviewQueueTab.tsx
@@ -309,7 +309,7 @@ export function ReviewQueueTab() {
             <Stack gap='md'>
               <div>
                 <Text fw={600} size='sm' mb={4}>
-                  Microhabitat / Condition photos
+                  Additional photos
                 </Text>
                 <Text size='xs' c='dimmed' mb='sm'>
                   From this upload and, when a match is selected, already stored for that turtle.

--- a/frontend/src/pages/AdminTurtleRecords/SheetsBrowserTab.tsx
+++ b/frontend/src/pages/AdminTurtleRecords/SheetsBrowserTab.tsx
@@ -54,6 +54,10 @@ import { AdditionalImagesSection } from '../../components/AdditionalImagesSectio
 import { formatSingleDateTokenToUs } from '../../utils/usDateFormat';
 import { validateFile } from '../../utils/fileValidation';
 import { useAdminTurtleRecordsContext } from './AdminTurtleRecordsContext';
+import {
+  ADDITIONAL_PHOTO_KIND_OPTIONS,
+  additionalPhotoKindLabel,
+} from '../../constants/additionalPhotoKinds';
 
 function turtleKey(turtle: TurtleSheetsData) {
   const id = turtleDiskFolderId(turtle);
@@ -125,6 +129,7 @@ export function SheetsBrowserTab() {
   const [primaryImages, setPrimaryImages] = useState<Record<string, string | null>>({});
   const [listMode, setListMode] = useState<'records' | 'tags'>('records');
   const [tagQuery, setTagQuery] = useState('');
+  const [photoTypeFilter, setPhotoTypeFilter] = useState<string | null>('');
   const [photoMatches, setPhotoMatches] = useState<TurtleAdditionalLabelSearchMatch[]>([]);
   const [photoSearchLoading, setPhotoSearchLoading] = useState(false);
   const [selectedMatchPath, setSelectedMatchPath] = useState<string | null>(null);
@@ -234,11 +239,12 @@ export function SheetsBrowserTab() {
 
   const runPhotoSearch = async () => {
     const q = tagQuery.trim();
-    if (!q) return;
+    const typeFilter = (photoTypeFilter || '').trim();
+    if (!q && !typeFilter) return;
     setPhotoSearchLoading(true);
     setSelectedMatchPath(null);
     try {
-      const res = await searchTurtleImagesByLabel(q);
+      const res = await searchTurtleImagesByLabel(q, typeFilter || undefined);
       setPhotoMatches(res.matches ?? []);
     } catch {
       setPhotoMatches([]);
@@ -503,8 +509,8 @@ export function SheetsBrowserTab() {
             ) : (
               <>
                 <Text size='xs' c='dimmed'>
-                  Find additional photos by tag (substring match, case-insensitive). Results respect the
-                  location filter above.
+                  Find additional photos by tag, category, or both. Results respect the location
+                  filter above.
                 </Text>
                 <TextInput
                   placeholder='e.g. burned, shell crack'
@@ -514,6 +520,15 @@ export function SheetsBrowserTab() {
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') void runPhotoSearch();
                   }}
+                />
+                <Select
+                  label='Photo category'
+                  placeholder='Any category'
+                  value={photoTypeFilter}
+                  onChange={(value) => setPhotoTypeFilter(value ?? '')}
+                  data={[{ value: '', label: 'Any category' }, ...ADDITIONAL_PHOTO_KIND_OPTIONS]}
+                  searchable
+                  clearable={false}
                 />
                 <Button
                   onClick={() => void runPhotoSearch()}
@@ -660,7 +675,7 @@ export function SheetsBrowserTab() {
                                           tt={m.type === 'other' ? undefined : 'capitalize'}
                                           style={{ alignSelf: 'center' }}
                                         >
-                                          {m.type === 'other' ? 'Other' : m.type}
+                                          {additionalPhotoKindLabel(m.type)}
                                         </Badge>
                                       </Stack>
                                     </Box>

--- a/frontend/src/services/api/turtle.ts
+++ b/frontend/src/services/api/turtle.ts
@@ -28,6 +28,19 @@ export interface LocationHint {
   source: 'gps' | 'manual';
 }
 
+export type AdditionalImageType =
+  | 'microhabitat'
+  | 'condition'
+  | 'carapace'
+  | 'plastron'
+  | 'anterior'
+  | 'posterior'
+  | 'left-side'
+  | 'right-side'
+  | 'people'
+  | 'injury'
+  | 'other';
+
 /** Additional image (microhabitat, condition, carapace) in a review packet */
 export interface AdditionalImage {
   filename: string;
@@ -110,7 +123,7 @@ export interface UploadFlagOptions {
 }
 
 export interface UploadExtraFile {
-  type: 'microhabitat' | 'condition' | 'carapace' | 'other';
+  type: AdditionalImageType;
   file: File;
   /** Stored as searchable tags on the additional image (same request as upload). */
   labels?: string[];
@@ -227,7 +240,7 @@ export const getReviewQueue = async (): Promise<ReviewQueueResponse> => {
 export const uploadReviewPacketAdditionalImages = async (
   requestId: string,
   files: Array<{
-    type: 'microhabitat' | 'condition' | 'carapace' | 'plastron' | 'other';
+    type: AdditionalImageType;
     file: File;
     labels?: string[];
   }>,
@@ -441,14 +454,18 @@ export const getTurtleImages = async (
   return await response.json();
 };
 
-/** Find additional images whose labels match q (substring, case-insensitive). Admin only. */
+/** Find additional images by labels and/or image type (case-insensitive). Admin only. */
 export const searchTurtleImagesByLabel = async (
   q: string,
+  photoType?: string | null,
 ): Promise<{ matches: TurtleAdditionalLabelSearchMatch[] }> => {
   const token = getToken();
   const headers: Record<string, string> = {};
   if (token) headers['Authorization'] = `Bearer ${token}`;
-  const params = new URLSearchParams({ q: q.trim() });
+  const params = new URLSearchParams();
+  const trimmed = q.trim();
+  if (trimmed) params.set('q', trimmed);
+  if (photoType?.trim()) params.set('type', photoType.trim());
   const response = await fetch(
     `${TURTLE_API_BASE_URL}/turtles/images/search-labels?${params.toString()}`,
     { method: 'GET', headers },
@@ -537,7 +554,7 @@ export const uploadTurtleIdentifierPlastron = async (
 export const uploadTurtleAdditionalImages = async (
   turtleId: string,
   files: Array<{
-    type: 'microhabitat' | 'condition' | 'carapace' | 'plastron' | 'other';
+    type: AdditionalImageType;
     file: File;
     /** Applied to this file only (comma-separated sent as labels_i) */
     labels?: string[];

--- a/frontend/tests/e2e/admin-match.spec.ts
+++ b/frontend/tests/e2e/admin-match.spec.ts
@@ -540,7 +540,7 @@ test.describe('Admin Turtle Match', () => {
     await expect(page).toHaveURL('/');
   });
 
-  test('Match page shows Microhabitat / Condition photos section', async ({ page }) => {
+  test('Match page shows Additional photos section', async ({ page }) => {
     test.setTimeout(60_000);
     await loginAsAdmin(page);
 
@@ -559,10 +559,10 @@ test.describe('Admin Turtle Match', () => {
 
     // Wait for either outcome — avoids racing upload/match load on slow mobile WebKit.
     const noMatches = page.getByText('No matches found');
-    const microSection = page.getByText('Microhabitat / Condition photos');
-    await expect(noMatches.or(microSection)).toBeVisible({ timeout: 25_000 });
+    const additionalSection = page.getByText('Additional photos');
+    await expect(noMatches.or(additionalSection)).toBeVisible({ timeout: 25_000 });
     if (await noMatches.isVisible()) return;
-    await expect(microSection).toBeVisible({ timeout: 10_000 });
+    await expect(additionalSection).toBeVisible({ timeout: 10_000 });
   });
 
   test('Upload with extra microhabitat: image appears under From this upload, then can be removed', async ({

--- a/frontend/tests/e2e/admin-records.spec.ts
+++ b/frontend/tests/e2e/admin-records.spec.ts
@@ -69,7 +69,7 @@ test.describe('Admin Turtle Records (Review Queue)', () => {
     }
   });
 
-  test('When a queue item is selected, Microhabitat / Condition photos section is visible', async ({
+  test('When a queue item is selected, Additional photos section is visible', async ({
     page,
   }) => {
     await loginAsAdmin(page);
@@ -93,7 +93,7 @@ test.describe('Admin Turtle Records (Review Queue)', () => {
     const hasItems = (await matchLink.count()) > 0;
     if (hasItems) {
       await matchLink.click();
-      await expect(page.getByText('Microhabitat / Condition photos')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText('Additional photos')).toBeVisible({ timeout: 5000 });
     } else {
       await expect(page.getByText('No pending reviews')).toBeVisible({ timeout: 10_000 });
     }

--- a/frontend/tests/e2e/admin-records.spec.ts
+++ b/frontend/tests/e2e/admin-records.spec.ts
@@ -51,6 +51,14 @@ test.describe('Admin Turtle Records (Review Queue)', () => {
     await expect(page.getByRole('tab', { name: /Review Queue/ })).toBeVisible();
 
     const tabPanel = page.getByRole('tabpanel', { name: /Review Queue/ });
+    await expect(
+      tabPanel
+        .getByText('No pending reviews')
+        .or(tabPanel.getByText(/\d+ matches/).first())
+        .or(tabPanel.getByText(/Finding matches/i).first())
+        .or(tabPanel.getByText(/Match search failed/i).first()),
+    ).toBeVisible({ timeout: 15_000 });
+
     const hasItems =
       (await tabPanel.getByText(/\d+ matches/).count()) > 0 ||
       (await tabPanel.getByText(/Finding matches/i).count()) > 0 ||
@@ -65,7 +73,7 @@ test.describe('Admin Turtle Records (Review Queue)', () => {
       await expect(page.getByRole('button', { name: /Back to list/ })).toBeVisible();
       await expect(page.getByText('Uploaded Photo')).toBeVisible();
     } else {
-      await expect(page.getByText('No pending reviews')).toBeVisible();
+      await expect(page.getByText('No pending reviews')).toBeVisible({ timeout: 10_000 });
     }
   });
 
@@ -93,7 +101,9 @@ test.describe('Admin Turtle Records (Review Queue)', () => {
     const hasItems = (await matchLink.count()) > 0;
     if (hasItems) {
       await matchLink.click();
-      await expect(page.getByText('Additional photos')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText('Additional photos', { exact: true })).toBeVisible({
+        timeout: 5000,
+      });
     } else {
       await expect(page.getByText('No pending reviews')).toBeVisible({ timeout: 10_000 });
     }

--- a/frontend/tests/e2e/admin-sheets-browser-photo-tags.spec.ts
+++ b/frontend/tests/e2e/admin-sheets-browser-photo-tags.spec.ts
@@ -122,7 +122,10 @@ test.describe('Admin Turtle Records — Sheets browser photo tags', () => {
     await expect(page.getByText('Tag Search Turtle')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Open turtle' })).toBeVisible();
     await expect(page.getByText('burned', { exact: true })).toBeVisible();
-    await expect(page.getByText(/^right side$/i)).toBeVisible();
+    // Category Select also shows "Right side"; scope to the results ScrollArea below the summary line.
+    await expect(
+      page.getByText(/1 photo match · 1 turtle/i).locator('xpath=following-sibling::*[1]').getByText('Right side', { exact: true }),
+    ).toBeVisible();
   });
 
   test('Photo tags: type-only search works without text query', async ({ page }) => {

--- a/frontend/tests/e2e/admin-sheets-browser-photo-tags.spec.ts
+++ b/frontend/tests/e2e/admin-sheets-browser-photo-tags.spec.ts
@@ -73,7 +73,8 @@ test.describe('Admin Turtle Records — Sheets browser photo tags', () => {
     await page.route('**/api/turtles/images/search-labels**', async (route) => {
       const url = new URL(route.request().url());
       const q = (url.searchParams.get('q') || '').toLowerCase();
-      if (q.includes('burn')) {
+      const type = (url.searchParams.get('type') || '').toLowerCase();
+      if (q.includes('burn') && type === 'right-side') {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
@@ -84,7 +85,7 @@ test.describe('Admin Turtle Records — Sheets browser photo tags', () => {
                 sheet_name: 'Kansas',
                 path: 'Kansas/2024-06-01/e2e_tagged.jpg',
                 filename: 'e2e_tagged.jpg',
-                type: 'carapace',
+                type: 'right-side',
                 labels: ['burned', 'e2e-smoke'],
               },
             ],
@@ -113,13 +114,120 @@ test.describe('Admin Turtle Records — Sheets browser photo tags', () => {
     await page.getByText('Photo tags', { exact: true }).click();
 
     await page.getByPlaceholder('e.g. burned, shell crack').fill('burned');
+    await page.getByRole('textbox', { name: /Photo category/i }).click();
+    await page.getByRole('option', { name: 'Right side' }).click();
     await page.getByRole('button', { name: 'Search photos' }).click();
 
     await expect(page.getByText(/1 photo match · 1 turtle/i)).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText('Tag Search Turtle')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Open turtle' })).toBeVisible();
     await expect(page.getByText('burned', { exact: true })).toBeVisible();
-    // Type badge: capitalize transform may surface as "carapace" or "Carapace" in a11y tree.
-    await expect(page.getByText(/^carapace$/i)).toBeVisible();
+    await expect(page.getByText(/^right side$/i)).toBeVisible();
+  });
+
+  test('Photo tags: type-only search works without text query', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const mockTurtle = {
+      id: 'M2',
+      primary_id: 'M2',
+      sheet_name: 'Kansas',
+      name: 'Type Only Turtle',
+      species: 'Painted',
+      sex: 'M',
+    };
+
+    await page.route('**/api/review-queue', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, items: [] }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.route('**/api/sheets/sheets', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, sheets: ['Kansas'] }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.route('**/api/sheets/turtles**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, turtles: [mockTurtle] }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.route('**/api/turtles/images/primaries', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            images: [{ turtle_id: 'M2', sheet_name: 'Kansas', primary: null }],
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.route('**/api/turtles/images/search-labels**', async (route) => {
+      const url = new URL(route.request().url());
+      const q = (url.searchParams.get('q') || '').toLowerCase();
+      const type = (url.searchParams.get('type') || '').toLowerCase();
+      if (!q && type === 'left-side') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            matches: [
+              {
+                turtle_id: 'M2',
+                sheet_name: 'Kansas',
+                path: 'Kansas/2024-06-02/e2e_left_side.jpg',
+                filename: 'e2e_left_side.jpg',
+                type: 'left-side',
+                labels: ['type-only'],
+              },
+            ],
+          }),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ matches: [] }),
+        });
+      }
+    });
+
+    await loginAsAdmin(page);
+    await navClick(page, 'Turtle Records');
+    await page.getByRole('tab', { name: /Google Sheets Browser/ }).click();
+
+    await page.getByText('Photo tags', { exact: true }).click();
+    await page.getByRole('textbox', { name: /Photo category/i }).click();
+    await page.getByRole('option', { name: 'Left side' }).click();
+    await page.getByRole('button', { name: 'Search photos' }).click();
+
+    await expect(page.getByText(/1 photo match · 1 turtle/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Type Only Turtle')).toBeVisible();
+    await expect(page.getByText(/^left side$/i).first()).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/upload.spec.ts
+++ b/frontend/tests/e2e/upload.spec.ts
@@ -59,7 +59,7 @@ test.describe('Photo Upload', () => {
     await expect(page).toHaveURL(matchUrl, { timeout: 30_000 });
   });
 
-  test('Admin: Additional photos (optional) section with Microhabitat/Condition buttons is visible after selecting file', async ({
+  test('Admin: Additional photos (optional) section shows extended category buttons', async ({
     page,
   }) => {
     test.setTimeout(30_000);
@@ -74,8 +74,54 @@ test.describe('Photo Upload', () => {
 
     await page.waitForSelector('button:has-text("Upload Photo")', { timeout: 5000 });
     await expect(page.getByText('Additional photos (optional)')).toBeVisible();
-    // Microhabitat/Condition are <label> (Button component="label"), not role="button"
     await expect(page.getByText('Microhabitat', { exact: true }).first()).toBeVisible();
     await expect(page.getByText('Condition', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Right side', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Left side', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Anterior', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Posterior', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('People', { exact: true }).first()).toBeVisible();
+  });
+
+  test('Admin: drag-and-drop onto Additional photos category button stages file', async ({
+    page,
+    browserName,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/i.test(testInfo.project.name) || browserName === 'webkit',
+      'Drag-and-drop event simulation is unstable on mobile/WebKit projects.',
+    );
+    test.setTimeout(30_000);
+    await loginAsAdmin(page);
+
+    const fileInput = page.locator('input[type="file"]:not([capture]):not([multiple])').first();
+    await fileInput.setInputFiles({
+      name: 'e2e-dnd-main.png',
+      mimeType: 'image/png',
+      buffer: getTestImageBuffer(),
+    });
+
+    await expect(page.getByRole('button', { name: 'Upload Photo' }).first()).toBeVisible({
+      timeout: 5000,
+    });
+    const additionalSection = page.getByText('Additional photos (optional)').locator('..').locator('..');
+    await expect(additionalSection).toBeVisible({ timeout: 5000 });
+    const rightSideButton = additionalSection.locator('label:has-text("Right side")').first();
+    await expect(rightSideButton).toBeVisible({ timeout: 5000 });
+
+    const dataTransfer = await page.evaluateHandle(() => {
+      const dt = new DataTransfer();
+      const file = new File([new Uint8Array([255, 216, 255, 224, 0, 16])], 'dnd-right-side.jpg', {
+        type: 'image/jpeg',
+      });
+      dt.items.add(file);
+      return dt;
+    });
+
+    await rightSideButton.dispatchEvent('dragenter', { dataTransfer });
+    await rightSideButton.dispatchEvent('dragover', { dataTransfer });
+    await rightSideButton.dispatchEvent('drop', { dataTransfer });
+
+    await expect(additionalSection.getByText('dnd-right-side.jpg')).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
### Added

- **Additional turtle photo categories** shared across homepage upload (PreviewCard), Admin Sheets browser, Review Queue, and Admin Match: anterior, posterior, left/right side, people, injury, and existing types (carapace, plastron, microhabitat, condition, other). Filenames continue to encode the category (e.g. `right-side_…`).
- **Drag-and-drop** onto each category button to stage additional photos (same UX pattern on homepage and admin additional-photo sections).
- **Sheets browser — Photo tags**: optional **Photo category** filter; search supports **category only**, **tags only**, or **combined** tag + category. **`GET /api/turtles/images/search-labels`** accepts `q` and/or `type` (at least one required).

### Changed

- **Legacy labels**: `head` / `tail` are no longer offered as buttons; stored values still normalize to **anterior** / **posterior** for backward compatibility.
- **Review queue** additional-image uploads use the same normalized category set as turtle records.
- **Admin token validation** (`backend/auth.py`): if **`AUTH_URL`** uses `localhost` and validation fails, retry once against **`127.0.0.1`** to avoid Windows/dev hostname resolution mismatches.

### Testing

- Backend integration tests for **`search-labels`** type-only and combined filters and for **`right-side`** on review packet additional-images.
- Playwright: Sheets browser type-only search; homepage extended category buttons and drag-and-drop staging (mobile/WebKit skipped where event simulation is unreliable).