### PR TITLE
Default old-photos filters to newest upload and all categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **View Old Turtle Photos default filters**: the date/sort dropdown now opens on "All photos — newest upload first" instead of the first history date; the category dropdown continues to default to "All categories".
+
 ## [2.0.7] - 2026-05-16 — Sheets-Browser Null filter count + list-flash fix
 
 ### Fixed

--- a/frontend/src/components/OldTurtlePhotosSection.tsx
+++ b/frontend/src/components/OldTurtlePhotosSection.tsx
@@ -111,7 +111,7 @@ export function OldTurtlePhotosSection({
   onRestore,
   onLabelsChange,
 }: OldTurtlePhotosSectionProps) {
-  const [selectedDate, setSelectedDate] = useState<string | null>(historyDates[0] ?? null);
+  const [selectedDate, setSelectedDate] = useState<string | null>(DATE_ALL_UPLOAD_DESC);
   const [selectedCategory, setSelectedCategory] = useState<string>(CAT_ALL);
   const [lightboxPath, setLightboxPath] = useState<string | null>(null);
   const [editingTags, setEditingTags] = useState<string[]>([]);


### PR DESCRIPTION
### Changed

- **View Old Turtle Photos default filters**: the date/sort dropdown now opens on "All photos — newest upload first" instead of the first history date; the category dropdown continues to default to "All categories".