### PR TITLE
fix(turtles): fail-closed cross-sheet lookup + new-turtle naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5] - 2026-05-14 — Fail-closed cross-sheet folder lookup + canonical new-turtle names
+
+### Fixed
+
+- **Cross-sheet biology-ID photo contamination**: turtles sharing a biology id across two sheets (e.g. `Kansas/North Topeka` and `NebraskaCPBS/CPBS`) could display the same plastron photos. The v2.0.4 scoped walk still fell back to walking the whole `data/` tree (`return [self.base_dir]`) whenever a hint could not be resolved -- and the Sheets Browser sends a hint without the top-level folder, so that fallback fired routinely. `_data_walk_roots_for_hint` now expands a leading flash-drive location key (`CPBS` -> `NebraskaCPBS/CPBS`) via `DRIVE_LOCATION_TO_BACKEND_PATH` and **fails closed** (`[]`, "not found") instead of broadening when a hint resolves to no existing directory. `_get_turtle_folder` additionally refuses to guess when there is no usable hint and a bare biology id matches more than one folder. `resolve_turtle_dir_for_sheet_upload` applies the same drive-key expansion so admin uploads cannot broaden or create a misplaced top-level folder. Regression tests in `backend/tests/test_turtle_plastron_upload.py`.
+- **Frontend image hint omitted the sheet**: `turtleDataFolderHint` (`frontend/src/services/api/sheets.ts`) returned only `general_location[/location]`, dropping the spreadsheet tab -- which IS the on-disk top-level folder. It now leads with `sheet_name`, so the backend reliably scopes the lookup to the correct sheet.
+- **New turtles were named bare `<bio_id>`**: the review-approve handler built the combined `<bio_id>_<primary_id>` folder name *before* the Sheets sync finalized `primary_id`, so backend-generated primary ids never reached the folder name. Both ids are now resolved up front (read-only next-id lookups) so the folder is born canonical; the same `primary_id` is reused by the Sheets sync. New helper `canonical_new_turtle_folder_id` with tests in `backend/tests/test_review_new_location_paths.py`.
+
 ## [2.0.4] - 2026-05-14 — Turtle folder lookup scoped by sheet path (duplicate biology IDs)
 
 ### Fixed
@@ -435,7 +443,8 @@ Major bump merging the SuperPoint implementation: **VLAD/FAISS → SuperPoint + 
 - **Documentation**: README with quick start (Docker and local), functionality overview, and versioning guide in `docs/VERSION_AND_RELEASES.md`.
 - Version control and release process: `CHANGELOG.md`, version in `frontend/package.json`, and guide in `docs/VERSION_AND_RELEASES.md`.
 
-[Unreleased]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.4...HEAD
+[Unreleased]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.5...HEAD
+[2.0.5]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.1...v2.0.2

