### PR TITLE
chore(chronodrop): quarantine backfill from daily wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Folder-name backfill quarantined from the daily chronodrop**: `scripts/daily-backup.sh` no longer invokes `backfill_folder_names.py --apply`. The backfill is now a manual operator command. Run it by hand with `docker compose exec backend python backfill_folder_names.py [--apply]`, followed by a manual `docker compose restart backend` if `--apply` reports changes. The wrapper's header documents the workflow; the backfill block is preserved in commented form for trivial revert.
+
 ## [2.0.0] - 2026-04-30 — SuperPoint + LightGlue matching, dual plastron/carapace references, per-turtle folder layout, admin photo workflow rewrite
 
 Major version bump. The Superpoint-Implementation branch reaches parity with

--- a/scripts/daily-backup.sh
+++ b/scripts/daily-backup.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
-# Run Google Sheets export (CSV/JSON), folder-name backfill, and backend data/
-# (images) backup in one shot.
+# Run Google Sheets export (CSV/JSON) and backend data/ (images) backup
+# in one shot.
 #
 # Intended for cron at 03:00 server time. Logs should be redirected by cron
 # (see docs/BACKUP.md).
 #
 # Sequence:
 #   1. Export sheets to CSV/JSON         — current Sheets state is authoritative.
-#   2. backfill_folder_names.py --apply  — rename / rehome on-disk turtle folders
-#      to match what the Sheets just exported (Sheets are read-only here; only
-#      disk gets touched). Picks up bio-ID changes (e.g. misgender corrections).
-#   3. Data backup                       — captures the post-backfill disk state
-#      so the snapshot is internally consistent with the Sheets snapshot.
-#   4. Restart backend ONLY if the backfill actually applied changes (exit 2).
-#      Necessary because the running VRAM cache holds .pt paths that just got
-#      renamed; restart triggers refresh_database_index.
+#   2. Data backup                       — captures the current disk state.
+#
+# QUARANTINED 2026-05-04: backfill_folder_names.py --apply is no longer
+# invoked by this wrapper. Run backfill manually instead:
+#   docker compose exec backend python backfill_folder_names.py             # dry run
+#   docker compose exec backend python backfill_folder_names.py --apply     # apply
+# After --apply, restart the backend manually so the VRAM cache reloads:
+#   docker compose restart backend
 #
 # Usage:
 #   COMPOSE_DIR=/absolute/path/to/TurtleTracker /path/to/scripts/daily-backup.sh
@@ -39,24 +39,27 @@ export BACKUP_DATE
 echo "=== $(date -Iseconds) daily-backup: Sheets (CSV/JSON) ==="
 $DOCKER compose exec -T -e "BACKUP_DATE=$BACKUP_DATE" backend python -m backup.run
 
-echo "=== $(date -Iseconds) daily-backup: folder-name backfill (gender/bio-id sync) ==="
-# Disable -e while we capture the exit code: 0 = no changes, 1 = errors, 2 = changes applied.
-set +e
-$DOCKER compose exec -T backend python backfill_folder_names.py --apply
-backfill_code=$?
-set -e
-if [ "$backfill_code" -eq 1 ]; then
-  echo "Backfill reported errors; continuing with data backup so the day is not lost." >&2
-fi
+# DISABLED 2026-05-04 — see header for full context. Run manually instead.
+# echo "=== $(date -Iseconds) daily-backup: folder-name backfill (gender/bio-id sync) ==="
+# # Disable -e while we capture the exit code: 0 = no changes, 1 = errors, 2 = changes applied.
+# set +e
+# $DOCKER compose exec -T backend python backfill_folder_names.py --apply
+# backfill_code=$?
+# set -e
+# if [ "$backfill_code" -eq 1 ]; then
+#   echo "Backfill reported errors; continuing with data backup so the day is not lost." >&2
+# fi
 
 echo "=== $(date -Iseconds) daily-backup: backend data/ (images) ==="
 BACKUP_OUTPUT_DIR="${BACKUP_OUTPUT_DIR:-$COMPOSE_DIR/backups}" \
   COMPOSE_DIR="$COMPOSE_DIR" \
   bash "$SCRIPT_DIR/backup-backend-data.sh"
 
-if [ "$backfill_code" -eq 2 ]; then
-  echo "=== $(date -Iseconds) daily-backup: backfill applied changes — restarting backend ==="
-  $DOCKER compose restart backend
-fi
+# DISABLED 2026-05-04 — restart-on-changes branch removed alongside backfill.
+# Restart backend manually after running backfill --apply by hand.
+# if [ "$backfill_code" -eq 2 ]; then
+#   echo "=== $(date -Iseconds) daily-backup: backfill applied changes — restarting backend ==="
+#   $DOCKER compose restart backend
+# fi
 
 echo "=== $(date -Iseconds) daily-backup: done ==="


### PR DESCRIPTION
## Summary
- Disable the `backfill_folder_names.py --apply` call in `scripts/daily-backup.sh`
- Disable the matching restart-on-exit-2 branch (no longer reachable)
- Update the wrapper header to document the manual command
- CHANGELOG entry under [Unreleased] / Changed

Backfill is now a manual operator command. The block is commented out, not deleted, so re-enabling is a one-line revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)