### PR TITLE
fix(sheets-browser): Null count + memoize filteredTurtles to stop list flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sheets Browser "Null" filter count**: the "X of Y turtles" line under the search panel was using the cheap eligibility pre-filter count, so toggling Null still showed `858 of 858 turtles`. It now reads from the actually-rendered list (`listForRecords`), so a Null search shows the real narrowed count (e.g. `15 of 858`).
+- **Sheets Browser turtle-card flash on selection**: clicking a turtle wiped every card's badge + thumbnail to a loading state for ~1s before populating the selected turtle's detail pane. Root cause: `filteredTurtles` in `useAdminTurtleRecords` was computed via plain `.filter()` (new array reference each render), so the primary-images batch effect in `SheetsBrowserTab` (deps `[filteredTurtles]`) re-fired on every parent re-render, calling `setPrimaryImages({})` + `setPrimaryImagesLoading(true)`. `filteredTurtles` is now memoized over `[allTurtles, searchQuery, nullFilterActive]` so the reference is stable when those don't change.
+
 ## [2.0.6] - 2026-05-15 — Sheets-Browser Null filter + canonical folder + General-Location relocate
 
 ### Added

--- a/frontend/src/hooks/useAdminTurtleRecords.tsx
+++ b/frontend/src/hooks/useAdminTurtleRecords.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   getReviewQueue,
@@ -611,26 +611,34 @@ export function useAdminTurtleRecords(role: string | undefined, authChecked: boo
     loadAllTurtles(value || undefined);
   };
 
-  const filteredTurtles = allTurtles.filter((turtle) => {
-    // "Null" filter eligibility — cheap, sheet-data only (no disk/batch lookup):
-    // a turtle can only be "Null" if it has both a Primary ID and a Bio ID. The
-    // SheetsBrowser narrows further by on-disk status once the batch resolves.
-    if (nullFilterActive) {
-      const hasPrimaryId = (turtle.primary_id || '').trim().length > 0;
-      const hasBioId = (turtle.id || '').trim().length > 0;
-      if (!hasPrimaryId || !hasBioId) return false;
-    }
-    if (!searchQuery) return true;
-    const query = searchQuery.toLowerCase();
-    return (
-      turtle.id?.toLowerCase().includes(query) ||
-      turtle.primary_id?.toLowerCase().includes(query) ||
-      turtle.name?.toLowerCase().includes(query) ||
-      turtle.species?.toLowerCase().includes(query) ||
-      turtle.location?.toLowerCase().includes(query) ||
-      turtle.general_location?.toLowerCase().includes(query)
-    );
-  });
+  // Memoized so the array identity is stable when none of the inputs change.
+  // SheetsBrowserTab's primary-images batch effect depends on this and would
+  // otherwise re-fire on every parent render (e.g. selecting a turtle), wiping
+  // the thumbnail/badge map and flashing the whole list back to a loading state.
+  const filteredTurtles = useMemo(
+    () =>
+      allTurtles.filter((turtle) => {
+        // "Null" filter eligibility — cheap, sheet-data only (no disk/batch lookup):
+        // a turtle can only be "Null" if it has both a Primary ID and a Bio ID. The
+        // SheetsBrowser narrows further by on-disk status once the batch resolves.
+        if (nullFilterActive) {
+          const hasPrimaryId = (turtle.primary_id || '').trim().length > 0;
+          const hasBioId = (turtle.id || '').trim().length > 0;
+          if (!hasPrimaryId || !hasBioId) return false;
+        }
+        if (!searchQuery) return true;
+        const query = searchQuery.toLowerCase();
+        return (
+          turtle.id?.toLowerCase().includes(query) ||
+          turtle.primary_id?.toLowerCase().includes(query) ||
+          turtle.name?.toLowerCase().includes(query) ||
+          turtle.species?.toLowerCase().includes(query) ||
+          turtle.location?.toLowerCase().includes(query) ||
+          turtle.general_location?.toLowerCase().includes(query)
+        );
+      }),
+    [allTurtles, searchQuery, nullFilterActive],
+  );
 
   return {
     activeTab,

--- a/frontend/src/pages/AdminTurtleRecords/SheetsBrowserTab.tsx
+++ b/frontend/src/pages/AdminTurtleRecords/SheetsBrowserTab.tsx
@@ -886,7 +886,7 @@ export function SheetsBrowserTab() {
                 )}
                 <Divider />
                 <Text size='sm' c='dimmed'>
-                  {filteredTurtles.length} of {allTurtles.length} turtles
+                  {listForRecords.length} of {allTurtles.length} turtles
                 </Text>
                 <ScrollArea h={560}>
                   <Stack gap='xs'>


### PR DESCRIPTION
## Summary

Two small Null-filter UX fixes reported during testing:

1. **Count mismatch.** The "X of Y turtles" line under the search panel was using `filteredTurtles.length` (the cheap eligibility pre-filter) instead of `listForRecords.length` (the actually-rendered list after the `computeNullSubState` narrowing). Toggling Null still showed e.g. `858 of 858 turtles` instead of the real narrowed count.

2. **List flash on selection.** Clicking a turtle wiped every card's badge + thumbnail to a loading state for ~1s before the detail pane populated. Root cause: `filteredTurtles` in `useAdminTurtleRecords` was computed via plain `.filter()` on every render, producing a new array reference each time. `SheetsBrowserTab`'s primary-images batch effect depends on `[filteredTurtles]` and starts with `setPrimaryImages({})` + `setPrimaryImagesLoading(true)` — so any parent re-render (selecting a turtle, etc.) triggered the wipe-and-refetch. Wrapped `filteredTurtles` in `useMemo` over `[allTurtles, searchQuery, nullFilterActive]`.