--- a/backend/routes/review.py
+++ b/backend/routes/review.py
@@ -89,6 +89,25 @@ def normalize_new_turtle_location_for_disk(
     return (out, resolved_general_loc)
 
 
+def canonical_new_turtle_folder_id(bio_id, primary_id, fallback_id):
+    """On-disk folder name for a NEW turtle: ``<bio_id>_<primary_id>``.
+
+    Biology id alone collides across sheets and primary id alone is opaque, so
+    the canonical folder name carries both. Falls back to the legacy partial
+    combine (``<bio_id>_<fallback_id>``) or the bare id when an id could not be
+    resolved (e.g. Sheets unavailable) -- never raises, so a missing id degrades
+    the name instead of failing the whole approve.
+    """
+    bio_id = (bio_id or '').strip()
+    primary_id = (primary_id or '').strip()
+    fallback_id = (fallback_id or '').strip()
+    if bio_id and primary_id:
+        return f"{bio_id}_{primary_id}"
+    if bio_id and fallback_id and not fallback_id.startswith(f"{bio_id}_"):
+        return f"{bio_id}_{fallback_id}"
+    return fallback_id or primary_id or bio_id
+
+
 def format_review_packet_item(packet_dir, request_id):
     """Build one queue item dict from packet_dir (used by get_review_queue and get_review_packet)."""
     metadata_path = os.path.join(packet_dir, 'metadata.json')
@@ -626,11 +645,45 @@ def register_review_routes(app):
         # This ensures the packet survives as a retry point if Sheets fails.
         is_new_turtle = bool(new_location and new_turtle_id and not match_turtle_id)
 
-        # Prepend biology ID to folder name: Biology_ID_PrimaryKey (e.g. F001_K14)
-        if is_new_turtle and isinstance(sheets_data, dict):
-            bio_id = (sheets_data.get('id') or '').strip()
-            if bio_id and new_turtle_id and not new_turtle_id.startswith(f"{bio_id}_"):
-                new_turtle_id = f"{bio_id}_{new_turtle_id}"
+        # Resolve BOTH the biology id and the primary id up front so the on-disk
+        # folder is born canonical (<bio_id>_<primary_id>). The Sheets sync below
+        # would otherwise finalize primary_id AFTER the folder is created, leaving
+        # it bare -- and bare <bio_id> folders collide across sheets. generate_*
+        # are read-only next-id lookups; the actual Sheets write still happens
+        # after disk success. canonical_primary_id is reused by the Sheets-sync
+        # block so the folder name and the sheet row carry the same primary id.
+        canonical_primary_id = None
+        if is_new_turtle:
+            sd = sheets_data if isinstance(sheets_data, dict) else {}
+            bio_id = (sd.get('id') or '').strip()
+            canonical_primary_id = (sd.get('primary_id') or '').strip() or None
+            id_sheet = (sd.get('sheet_name') or '').strip() or (new_location or '')
+            id_state = (sd.get('general_location') or '').strip()
+            id_location = (sd.get('location') or '').strip()
+            try:
+                id_service = (
+                    get_community_sheets_service() if is_community_upload
+                    else get_sheets_service()
+                )
+            except Exception as svc_err:
+                print(f"⚠️ Could not load Sheets service for id pre-resolution: {svc_err}")
+                id_service = None
+            if id_service:
+                if not canonical_primary_id:
+                    try:
+                        canonical_primary_id = id_service.generate_primary_id(id_state, id_location)
+                    except Exception as id_err:
+                        print(f"⚠️ Could not pre-generate primary_id for new turtle: {id_err}")
+                if not bio_id and id_sheet:
+                    try:
+                        sex = (sd.get('sex') or '').strip().upper()
+                        gender = sex if sex in ('M', 'F', 'J') else 'U'
+                        bio_id = id_service.generate_biology_id(gender, id_sheet)
+                        if isinstance(sheets_data, dict):
+                            sheets_data['id'] = bio_id
+                    except Exception as id_err:
+                        print(f"⚠️ Could not pre-generate biology id for new turtle: {id_err}")
+            new_turtle_id = canonical_new_turtle_folder_id(bio_id, canonical_primary_id, new_turtle_id)
 
         try:
             success, message = manager_service.manager.approve_review_packet(
@@ -672,7 +725,7 @@ def register_review_routes(app):
                                     if isinstance(sheets_data, dict) and sheets_data.get('primary_id'):
                                         primary_id = sheets_data.get('primary_id')
                                     else:
-                                        primary_id = comm.generate_primary_id(state, location)
+                                        primary_id = canonical_primary_id or comm.generate_primary_id(state, location)
                                     turtle_data = sheets_data.copy() if isinstance(sheets_data, dict) else {}
                                     turtle_data.pop('sheet_name', None)
                                     turtle_data['primary_id'] = primary_id
@@ -696,7 +749,7 @@ def register_review_routes(app):
                                     print(f"✅ Google Sheets entry already created by frontend for new turtle {new_turtle_id} with Primary ID {primary_id}")
                                 elif isinstance(sheets_data, dict) and sheets_data.get('sheet_name') and not sheets_data.get('primary_id'):
                                     print(f"⚠️ Frontend createTurtleSheetsData failed (no primary_id in sheets_data), creating in fallback mode")
-                                    primary_id = service.generate_primary_id(state, location)
+                                    primary_id = canonical_primary_id or service.generate_primary_id(state, location)
                                     turtle_data = sheets_data.copy()
                                     turtle_data.pop('sheet_name', None)
                                     turtle_data['primary_id'] = primary_id
@@ -708,7 +761,7 @@ def register_review_routes(app):
                                     service.create_turtle_data(turtle_data, sheet_name, state, location)
                                     print(f"✅ Created Google Sheets entry for new turtle {new_turtle_id} with Primary ID {primary_id} (fallback)")
                                 else:
-                                    primary_id = service.generate_primary_id(state, location) if not (isinstance(sheets_data, dict) and sheets_data.get('primary_id')) else sheets_data.get('primary_id')
+                                    primary_id = canonical_primary_id or service.generate_primary_id(state, location)
                                     turtle_data = sheets_data.copy() if isinstance(sheets_data, dict) else {}
                                     turtle_data.pop('sheet_name', None)
                                     turtle_data['primary_id'] = primary_id

--- a/backend/tests/test_review_new_location_paths.py
+++ b/backend/tests/test_review_new_location_paths.py
@@ -1,6 +1,9 @@
 """Regression: new-turtle disk paths must use sheet tab name, not General Location alone."""
 
-from routes.review import normalize_new_turtle_location_for_disk
+from routes.review import (
+    canonical_new_turtle_folder_id,
+    normalize_new_turtle_location_for_disk,
+)
 
 
 def test_nebraska_cpbs_wrong_cpbs_prefix_uses_sheet_tab():
@@ -41,3 +44,29 @@ def test_community_single_segment_returns_none_second():
     )
     assert loc == "Kansas"
     assert gl is None
+
+
+# --- Canonical <bio_id>_<primary_id> folder naming for new turtles ---
+
+
+def test_canonical_folder_id_combines_bio_and_primary():
+    assert canonical_new_turtle_folder_id("F298", "T1771234567", "T1771234567") == "F298_T1771234567"
+
+
+def test_canonical_folder_id_ignores_fallback_when_both_known():
+    # the frontend-sent id is discarded once both real ids are resolved
+    assert canonical_new_turtle_folder_id("F298", "T1771234567", "whatever") == "F298_T1771234567"
+
+
+def test_canonical_folder_id_partial_combine_when_primary_missing():
+    # primary couldn't be resolved (e.g. Sheets down) -> legacy partial combine
+    assert canonical_new_turtle_folder_id("F298", "", "T1771234567") == "F298_T1771234567"
+
+
+def test_canonical_folder_id_no_double_prefix():
+    # fallback already carries the bio_id prefix -> don't prepend it twice
+    assert canonical_new_turtle_folder_id("F298", "", "F298_T1771234567") == "F298_T1771234567"
+
+
+def test_canonical_folder_id_bare_fallback_when_no_bio_id():
+    assert canonical_new_turtle_folder_id("", "", "T1771234567") == "T1771234567"

--- a/backend/tests/test_turtle_plastron_upload.py
+++ b/backend/tests/test_turtle_plastron_upload.py
@@ -151,3 +151,77 @@ def test_resolve_no_shallow_folder_when_state_has_site_layout(mgr):
     d = mgr.resolve_turtle_dir_for_sheet_upload("BRANDNEW99", "Kansas")
     assert d is None
     assert not os.path.isdir(os.path.join(mgr.base_dir, "Kansas", "BRANDNEW99"))
+
+
+# --- Cross-sheet biology-ID scoping (incident: same bio_id served wrong photos) ---
+
+
+def _make_turtle(mgr, *parts):
+    """Create data/<parts...>/plastron/<id>.{jpg,pt}; return the turtle dir."""
+    tid = parts[-1]
+    turtle_dir = os.path.join(mgr.base_dir, *parts)
+    ref = os.path.join(turtle_dir, "plastron")
+    os.makedirs(ref, exist_ok=True)
+    with open(os.path.join(ref, f"{tid}.jpg"), "wb") as f:
+        f.write(b"\xff\xd8\xff x")
+    with open(os.path.join(ref, f"{tid}.pt"), "wb") as f:
+        f.write(b"pt")
+    return turtle_dir
+
+
+def test_get_turtle_folder_bare_general_location_hint_stays_in_sheet(mgr):
+    """Real Sheets-Browser hint shape: a bare general_location (no top-level
+    folder) still scopes to the correct sheet via drive-key expansion."""
+    ks = _make_turtle(mgr, "Kansas", "North Topeka", "F298")
+    ne = _make_turtle(mgr, "NebraskaCPBS", "CPBS", "F298")
+    assert os.path.normpath(mgr._get_turtle_folder("F298", "North Topeka")) == os.path.normpath(ks)
+    assert os.path.normpath(mgr._get_turtle_folder("F298", "CPBS")) == os.path.normpath(ne)
+    assert os.path.normpath(mgr._get_turtle_folder("F298", "Kansas/North Topeka")) == os.path.normpath(ks)
+    assert os.path.normpath(mgr._get_turtle_folder("F298", "Kansas")) == os.path.normpath(ks)
+
+
+def test_get_turtle_folder_missing_sheet_folder_returns_none_not_other_sheet(mgr):
+    """The reported incident: the requested sheet has no such turtle -> None,
+    never the same-bio_id turtle from a different sheet."""
+    _make_turtle(mgr, "NebraskaCPBS", "CPBS", "F298")  # only NebraskaCPBS has F298
+    assert mgr._get_turtle_folder("F298", "North Topeka") is None
+    assert mgr._get_turtle_folder("F298", "Kansas/North Topeka") is None
+    assert mgr._get_turtle_folder("F298", "Kansas") is None
+
+
+def test_get_turtle_folder_unresolvable_hint_returns_none(mgr):
+    """A hint that maps to no existing top-level folder fails closed."""
+    _make_turtle(mgr, "Kansas", "North Topeka", "F298")
+    assert mgr._get_turtle_folder("F298", "Nonexistent Place") is None
+
+
+def test_get_turtle_folder_no_hint_ambiguous_bio_id_returns_none(mgr):
+    """No hint + a bare bio_id matching two sheets is ambiguous -> refuse to guess."""
+    _make_turtle(mgr, "Kansas", "North Topeka", "F298")
+    _make_turtle(mgr, "NebraskaCPBS", "CPBS", "F298")
+    assert mgr._get_turtle_folder("F298", None) is None
+
+
+def test_get_turtle_folder_no_hint_single_match_still_resolves(mgr):
+    """No hint + a bio_id that exists in exactly one place still resolves
+    (preserves review-approval Scenario A)."""
+    only = _make_turtle(mgr, "Kansas", "North Topeka", "F777")
+    assert os.path.normpath(mgr._get_turtle_folder("F777", None)) == os.path.normpath(only)
+
+
+def test_get_turtle_folder_no_hint_primary_id_resolves_across_tree(mgr):
+    """primary_id is globally unique -> an unscoped walk is safe even with
+    other turtles present."""
+    _make_turtle(mgr, "Kansas", "North Topeka", "F298")
+    pj = _make_turtle(mgr, "NebraskaCPBS", "CPBS", "T1771234567")
+    assert os.path.normpath(mgr._get_turtle_folder("T1771234567", None)) == os.path.normpath(pj)
+
+
+def test_resolve_upload_bare_general_location_stays_in_sheet(mgr):
+    """resolve_turtle_dir_for_sheet_upload must not cross sheets when the hint
+    is a bare general_location and the same bio_id exists in another sheet."""
+    _make_turtle(mgr, "Kansas", "North Topeka", "F298")
+    ne = _make_turtle(mgr, "NebraskaCPBS", "CPBS", "F298")
+    got = mgr.resolve_turtle_dir_for_sheet_upload("F298", "CPBS")
+    assert os.path.normpath(got) == os.path.normpath(ne)
+    assert not os.path.isdir(os.path.join(mgr.base_dir, "CPBS"))

--- a/backend/turtle_manager.py
+++ b/backend/turtle_manager.py
@@ -225,6 +225,15 @@ def _safe_folder_name(sheet_name):
 # --- FILENAME PARSING ---
 _BIO_ID_RE = re.compile(r'^([FMJUfmju]\d+)')
 _CARAPACE_RE = re.compile(r'carapac|carapce|carapae', re.IGNORECASE)
+# A globally-unique primary key is "T" + a long digit run. Only this shape is
+# safe to resolve via an unscoped whole-tree walk; a bare biology id (F298,
+# J308, ...) repeats across sheets and must stay scoped to one top-level folder.
+_PRIMARY_ID_RE = re.compile(r'^T\d{10,}$')
+
+
+def _looks_like_primary_id(tid):
+    """True if ``tid`` is a globally-unique primary key (``T`` + 10+ digits)."""
+    return bool(tid) and bool(_PRIMARY_ID_RE.match(str(tid).strip()))
 
 
 def _parse_bio_id(filename):
@@ -2148,25 +2157,30 @@ class TurtleManager:
         wrong one after scoring. When a sheet path hint is present, restrict the
         walk to that subtree (e.g. ``data/Kansas`` or ``data/NebraskaCPBS/CPBS``).
 
-        Falls back to ``[base_dir]`` only when no usable scoped directory exists
-        (unknown layout / typo) so admin tooling without a hint still works.
+        A leading flash-drive location key (``CPBS``, ``North Topeka``, ...) is
+        expanded to its canonical ``State/Location`` so a hint that omits the
+        top-level folder still scopes correctly. When a hint IS given but cannot
+        be resolved to any existing directory, this returns ``[]`` (fail closed)
+        so the lookup reports "not found" rather than silently broadening to a
+        same-bio_id turtle in another sheet. ``[base_dir]`` is returned only for
+        the genuine no-hint case.
         """
         if not location_hint or not str(location_hint).strip() or location_hint == "Unknown":
             return [self.base_dir]
         rel = _location_dir_from_sheet_name(location_hint)
         if not rel:
-            return [self.base_dir]
+            return []
         rel_parts = [p for p in rel.replace("\\", "/").split("/") if str(p).strip()]
+        rel_parts = _expand_flat_drive_folder_prefix(rel_parts)
         if not rel_parts:
-            return [self.base_dir]
-        full = _resolved_path_under_base(self.base_dir, *rel_parts)
-        if full and os.path.isdir(full):
-            return [full]
-        if len(rel_parts) >= 2:
-            parent = _resolved_path_under_base(self.base_dir, *rel_parts[:-1])
-            if parent and os.path.isdir(parent):
-                return [parent]
-        return [self.base_dir]
+            return []
+        # Walk the deepest hinted prefix that exists; fall back to shorter
+        # prefixes but never below the top-level (sheet) folder.
+        for depth in range(len(rel_parts), 0, -1):
+            cand = _resolved_path_under_base(self.base_dir, *rel_parts[:depth])
+            if cand and os.path.isdir(cand):
+                return [cand]
+        return []
 
     def _get_turtle_folder(self, turtle_id, location_hint=None):
         """
@@ -2202,6 +2216,7 @@ class TurtleManager:
             rel = _location_dir_from_sheet_name(location_hint)
             if rel:
                 rel_parts = [p for p in rel.replace("\\", "/").split("/") if str(p).strip()]
+                rel_parts = _expand_flat_drive_folder_prefix(rel_parts)
                 if rel_parts:
                     hinted_path = _resolved_path_under_base(self.base_dir, *rel_parts, tid)
             if not hinted_path:
@@ -2218,6 +2233,16 @@ class TurtleManager:
             pass
 
         if not candidates:
+            return None
+        # No usable hint + a bare biology id matching more than one folder is
+        # ambiguous (bio_ids repeat across top-level sheet folders). Refuse to
+        # guess; only a globally-unique primary_id may resolve unscoped.
+        no_usable_hint = (
+            not location_hint
+            or not str(location_hint).strip()
+            or location_hint == "Unknown"
+        )
+        if no_usable_hint and len(candidates) > 1 and not _looks_like_primary_id(tid):
             return None
         if len(candidates) == 1:
             return candidates[0]
@@ -2331,12 +2356,19 @@ class TurtleManager:
             return None
         rel = _location_dir_from_sheet_name(sheet_name) if sheet_name else None
         if rel:
-            explicit = _resolved_path_under_base(self.base_dir, rel, tid)
+            rel_parts = [p for p in rel.replace("\\", "/").split("/") if str(p).strip()]
+            # Expand a leading flash-drive location key (e.g. "CPBS" ->
+            # "NebraskaCPBS/CPBS") so an upload hint that omits the top-level
+            # folder neither broadens across sheets nor creates a misplaced
+            # top-level folder.
+            rel_parts = _expand_flat_drive_folder_prefix(rel_parts)
+            if not rel_parts:
+                return None
+            explicit = _resolved_path_under_base(self.base_dir, *rel_parts, tid)
             if not explicit:
                 return None
             if os.path.isdir(explicit):
                 return explicit
-            rel_parts = [p for p in rel.replace("\\", "/").split("/") if str(p).strip()]
             if len(rel_parts) == 1:
                 nested = self._find_turtle_under_single_state_segment(rel_parts[0], tid)
                 if nested:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picturfrontend",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picturfrontend",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@mantine/code-highlight": "^8.3.5",
         "@mantine/core": "^8.3.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "picturfrontend",
   "private": true,
-  "version": "2.0.4",
+  "version": "2.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/services/api/sheets.ts
+++ b/frontend/src/services/api/sheets.ts
@@ -72,9 +72,12 @@ export function turtleDiskFolderId(
 }
 
 /**
- * Folder hint for turtle image APIs: matches `data/<…>/` on disk.
- * The spreadsheet tab (`sheet_name`) is often only the state (e.g. `Kansas`); real paths use
- * `general_location` + `location` (e.g. `Kansas/North Topeka`), same as review-queue `state/location`.
+ * Folder hint for turtle image APIs: matches `data/<...>/` on disk.
+ * The on-disk top-level folder IS the spreadsheet tab (`sheet_name`, e.g.
+ * `Kansas`, `NebraskaCPBS`); `general_location` / `location` are subpaths under
+ * it. Lead with the tab so the backend scopes the lookup to the correct sheet —
+ * biology IDs repeat across sheets, so a hint missing the tab can resolve to
+ * the wrong turtle's photos.
  */
 export function turtleDataFolderHint(
   t: Pick<TurtleSheetsData, 'sheet_name' | 'general_location' | 'location'>,
@@ -82,10 +85,11 @@ export function turtleDataFolderHint(
   const gl = (t.general_location || '').trim().replace(/\\/g, '/');
   const loc = (t.location || '').trim().replace(/\\/g, '/');
   const sheet = (t.sheet_name || '').trim();
-  if (gl && loc) return `${gl}/${loc}`;
-  if (gl && !loc) return gl;
-  if (!gl && loc) return loc;
-  return sheet || null;
+  const segs = [sheet, gl, loc].filter(Boolean);
+  // Drop consecutive duplicate segments (e.g. a sheet whose tab name equals its
+  // general_location) so the hint doesn't become `Kansas/Kansas/...`.
+  const deduped = segs.filter((s, i) => i === 0 || s !== segs[i - 1]);
+  return deduped.length ? deduped.join('/') : null;
 }
 
 export interface GetTurtleSheetsDataResponse {


### PR DESCRIPTION
## Summary

Production incident: turtles sharing a biology id across sheets (`Kansas/North Topeka` vs `NebraskaCPBS/CPBS`) served the **same plastron photos**. v2.0.4's scoped walk still fell back to walking all of `data/` whenever a hint couldn't be resolved — and the Sheets Browser sends a hint without the top-level folder, so that fallback fired routinely. Three compounding defects, all fixed here:

- **Backend lookup** (`turtle_manager.py`): `_data_walk_roots_for_hint` now expands flash-drive location keys (`CPBS` → `NebraskaCPBS/CPBS`) via `DRIVE_LOCATION_TO_BACKEND_PATH` and **fails closed** (`[]`, "not found") instead of `[self.base_dir]` when a hint resolves to no existing directory. `_get_turtle_folder` refuses to guess on an ambiguous bare bio_id when no hint is given. `resolve_turtle_dir_for_sheet_upload` gets the same expansion so admin uploads can't broaden or misplace.
- **Frontend hint** (`sheets.ts`): `turtleDataFolderHint` now leads with `sheet_name` (the on-disk top-level folder), which it previously dropped in favour of `general_location`.
- **New-turtle naming** (`routes/review.py`): the approve handler resolves `bio_id` + `primary_id` *before* folder creation so new turtles are born canonical `<bio_id>_<primary_id>` instead of bare `<bio_id>`; the same `primary_id` is reused by the Sheets sync. New pure helper `canonical_new_turtle_folder_id`.

Branched off `origin/main` (v2.0.4). Releases as **v2.0.5**.


