### PR TITLE
Optimize photos before upload and harden server ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Upload image optimization**: Photos are resized/compressed in the browser before upload (max 2048 px edge, JPEG ~82%) so smartphone originals and microhabitat shots no longer hit size limits. Server enforces an 8 MB per-file cap, 12 MB request body limit, ingest downscaling for bypassed clients, and per-IP rate limits (community vs admin) on all multipart image endpoints.
+
+### Changed
+
+- **Upload UX copy**: Homepage dropzone accepts up to 25 MB from the device and explains that photos are optimized automatically.
+
 ## [2.0.8] - 2026-05-20 — Admin side-by-side match compare + Turtle Match / Review Queue UX
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upload rate-limit client IP**: Per-IP throttles use `remote_addr` by default; with `TRUSTED_PROXY_COUNT` set, `ProxyFix` and the limiter take the proxy-appended `X-Forwarded-For` hop (not the spoofable leftmost value).
 - **Client upload EXIF dates**: Browser resize/compress re-encode now copies EXIF from the original JPEG (including `DateTimeOriginal`) into the optimized file so turtle history/timeline ordering no longer falls back to upload time for compressed photos.
 
 ## [2.0.8] - 2026-05-20 — Admin side-by-side match compare + Turtle Match / Review Queue UX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Double JPEG encode on upload**: API upload helpers no longer recompress files already optimized at selection time (`acceptUploadFile`), avoiding extra quality loss and duplicate client work on large turtle photos.
 - **Upload rate-limit client IP**: Per-IP throttles use `remote_addr` by default; with `TRUSTED_PROXY_COUNT` set, `ProxyFix` and the limiter take the proxy-appended `X-Forwarded-For` hop (not the spoofable leftmost value).
 - **Client upload EXIF dates**: Browser resize/compress re-encode now copies EXIF from the original JPEG (including `DateTimeOriginal`) into the optimized file so turtle history/timeline ordering no longer falls back to upload time for compressed photos.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Upload image optimization**: Photos are resized/compressed in the browser before upload (max 2048 px edge, JPEG ~82%) so smartphone originals and microhabitat shots no longer hit size limits. Server enforces an 8 MB per-file cap, 12 MB request body limit, ingest downscaling for bypassed clients, and per-IP rate limits (community vs admin) on all multipart image endpoints.
+- **Upload image optimization**: Photos are resized/compressed in the browser before upload (max 2048 px edge, JPEG ~82%) so smartphone originals and microhabitat shots no longer hit size limits. Server enforces an 8 MB per-file cap, ~96 MB multipart body cap (up to 12 optimized files plus form overhead), ingest downscaling for bypassed clients, and per-IP rate limits (community vs admin) on all multipart image endpoints.
 
 ### Changed
 
 - **Upload UX copy**: Homepage dropzone accepts up to 25 MB from the device and explains that photos are optimized automatically.
+
+### Fixed
+
+- **Client upload EXIF dates**: Browser resize/compress re-encode now copies EXIF from the original JPEG (including `DateTimeOriginal`) into the optimized file so turtle history/timeline ordering no longer falls back to upload time for compressed photos.
 
 ## [2.0.8] - 2026-05-20 — Admin side-by-side match compare + Turtle Match / Review Queue UX
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -39,10 +39,13 @@ from routes.general_locations import register_general_location_routes
 from routes.admin_backup import register_admin_backup_routes
 
 # Create Flask app
-from config import MAX_CONTENT_LENGTH
+from config import MAX_CONTENT_LENGTH, TRUSTED_PROXY_COUNT
 
 app = Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = MAX_CONTENT_LENGTH
+if TRUSTED_PROXY_COUNT > 0:
+    from werkzeug.middleware.proxy_fix import ProxyFix
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=TRUSTED_PROXY_COUNT)
 CORS(app, resources={r"/api/*": {"origins": "*", "methods": ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"], "allow_headers": ["Content-Type", "Authorization"]}})
 
 # Add after_request handler to ensure CORS headers are always set

--- a/backend/app.py
+++ b/backend/app.py
@@ -39,7 +39,10 @@ from routes.general_locations import register_general_location_routes
 from routes.admin_backup import register_admin_backup_routes
 
 # Create Flask app
+from config import MAX_CONTENT_LENGTH
+
 app = Flask(__name__)
+app.config['MAX_CONTENT_LENGTH'] = MAX_CONTENT_LENGTH
 CORS(app, resources={r"/api/*": {"origins": "*", "methods": ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"], "allow_headers": ["Content-Type", "Authorization"]}})
 
 # Add after_request handler to ensure CORS headers are always set

--- a/backend/config.py
+++ b/backend/config.py
@@ -60,7 +60,13 @@ if 'PORT' not in os.environ:
 # Configuration constants
 UPLOAD_FOLDER = tempfile.gettempdir()
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'webp', 'heic', 'heif'}
-MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
+# Hard cap per file after client optimization; blocks bypassed huge uploads.
+MAX_FILE_SIZE = 8 * 1024 * 1024  # 8MB
+# Reject entire HTTP body before buffering (DoS guard).
+MAX_CONTENT_LENGTH = 12 * 1024 * 1024  # 12MB
+# Server-side downscale if a client skips optimization.
+INGEST_MAX_DIMENSION = 2560
+INGEST_MAX_FILE_BYTES = 3 * 1024 * 1024
 
 # JWT Configuration - must match auth-backend JWT_SECRET
 JWT_SECRET = os.environ.get('JWT_SECRET', 'your-secret-key-change-in-production')

--- a/backend/config.py
+++ b/backend/config.py
@@ -80,6 +80,9 @@ JWT_SECRET = os.environ.get('JWT_SECRET', 'your-secret-key-change-in-production'
 # Auth service URL (required for staff/admin routes). E.g. http://localhost:3001/api
 AUTH_URL = os.environ.get('AUTH_URL', '').rstrip('/')
 
+# Reverse proxies in front of the API (each appends to X-Forwarded-For). 0 = trust none.
+TRUSTED_PROXY_COUNT = max(0, int(os.environ.get('TRUSTED_PROXY_COUNT', '0')))
+
 if JWT_SECRET == 'your-secret-key-change-in-production':
     try:
         print("⚠️  WARNING: Using default JWT_SECRET. This should match auth-backend JWT_SECRET!")

--- a/backend/config.py
+++ b/backend/config.py
@@ -62,8 +62,14 @@ UPLOAD_FOLDER = tempfile.gettempdir()
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'webp', 'heic', 'heif'}
 # Hard cap per file after client optimization; blocks bypassed huge uploads.
 MAX_FILE_SIZE = 8 * 1024 * 1024  # 8MB
+# Max image parts in one multipart request (main + extras, or batch additional upload).
+MAX_MULTIPART_IMAGE_PARTS = 12
+# Room for boundaries, field names, labels, GPS flags (not image bytes).
+_MULTIPART_FORM_OVERHEAD_BYTES = 512 * 1024
 # Reject entire HTTP body before buffering (DoS guard).
-MAX_CONTENT_LENGTH = 12 * 1024 * 1024  # 12MB
+MAX_CONTENT_LENGTH = (
+    MAX_FILE_SIZE * MAX_MULTIPART_IMAGE_PARTS + _MULTIPART_FORM_OVERHEAD_BYTES
+)
 # Server-side downscale if a client skips optimization.
 INGEST_MAX_DIMENSION = 2560
 INGEST_MAX_FILE_BYTES = 3 * 1024 * 1024

--- a/backend/image_utils.py
+++ b/backend/image_utils.py
@@ -1,15 +1,20 @@
-"""HEIC/HEIF → JPEG normalization for uploaded images.
+"""HEIC/HEIF → JPEG normalization and ingest resizing for uploaded images.
 
 iPhone photos arrive as HEIC by default. We normalize to JPEG at every
 upload boundary so downstream code (SuperPoint, frontend <img>) only sees
 formats it can handle. EXIF is preserved so the history-date aggregation
 keeps working on iPhone uploads.
+
+``process_uploaded_image`` also downscales oversized files server-side when
+clients bypass browser optimization (attack or old clients).
 """
 
 import os
 
 from PIL import Image, ImageOps
 from pillow_heif import register_heif_opener
+
+from config import INGEST_MAX_DIMENSION, INGEST_MAX_FILE_BYTES
 
 register_heif_opener()
 
@@ -35,3 +40,54 @@ def normalize_to_jpeg(src_path):
         img.convert('RGB').save(dest, 'JPEG', **save_kwargs)
     os.remove(src_path)
     return dest
+
+
+def _resize_ingest_if_needed(path):
+    """Downscale or recompress when dimensions or bytes exceed ingest budgets."""
+    if not path or not os.path.isfile(path):
+        return path
+
+    try:
+        size_bytes = os.path.getsize(path)
+    except OSError:
+        return path
+
+    with Image.open(path) as im:
+        im = ImageOps.exif_transpose(im)
+        w, h = im.size
+        needs_dim = max(w, h) > INGEST_MAX_DIMENSION
+        needs_bytes = size_bytes > INGEST_MAX_FILE_BYTES
+        if not needs_dim and not needs_bytes:
+            return path
+
+        if im.mode in ('RGBA', 'LA'):
+            background = Image.new('RGB', im.size, (255, 255, 255))
+            if im.mode == 'RGBA':
+                background.paste(im, mask=im.split()[3])
+            else:
+                background.paste(im, mask=im.split()[1])
+            im = background
+        elif im.mode != 'RGB':
+            im = im.convert('RGB')
+
+        if needs_dim:
+            im.thumbnail((INGEST_MAX_DIMENSION, INGEST_MAX_DIMENSION), Image.Resampling.LANCZOS)
+
+        dest = os.path.splitext(path)[0] + '.jpg'
+        save_kwargs = {'quality': 88, 'optimize': True}
+        exif_bytes = im.info.get('exif') or b''
+        if exif_bytes:
+            save_kwargs['exif'] = exif_bytes
+        im.save(dest, 'JPEG', **save_kwargs)
+
+    if dest != path and os.path.isfile(path):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+    return dest
+
+
+def process_uploaded_image(src_path):
+    """Normalize HEIC and enforce server-side size/dimension limits."""
+    return _resize_ingest_if_needed(normalize_to_jpeg(src_path))

--- a/backend/routes/review.py
+++ b/backend/routes/review.py
@@ -14,7 +14,8 @@ from auth import require_admin
 from services import manager_service
 from services.manager_service import get_sheets_service, get_community_sheets_service
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
-from image_utils import normalize_to_jpeg
+from image_utils import process_uploaded_image
+from upload_rate_limit import upload_rate_limit_ok, upload_rate_limit_response
 from turtle_manager import canonical_new_turtle_folder_id  # re-exported for callers/tests
 from general_locations_catalog import (
     get_sheet_default,
@@ -250,6 +251,8 @@ def register_review_routes(app):
     @require_admin
     def add_review_packet_additional_images(request_id):
         """Add additional images to an existing review packet (Admin only)."""
+        if not upload_rate_limit_ok(request, 'admin'):
+            return upload_rate_limit_response()
         if not manager_service.manager_ready.wait(timeout=30):
             return jsonify({'error': 'TurtleManager is still initializing.'}), 503
         if manager_service.manager is None:
@@ -277,7 +280,7 @@ def register_review_routes(app):
                 temp_path = os.path.join(UPLOAD_FOLDER, f"review_extra_{request_id}_{idx}_{int(time.time())}{ext}")
                 f.save(temp_path)
                 # HEIC/HEIF → JPEG (no-op for other formats)
-                temp_path = normalize_to_jpeg(temp_path)
+                temp_path = process_uploaded_image(temp_path)
                 item = {
                     'path': temp_path,
                     'type': typ,

--- a/backend/routes/turtles.py
+++ b/backend/routes/turtles.py
@@ -10,7 +10,8 @@ from flask import request, jsonify
 from werkzeug.utils import secure_filename
 from auth import require_admin
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
-from image_utils import normalize_to_jpeg
+from image_utils import process_uploaded_image
+from upload_rate_limit import upload_rate_limit_ok, upload_rate_limit_response
 from services import manager_service
 from turtle_manager import _extract_exif_date
 from additional_image_labels import (
@@ -635,6 +636,8 @@ def register_turtle_routes(app):
         Form: file_0, type_0, labels_0, ... (type normalized server-side),
         optional sheet_name. When the folder is missing, sheet_name creates data/<location>/<turtle_id>/ .
         """
+        if not upload_rate_limit_ok(request, 'admin'):
+            return upload_rate_limit_response()
         if not manager_service.manager_ready.wait(timeout=5):
             return jsonify({'error': 'TurtleManager is still initializing'}), 503
         if manager_service.manager is None:
@@ -676,7 +679,7 @@ def register_turtle_routes(app):
                 )
                 f.save(temp_path)
                 # HEIC/HEIF → JPEG (no-op for other formats)
-                temp_path = normalize_to_jpeg(temp_path)
+                temp_path = process_uploaded_image(temp_path)
                 orig_base = os.path.basename(orig_safe) if orig_safe else f'upload{ext}'
                 item = {
                     'path': temp_path,
@@ -720,6 +723,8 @@ def register_turtle_routes(app):
         Form: turtle_id (required), photo_type ('plastron'|'carapace'), file, sheet_name (optional).
         Archives the old reference to {photo_type}/Old References/ and updates VRAM cache.
         """
+        if not upload_rate_limit_ok(request, 'admin'):
+            return upload_rate_limit_response()
         if not manager_service.manager_ready.wait(timeout=5):
             return jsonify({'error': 'TurtleManager is still initializing'}), 503
         if manager_service.manager is None:
@@ -752,6 +757,7 @@ def register_turtle_routes(app):
             f"replace_{turtle_id}_{photo_type}_{int(time.time() * 1000)}{ext}".replace(os.sep, '_'),
         )
         f.save(temp_path)
+        temp_path = process_uploaded_image(temp_path)
         try:
             success, msg = manager_service.manager.replace_turtle_reference(
                 turtle_id, temp_path, photo_type=photo_type, sheet_name=sheet_name,
@@ -779,6 +785,8 @@ def register_turtle_routes(app):
         set_if_missing: fails if ref_data already has an identifier for this turtle_id.
         replace: archives the previous master image to loose_images when present, then sets the new one.
         """
+        if not upload_rate_limit_ok(request, 'admin'):
+            return upload_rate_limit_response()
         if not manager_service.manager_ready.wait(timeout=5):
             return jsonify({'error': 'TurtleManager is still initializing'}), 503
         if manager_service.manager is None:
@@ -815,7 +823,7 @@ def register_turtle_routes(app):
         )
         try:
             f.save(temp_path)
-            temp_path = normalize_to_jpeg(temp_path)
+            temp_path = process_uploaded_image(temp_path)
             ok, msg = manager_service.manager.set_identifier_plastron_from_path(
                 turtle_id, temp_path, sheet_name, mode, primary_id=primary_id,
             )

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -15,7 +15,8 @@ from flask import request, jsonify
 from werkzeug.utils import secure_filename
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
 from auth import optional_auth, check_auth_revocation
-from image_utils import normalize_to_jpeg
+from image_utils import process_uploaded_image
+from upload_rate_limit import upload_rate_limit_ok, upload_rate_limit_response
 from services import manager_service
 from additional_image_labels import normalize_additional_type, parse_labels_from_form
 
@@ -55,7 +56,7 @@ def _collect_extra_upload_files(request, request_id):
         ext = os.path.splitext(secure_filename(f.filename))[1] or '.jpg'
         extra_temp = os.path.join(UPLOAD_FOLDER, f"extra_{request_id}_{typ}_{int(time.time())}{ext}")
         f.save(extra_temp)
-        extra_temp = normalize_to_jpeg(extra_temp)
+        extra_temp = process_uploaded_image(extra_temp)
         item = {
             'path': extra_temp,
             'type': typ,
@@ -129,6 +130,9 @@ def register_upload_routes(app):
                 user_role = 'community'
                 user_email = 'anonymous'
 
+            if not upload_rate_limit_ok(request, user_role):
+                return upload_rate_limit_response()
+
             file = request.files['file']
             state = request.form.get('state', '')
             location = request.form.get('location', '')
@@ -154,13 +158,13 @@ def register_upload_routes(app):
             file.seek(0)
 
             if file_size > MAX_FILE_SIZE:
-                return jsonify({'error': 'File too large (max 5MB)'}), 400
+                return jsonify({'error': 'File too large (max 8MB)'}), 400
 
             filename = secure_filename(file.filename)
             temp_path = os.path.join(UPLOAD_FOLDER, filename)
             file.save(temp_path)
             # HEIC/HEIF → JPEG so SuperPoint + frontend can handle it
-            temp_path = normalize_to_jpeg(temp_path)
+            temp_path = process_uploaded_image(temp_path)
             filename = os.path.basename(temp_path)
 
             if not os.path.exists(temp_path):

--- a/backend/tests/image_fixtures.py
+++ b/backend/tests/image_fixtures.py
@@ -1,0 +1,24 @@
+"""Valid minimal image bytes for tests that hit server ingest (``process_uploaded_image``)."""
+
+import os
+from io import BytesIO
+
+from PIL import Image
+
+
+def valid_jpeg_bytes(width: int = 16, height: int = 16) -> bytes:
+    buf = BytesIO()
+    Image.new('RGB', (width, height), color=(128, 64, 32)).save(buf, format='JPEG')
+    return buf.getvalue()
+
+
+def valid_png_bytes(width: int = 16, height: int = 16) -> bytes:
+    buf = BytesIO()
+    Image.new('RGB', (width, height), color=(128, 64, 32)).save(buf, format='PNG')
+    return buf.getvalue()
+
+
+def write_valid_jpeg(path: str, width: int = 16, height: int = 16) -> str:
+    os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+    Image.new('RGB', (width, height), color=(128, 64, 32)).save(path, format='JPEG')
+    return path

--- a/backend/tests/integration/test_review_additional_images.py
+++ b/backend/tests/integration/test_review_additional_images.py
@@ -8,13 +8,7 @@ import os
 import pytest
 from io import BytesIO
 
-
-def _make_dummy_image(path, size=100):
-    """Write a minimal binary file that can be sent as image (e.g. JPEG)."""
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    with open(path, "wb") as f:
-        f.write(b"\xff\xd8\xff" + b"\x00" * (size - 3))
-    return path
+from tests.image_fixtures import write_valid_jpeg
 
 
 # Request ID from fixture data (backend/tests/fixture-data/Review_Queue/test_req_001)
@@ -99,7 +93,7 @@ def test_add_additional_images_success(client, review_packet_dir, tmp_path):
     """POST additional-images with file_0 and type_0 adds image to packet."""
     request_id, _ = review_packet_dir
     img_path = str(tmp_path / "micro.jpg")
-    _make_dummy_image(img_path)
+    write_valid_jpeg(img_path)
     with open(img_path, "rb") as f:
         file_data = f.read()
     r = client.post(
@@ -127,7 +121,7 @@ def test_add_additional_images_carapace_with_labels(client, review_packet_dir, t
     """POST with type carapace and labels_0; GET packet lists normalized labels."""
     request_id, _ = review_packet_dir
     img_path = str(tmp_path / "cap_labeled.jpg")
-    _make_dummy_image(img_path)
+    write_valid_jpeg(img_path)
     with open(img_path, "rb") as f:
         file_data = f.read()
     r = client.post(
@@ -156,7 +150,7 @@ def test_add_additional_images_right_side_type(client, review_packet_dir, tmp_pa
     """POST with new category (right-side) is accepted and persisted in packet manifest output."""
     request_id, _ = review_packet_dir
     img_path = str(tmp_path / "right_side.jpg")
-    _make_dummy_image(img_path)
+    write_valid_jpeg(img_path)
     with open(img_path, "rb") as f:
         file_data = f.read()
     r = client.post(
@@ -194,7 +188,7 @@ def test_remove_additional_image_success(client, review_packet_dir, tmp_path):
     """Add one image then DELETE by filename; packet then has no additional images."""
     request_id, _ = review_packet_dir
     img_path = str(tmp_path / "cond.jpg")
-    _make_dummy_image(img_path)
+    write_valid_jpeg(img_path)
     with open(img_path, "rb") as f:
         data = f.read()
     r = client.post(
@@ -226,8 +220,8 @@ def test_add_two_images_then_remove_both(client, review_packet_dir, tmp_path):
     request_id, _ = review_packet_dir
     micro_path = str(tmp_path / "micro.jpg")
     cond_path = str(tmp_path / "cond.jpg")
-    _make_dummy_image(micro_path)
-    _make_dummy_image(cond_path)
+    write_valid_jpeg(micro_path)
+    write_valid_jpeg(cond_path)
     with open(micro_path, "rb") as f:
         micro_data = f.read()
     with open(cond_path, "rb") as f:
@@ -288,7 +282,7 @@ def test_z_approve_merges_packet_additional_into_turtle(client, review_packet_di
     request_id, _ = review_packet_dir
     # Add one additional image to the packet
     img_path = str(tmp_path / "merge_test.jpg")
-    _make_dummy_image(img_path)
+    write_valid_jpeg(img_path)
     with open(img_path, "rb") as f:
         img_data = f.read()
     r = client.post(

--- a/backend/tests/integration/test_turtles_routes.py
+++ b/backend/tests/integration/test_turtles_routes.py
@@ -8,6 +8,8 @@ import os
 import pytest
 from io import BytesIO
 
+from tests.image_fixtures import valid_jpeg_bytes
+
 # From fixture data: backend/tests/fixture-data/Kansas/Topeka/T42
 TURTLE_WITH_IMAGES = {
     "turtle_id": "T42",
@@ -150,16 +152,11 @@ def test_post_primaries_batch_mixed(client, turtle_with_images):
 # --- POST /api/turtles/images/additional (add to turtle) ---
 
 
-def _dummy_image_bytes(size=100):
-    """Minimal bytes that can be sent as image (e.g. JPEG-like)."""
-    return b"\xff\xd8\xff" + b"\x00" * (size - 3)
-
-
 def test_post_turtle_additional_no_turtle_id(client):
     """POST /api/turtles/images/additional without turtle_id returns 400."""
     r = client.post(
         "/api/turtles/images/additional",
-        data={"file_0": ("x.jpg", BytesIO(_dummy_image_bytes())), "type_0": "microhabitat"},
+        data={"file_0": ("x.jpg", BytesIO(valid_jpeg_bytes())), "type_0": "microhabitat"},
     )
     assert r.status_code == 400
     data = r.json()
@@ -183,7 +180,7 @@ def test_post_turtle_additional_success(client, turtle_with_images):
     """POST /api/turtles/images/additional adds image to turtle folder; GET images shows it."""
     tid = turtle_with_images["turtle_id"]
     loc = turtle_with_images["location"]
-    img_bytes = _dummy_image_bytes()
+    img_bytes = valid_jpeg_bytes()
     r = client.post(
         "/api/turtles/images/additional",
         data={
@@ -214,7 +211,7 @@ def test_post_turtle_additional_then_delete_roundtrip(client, turtle_with_images
     assert r0.status_code == 200
     before_paths = {os.path.basename(a.get("path", "")) for a in r0.json()["additional"]}
 
-    img_bytes = _dummy_image_bytes()
+    img_bytes = valid_jpeg_bytes()
     r = client.post(
         "/api/turtles/images/additional",
         data={
@@ -257,7 +254,7 @@ def test_post_additional_with_labels_and_search(client, turtle_with_images):
     """POST with labels_0; GET search-labels finds the image by tag substring."""
     tid = turtle_with_images["turtle_id"]
     loc = turtle_with_images["location"]
-    img_bytes = _dummy_image_bytes()
+    img_bytes = valid_jpeg_bytes()
     # Note: type=carapace/plastron route to Other Carapaces / Other Plastrons (no manifest),
     # so labels on those types are not currently searchable. Architectural follow-up tracked
     # in benchmarks. Use 'condition' here so labels land in additional_images/manifest.json.
@@ -287,7 +284,7 @@ def test_patch_additional_labels(client, turtle_with_images):
     """PATCH additional-labels updates manifest; GET images reflects new labels."""
     tid = turtle_with_images["turtle_id"]
     loc = turtle_with_images["location"]
-    img_bytes = _dummy_image_bytes()
+    img_bytes = valid_jpeg_bytes()
     r_add = client.post(
         "/api/turtles/images/additional",
         data={
@@ -326,7 +323,7 @@ def test_search_labels_with_type_filter_and_combo(client, turtle_with_images):
     """Search endpoint supports category-only and combined category+label filtering."""
     tid = turtle_with_images["turtle_id"]
     loc = turtle_with_images["location"]
-    img_bytes = _dummy_image_bytes()
+    img_bytes = valid_jpeg_bytes()
 
     r_add = client.post(
         "/api/turtles/images/additional",

--- a/backend/tests/integration/test_upload_match_response.py
+++ b/backend/tests/integration/test_upload_match_response.py
@@ -6,17 +6,14 @@ Requires BACKEND_URL and AUTH_URL (see tests/conftest.py).
 
 from io import BytesIO
 
-
-def _dummy_png_bytes() -> bytes:
-    # Minimal PNG header + payload; sufficient for upload-path validation.
-    return b"\x89PNG\r\n\x1a\n" + b"\x00" * 512
+from tests.image_fixtures import valid_png_bytes
 
 
 def test_admin_upload_response_uses_score_confidence(client):
     response = client.post(
         "/api/upload",
         data={
-            "file": ("match-api-test.png", BytesIO(_dummy_png_bytes())),
+            "file": ("match-api-test.png", BytesIO(valid_png_bytes())),
         },
     )
 

--- a/backend/tests/test_image_utils.py
+++ b/backend/tests/test_image_utils.py
@@ -19,7 +19,7 @@ import os
 import pytest
 from PIL import Image
 
-from image_utils import HEIC_EXTENSIONS, normalize_to_jpeg
+from image_utils import HEIC_EXTENSIONS, normalize_to_jpeg, process_uploaded_image
 
 
 # ---------- Passthrough cases (no re-encoding) ----------
@@ -156,6 +156,14 @@ def test_multiple_exif_tags_preserved(tmp_path):
         assert out.get(36867) == '2024:07:12 14:30:00'
         assert out.get(272) == 'TestCamera'
         assert out.get(271) == 'TestMake'
+
+
+def test_process_uploaded_image_shrinks_oversized_jpeg(tmp_path):
+    path = tmp_path / 'big.jpg'
+    Image.new('RGB', (4000, 3000)).save(str(path), 'JPEG', quality=95)
+    result = process_uploaded_image(str(path))
+    with Image.open(result) as im:
+        assert max(im.size) <= 2560
 
 
 # ---------- Module exports ----------

--- a/backend/tests/test_upload_limits.py
+++ b/backend/tests/test_upload_limits.py
@@ -1,0 +1,9 @@
+"""Upload size limits: per-file cap vs multipart body cap."""
+
+from config import MAX_CONTENT_LENGTH, MAX_FILE_SIZE, MAX_MULTIPART_IMAGE_PARTS
+
+
+def test_multipart_body_cap_fits_main_plus_additional():
+    """Flask MAX_CONTENT_LENGTH must allow N max-sized files (e.g. main + extras)."""
+    assert MAX_CONTENT_LENGTH >= MAX_FILE_SIZE * MAX_MULTIPART_IMAGE_PARTS
+    assert MAX_CONTENT_LENGTH >= 2 * MAX_FILE_SIZE

--- a/backend/tests/test_upload_rate_limit.py
+++ b/backend/tests/test_upload_rate_limit.py
@@ -43,12 +43,32 @@ def test_admin_has_higher_cap(monkeypatch):
     assert upload_rate_limit_ok(req, 'admin') is False
 
 
+def test_community_exhaustion_does_not_block_privileged(monkeypatch):
+    monkeypatch.setattr('upload_rate_limit._MAX_COMMUNITY', 2)
+    monkeypatch.setattr('upload_rate_limit._MAX_PRIVILEGED', 5)
+    req = _mock_request()
+    assert upload_rate_limit_ok(req, 'community') is True
+    assert upload_rate_limit_ok(req, 'community') is True
+    assert upload_rate_limit_ok(req, 'community') is False
+    assert upload_rate_limit_ok(req, 'admin') is True
+
+
+def test_privileged_exhaustion_does_not_block_community(monkeypatch):
+    monkeypatch.setattr('upload_rate_limit._MAX_COMMUNITY', 3)
+    monkeypatch.setattr('upload_rate_limit._MAX_PRIVILEGED', 2)
+    req = _mock_request()
+    assert upload_rate_limit_ok(req, 'admin') is True
+    assert upload_rate_limit_ok(req, 'admin') is True
+    assert upload_rate_limit_ok(req, 'admin') is False
+    assert upload_rate_limit_ok(req, 'community') is True
+
+
 def test_ignores_forwarded_without_trusted_proxy(monkeypatch):
     monkeypatch.setattr('config.TRUSTED_PROXY_COUNT', 0)
     req = _mock_request(ip='203.0.113.1', forwarded='198.51.100.2, 10.0.0.1')
     assert upload_rate_limit_ok(req, 'community') is True
     with _lock:
-        assert '203.0.113.1' in _buckets
+        assert '203.0.113.1:community' in _buckets
         assert '198.51.100.2' not in _buckets
 
 
@@ -58,5 +78,5 @@ def test_uses_trusted_forwarded_hop(monkeypatch):
     req = _mock_request(ip='10.0.0.1', forwarded='198.51.100.99, 198.51.100.2')
     assert upload_rate_limit_ok(req, 'community') is True
     with _lock:
-        assert '198.51.100.2' in _buckets
+        assert '198.51.100.2:community' in _buckets
         assert '198.51.100.99' not in _buckets

--- a/backend/tests/test_upload_rate_limit.py
+++ b/backend/tests/test_upload_rate_limit.py
@@ -1,0 +1,50 @@
+"""Tests for per-IP upload rate limiting."""
+
+import time
+from unittest.mock import MagicMock
+
+from upload_rate_limit import upload_rate_limit_ok, _buckets, _lock
+
+
+def _mock_request(ip='203.0.113.1', forwarded=None):
+    req = MagicMock()
+    req.remote_addr = ip
+    req.headers = {'X-Forwarded-For': forwarded} if forwarded else {}
+    return req
+
+
+def setup_function():
+    with _lock:
+        _buckets.clear()
+
+
+def test_allows_under_limit():
+    req = _mock_request()
+    for _ in range(5):
+        assert upload_rate_limit_ok(req, 'community') is True
+
+
+def test_blocks_over_community_limit(monkeypatch):
+    monkeypatch.setattr('upload_rate_limit._MAX_COMMUNITY', 3)
+    req = _mock_request()
+    assert upload_rate_limit_ok(req, 'community') is True
+    assert upload_rate_limit_ok(req, 'community') is True
+    assert upload_rate_limit_ok(req, 'community') is True
+    assert upload_rate_limit_ok(req, 'community') is False
+
+
+def test_admin_has_higher_cap(monkeypatch):
+    monkeypatch.setattr('upload_rate_limit._MAX_COMMUNITY', 2)
+    monkeypatch.setattr('upload_rate_limit._MAX_PRIVILEGED', 5)
+    req = _mock_request()
+    for _ in range(4):
+        assert upload_rate_limit_ok(req, 'admin') is True
+    assert upload_rate_limit_ok(req, 'admin') is True
+    assert upload_rate_limit_ok(req, 'admin') is False
+
+
+def test_uses_forwarded_for_first_hop():
+    req = _mock_request(forwarded='198.51.100.2, 10.0.0.1')
+    assert upload_rate_limit_ok(req, 'community') is True
+    with _lock:
+        assert '198.51.100.2' in _buckets

--- a/backend/tests/test_upload_rate_limit.py
+++ b/backend/tests/test_upload_rate_limit.py
@@ -43,8 +43,20 @@ def test_admin_has_higher_cap(monkeypatch):
     assert upload_rate_limit_ok(req, 'admin') is False
 
 
-def test_uses_forwarded_for_first_hop():
-    req = _mock_request(forwarded='198.51.100.2, 10.0.0.1')
+def test_ignores_forwarded_without_trusted_proxy(monkeypatch):
+    monkeypatch.setattr('config.TRUSTED_PROXY_COUNT', 0)
+    req = _mock_request(ip='203.0.113.1', forwarded='198.51.100.2, 10.0.0.1')
+    assert upload_rate_limit_ok(req, 'community') is True
+    with _lock:
+        assert '203.0.113.1' in _buckets
+        assert '198.51.100.2' not in _buckets
+
+
+def test_uses_trusted_forwarded_hop(monkeypatch):
+    monkeypatch.setattr('config.TRUSTED_PROXY_COUNT', 1)
+    # Proxy appends the connection IP after any client-supplied chain.
+    req = _mock_request(ip='10.0.0.1', forwarded='198.51.100.99, 198.51.100.2')
     assert upload_rate_limit_ok(req, 'community') is True
     with _lock:
         assert '198.51.100.2' in _buckets
+        assert '198.51.100.99' not in _buckets

--- a/backend/upload_rate_limit.py
+++ b/backend/upload_rate_limit.py
@@ -4,6 +4,8 @@ import os
 import time
 from threading import Lock
 
+from werkzeug.http import parse_list_header
+
 # 15-minute window; separate caps for anonymous vs staff/admin.
 _WINDOW_SEC = int(os.environ.get('UPLOAD_RATE_WINDOW_SEC', '900'))
 _MAX_COMMUNITY = int(os.environ.get('UPLOAD_RATE_MAX_COMMUNITY', '40'))
@@ -13,10 +15,23 @@ _buckets: dict[str, list[float]] = {}
 _lock = Lock()
 
 
+def _trusted_proxy_count() -> int:
+    try:
+        from config import TRUSTED_PROXY_COUNT
+        return TRUSTED_PROXY_COUNT
+    except ImportError:
+        return max(0, int(os.environ.get('TRUSTED_PROXY_COUNT', '0')))
+
+
 def client_ip(request) -> str:
-    forwarded = request.headers.get('X-Forwarded-For', '')
-    if forwarded:
-        return forwarded.split(',')[0].strip()
+    """Client IP for rate limiting; matches werkzeug ProxyFix x_for semantics."""
+    trusted = _trusted_proxy_count()
+    if trusted:
+        forwarded = request.headers.get('X-Forwarded-For', '')
+        if forwarded:
+            values = parse_list_header(forwarded)
+            if len(values) >= trusted:
+                return values[-trusted]
     return request.remote_addr or '127.0.0.1'
 
 

--- a/backend/upload_rate_limit.py
+++ b/backend/upload_rate_limit.py
@@ -35,6 +35,16 @@ def client_ip(request) -> str:
     return request.remote_addr or '127.0.0.1'
 
 
+def _policy_tier(role: str) -> str:
+    if role in ('staff', 'admin'):
+        return 'privileged'
+    return 'community'
+
+
+def _bucket_key(ip: str, role: str) -> str:
+    return f'{ip}:{_policy_tier(role)}'
+
+
 def _max_hits_for_role(role: str) -> int:
     if role in ('staff', 'admin'):
         return _MAX_PRIVILEGED
@@ -43,17 +53,18 @@ def _max_hits_for_role(role: str) -> int:
 
 def upload_rate_limit_ok(request, role: str = 'community') -> bool:
     ip = client_ip(request)
+    key = _bucket_key(ip, role)
     now = time.time()
     window_start = now - _WINDOW_SEC
     max_hits = _max_hits_for_role(role)
 
     with _lock:
-        hits = [t for t in _buckets.get(ip, []) if t > window_start]
+        hits = [t for t in _buckets.get(key, []) if t > window_start]
         if len(hits) >= max_hits:
-            _buckets[ip] = hits
+            _buckets[key] = hits
             return False
         hits.append(now)
-        _buckets[ip] = hits
+        _buckets[key] = hits
     return True
 
 

--- a/backend/upload_rate_limit.py
+++ b/backend/upload_rate_limit.py
@@ -1,0 +1,49 @@
+"""Per-IP sliding-window rate limits for multipart image uploads."""
+
+import os
+import time
+from threading import Lock
+
+# 15-minute window; separate caps for anonymous vs staff/admin.
+_WINDOW_SEC = int(os.environ.get('UPLOAD_RATE_WINDOW_SEC', '900'))
+_MAX_COMMUNITY = int(os.environ.get('UPLOAD_RATE_MAX_COMMUNITY', '40'))
+_MAX_PRIVILEGED = int(os.environ.get('UPLOAD_RATE_MAX_PRIVILEGED', '200'))
+
+_buckets: dict[str, list[float]] = {}
+_lock = Lock()
+
+
+def client_ip(request) -> str:
+    forwarded = request.headers.get('X-Forwarded-For', '')
+    if forwarded:
+        return forwarded.split(',')[0].strip()
+    return request.remote_addr or '127.0.0.1'
+
+
+def _max_hits_for_role(role: str) -> int:
+    if role in ('staff', 'admin'):
+        return _MAX_PRIVILEGED
+    return _MAX_COMMUNITY
+
+
+def upload_rate_limit_ok(request, role: str = 'community') -> bool:
+    ip = client_ip(request)
+    now = time.time()
+    window_start = now - _WINDOW_SEC
+    max_hits = _max_hits_for_role(role)
+
+    with _lock:
+        hits = [t for t in _buckets.get(ip, []) if t > window_start]
+        if len(hits) >= max_hits:
+            _buckets[ip] = hits
+            return False
+        hits.append(now)
+        _buckets[ip] = hits
+    return True
+
+
+def upload_rate_limit_response():
+    from flask import jsonify
+    return jsonify({
+        'error': 'Too many uploads in a short time. Please wait a few minutes and try again.',
+    }), 429

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@tabler/icons-react": "^3.35.0",
         "@tailwindcss/vite": "^4.1.14",
         "leaflet": "^1.9.4",
+        "piexifjs": "^1.0.6",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-redux": "^9.2.0",
@@ -4028,6 +4029,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/piexifjs": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/piexifjs/-/piexifjs-1.0.6.tgz",
+      "integrity": "sha512-0wVyH0cKohzBQ5Gi2V1BuxYpxWfxF3cSqfFXfPIpl5tl9XLS5z4ogqhUCD20AbHi0h9aJkqXNJnkVev6gwh2ag==",
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.57.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@tabler/icons-react": "^3.35.0",
     "@tailwindcss/vite": "^4.1.14",
     "leaflet": "^1.9.4",
+    "piexifjs": "^1.0.6",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-redux": "^9.2.0",

--- a/frontend/src/components/AdditionalImagesSection.tsx
+++ b/frontend/src/components/AdditionalImagesSection.tsx
@@ -20,7 +20,7 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useRef, useState, type DragEvent } from 'react';
 import { getImageUrl } from '../services/api';
-import { validateFile } from '../utils/fileValidation';
+import { acceptUploadFile } from '../utils/uploadFilePipeline';
 import {
   uploadReviewPacketAdditionalImages,
   removeReviewPacketAdditionalImage,
@@ -354,43 +354,39 @@ export function AdditionalImagesSection({
   // per row before the explicit Upload click.
   const handleAdd = (type: AdditionalPhotoKind, files: FileList | null) => {
     if (!files?.length) return;
-    if (onStagePhoto) {
-      for (let i = 0; i < files.length; i++) {
-        const file = files[i];
-        const validation = validateFile(file);
-        if (validation.isValid) {
-          onStagePhoto(type, file);
-        } else if (validation.error) {
-          notifications.show({ title: 'Invalid file', message: validation.error, color: 'red' });
-        }
-      }
-      return;
-    }
-    addFilesToStaging(type, files);
+    void addFilesFromInput(type, files, Boolean(onStagePhoto));
   };
 
-  const addFilesToStaging = (type: AdditionalPhotoKind, files: FileList | null) => {
-    if (!files?.length) return;
-    const next: StagedRow[] = [];
+  const addFilesFromInput = async (
+    type: AdditionalPhotoKind,
+    files: FileList,
+    stageOnly: boolean,
+  ) => {
     for (let i = 0; i < files.length; i++) {
-      const file = files[i];
-      const validation = validateFile(file);
-      if (!validation.isValid) {
-        if (validation.error) {
-          notifications.show({ title: 'Invalid file', message: validation.error, color: 'red' });
+      const accepted = await acceptUploadFile(files[i]);
+      if (!accepted.isValid || !accepted.file) {
+        if (accepted.error) {
+          notifications.show({ title: 'Invalid file', message: accepted.error, color: 'red' });
         }
         continue;
       }
-      const previewUrl = URL.createObjectURL(file);
-      next.push({
-        id: `${Date.now()}-${i}-${Math.random().toString(36).slice(2)}`,
-        file,
-        previewUrl,
-        type,
-        labels: [],
-      });
+      const prepared = accepted.file;
+      if (stageOnly && onStagePhoto) {
+        onStagePhoto(type, prepared);
+        continue;
+      }
+      const previewUrl = URL.createObjectURL(prepared);
+      setStaged((prev) => [
+        ...prev,
+        {
+          id: `${Date.now()}-${i}-${Math.random().toString(36).slice(2)}`,
+          file: prepared,
+          previewUrl,
+          type,
+          labels: [],
+        },
+      ]);
     }
-    if (next.length) setStaged((prev) => [...prev, ...next]);
   };
 
   const removeStagedRow = (id: string) => {

--- a/frontend/src/components/PreviewCard.tsx
+++ b/frontend/src/components/PreviewCard.tsx
@@ -38,7 +38,7 @@ import { useState, useEffect, useRef, type DragEvent } from 'react';
 import type { FileWithPath } from '@mantine/dropzone';
 import type { LocationHint, UploadExtraFile } from '../services/api';
 import { MapPicker } from './MapPicker';
-import { validateFile } from '../utils/fileValidation';
+import { acceptUploadFile } from '../utils/uploadFilePipeline';
 import { notifications } from '@mantine/notifications';
 import {
   ADDITIONAL_PHOTO_KIND_OPTIONS,
@@ -108,23 +108,23 @@ export function PreviewCard({
   const [activeDropKind, setActiveDropKind] = useState<AdditionalPhotoKind | null>(null);
   const isMobile = useMediaQuery('(max-width: 576px)');
 
-  const addExtraFilesByType = (type: AdditionalPhotoKind, list: FileList | null) => {
+  const addExtraFilesByType = async (type: AdditionalPhotoKind, list: FileList | null) => {
     if (!setExtraFiles || !list?.length) return;
     const valid: UploadExtraFile[] = [];
     for (let i = 0; i < list.length; i++) {
       const file = list[i];
-      const validation = validateFile(file);
-      if (validation.isValid) {
+      const accepted = await acceptUploadFile(file);
+      if (accepted.isValid && accepted.file) {
         valid.push({
           type,
-          file,
+          file: accepted.file,
           labels: [],
           localId: crypto.randomUUID(),
         });
-      } else if (validation.error) {
+      } else if (accepted.error) {
         notifications.show({
           title: 'Invalid file',
-          message: validation.error,
+          message: accepted.error,
           color: 'red',
         });
       }
@@ -136,7 +136,7 @@ export function PreviewCard({
     event.preventDefault();
     event.stopPropagation();
     setActiveDropKind(null);
-    addExtraFilesByType(type, event.dataTransfer.files);
+    void addExtraFilesByType(type, event.dataTransfer.files);
   };
 
   const prevStillAtLocation = useRef<'yes' | 'no' | null>(null);
@@ -255,7 +255,7 @@ export function PreviewCard({
                         multiple
                         hidden
                         onChange={(e) => {
-                          addExtraFilesByType(kindOpt.value as AdditionalPhotoKind, e.target.files);
+                          void addExtraFilesByType(kindOpt.value as AdditionalPhotoKind, e.target.files);
                           e.target.value = '';
                         }}
                       />

--- a/frontend/src/hooks/usePhotoUpload.tsx
+++ b/frontend/src/hooks/usePhotoUpload.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { notifications } from '@mantine/notifications';
 import { IconCheck, IconAlertCircle } from '@tabler/icons-react';
-import { validateFile } from '../utils/fileValidation';
+import { acceptUploadFile } from '../utils/uploadFilePipeline';
 import { getCurrentLocation } from '../services/geolocation';
 import {
   uploadTurtlePhoto,
@@ -96,23 +96,25 @@ export function usePhotoUpload({
     };
   }, []);
 
-  const handleDrop = (acceptedFiles: FileWithPath[]): void => {
+  const handleDrop = async (acceptedFiles: FileWithPath[]): Promise<void> => {
     if (acceptedFiles.length > 0) {
       const file = acceptedFiles[0];
 
-      // Validation
-      const validation = validateFile(file);
-      if (!validation.isValid) {
+      const accepted = await acceptUploadFile(file);
+      if (!accepted.isValid || !accepted.file) {
         notifications.show({
           title: 'Invalid File',
-          message: validation.error || 'File could not be validated',
+          message: accepted.error || 'File could not be validated',
           color: 'red',
           icon: <IconAlertCircle size={18} />,
         });
         return;
       }
 
-      setFiles(acceptedFiles);
+      const fileWithPath = Object.assign(accepted.file, {
+        path: accepted.file.name,
+      }) as FileWithPath;
+      setFiles([fileWithPath]);
       setUploadState('idle');
       setUploadResponse(null);
       setImageId(null);
@@ -129,7 +131,7 @@ export function usePhotoUpload({
       reader.onload = (e: ProgressEvent<FileReader>) => {
         setPreview(e.target?.result as string);
       };
-      reader.readAsDataURL(file);
+      reader.readAsDataURL(accepted.file);
     }
   };
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -28,7 +28,7 @@ import {
   IconStarFilled,
 } from '@tabler/icons-react';
 import { useRef, useState, useEffect, useLayoutEffect, useMemo, useCallback } from 'react';
-import { validateFile } from '../utils/fileValidation';
+import { MAX_RAW_FILE_BYTES } from '../utils/uploadConstants';
 import { useUser } from '../hooks/useUser';
 import { usePhotoUpload } from '../hooks/usePhotoUpload';
 import { isStaffRole } from '../services/api/auth';
@@ -392,21 +392,7 @@ export default function HomePage() {
 
   const handleDropWithValidation = (acceptedFiles: FileWithPath[]): void => {
     if (acceptedFiles.length > 0) {
-      const file = acceptedFiles[0];
-
-      // Validation
-      const validation = validateFile(file);
-      if (!validation.isValid) {
-        notifications.show({
-          title: 'Invalid File',
-          message: validation.error || 'File could not be validated',
-          color: 'red',
-          icon: <IconAlertCircle size={18} />,
-        });
-        return;
-      }
-
-      handleDrop(acceptedFiles);
+      void handleDrop(acceptedFiles);
     }
   };
 
@@ -415,7 +401,7 @@ export default function HomePage() {
     let message = 'File could not be accepted';
 
     if (rejection.errors[0]?.code === 'file-too-large') {
-      message = 'File is too large. Maximum: 5MB';
+      message = `File is too large. Maximum from device: ${(MAX_RAW_FILE_BYTES / 1024 / 1024).toFixed(0)} MB`;
     } else if (rejection.errors[0]?.code === 'file-invalid-type') {
       message = 'Invalid file type. Allowed: PNG, JPG, JPEG, GIF, WEBP, HEIC';
     }
@@ -618,14 +604,14 @@ export default function HomePage() {
                 Upload Photo
               </Button>
               <Text size='sm' c='dimmed' ta='center' mt='xs'>
-                Supported formats: PNG, JPG, JPEG, GIF, WEBP, HEIC (max. 5MB)
+                Photos are optimized automatically (up to 25 MB from your device)
               </Text>
             </Stack>
           ) : (
             <Dropzone
               onDrop={handleDropWithValidation}
               onReject={handleReject}
-              maxSize={5 * 1024 * 1024} // 5MB
+              maxSize={MAX_RAW_FILE_BYTES}
               accept={{
                 'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.heic', '.heif'],
               }}
@@ -660,7 +646,7 @@ export default function HomePage() {
                     ta='center'
                     style={{ display: 'block' }}
                   >
-                    Supported formats: PNG, JPG, JPEG, GIF, WEBP, HEIC (max. 5MB)
+                    Photos are optimized automatically (up to 25 MB from your device)
                   </Text>
                 </div>
               </Group>

--- a/frontend/src/services/api/turtle.ts
+++ b/frontend/src/services/api/turtle.ts
@@ -4,6 +4,7 @@
 
 import { getToken, removeToken, TURTLE_API_BASE_URL } from './config';
 import type { TurtleSheetsData } from './sheets';
+import { prepareImageForUpload } from '../../utils/prepareImageForUpload';
 
 export interface TurtleMatch {
   turtle_id: string;
@@ -161,8 +162,18 @@ export const uploadTurtlePhoto = async (
   /** Optional: microhabitat or condition photos (community upload, same request) */
   extraFiles?: UploadExtraFile[],
 ): Promise<UploadPhotoResponse> => {
+  const preparedMain = await prepareImageForUpload(file);
+  const preparedExtras = extraFiles?.length
+    ? await Promise.all(
+        extraFiles.map(async (ef) => ({
+          ...ef,
+          file: await prepareImageForUpload(ef.file),
+        })),
+      )
+    : undefined;
+
   const formData = new FormData();
-  formData.append('file', file);
+  formData.append('file', preparedMain);
 
   if (location) {
     formData.append('state', location.state);
@@ -185,8 +196,8 @@ export const uploadTurtlePhoto = async (
       formData.append('digital_flag_source', flagOptions.digitalFlag.source);
     }
   }
-  if (extraFiles?.length) {
-    extraFiles.forEach((ef, i) => {
+  if (preparedExtras?.length) {
+    preparedExtras.forEach((ef, i) => {
       formData.append(`extra_${ef.type}_${i}`, ef.file);
       if (ef.labels?.length) {
         formData.append(`extra_labels_${i}`, ef.labels.join(', '));
@@ -258,8 +269,11 @@ export const uploadReviewPacketAdditionalImages = async (
   const token = getToken();
   const headers: Record<string, string> = {};
   if (token) headers['Authorization'] = `Bearer ${token}`;
+  const prepared = await Promise.all(
+    files.map(async (f) => ({ ...f, file: await prepareImageForUpload(f.file) })),
+  );
   const formData = new FormData();
-  files.forEach((f, i) => {
+  prepared.forEach((f, i) => {
     formData.append(`file_${i}`, f.file);
     formData.append(`type_${i}`, f.type);
     if (f.labels?.length) {
@@ -763,10 +777,11 @@ export const uploadTurtleReplaceReference = async (
   const token = getToken();
   const headers: Record<string, string> = {};
   if (token) headers['Authorization'] = `Bearer ${token}`;
+  const prepared = await prepareImageForUpload(file);
   const formData = new FormData();
   formData.append('turtle_id', turtleId);
   formData.append('photo_type', photoType);
-  formData.append('file', file);
+  formData.append('file', prepared);
   if (sheetName) formData.append('sheet_name', sheetName);
   if (primaryId) formData.append('primary_id', primaryId);
   if (opts?.createIfMissing) formData.append('create_if_missing', 'true');
@@ -794,9 +809,10 @@ export const uploadTurtleIdentifierPlastron = async (
   const token = getToken();
   const headers: Record<string, string> = {};
   if (token) headers['Authorization'] = `Bearer ${token}`;
+  const prepared = await prepareImageForUpload(file);
   const formData = new FormData();
   formData.append('turtle_id', turtleId);
-  formData.append('file', file);
+  formData.append('file', prepared);
   formData.append('mode', mode);
   if (sheetName) formData.append('sheet_name', sheetName);
   if (primaryId) formData.append('primary_id', primaryId);
@@ -831,12 +847,15 @@ export const uploadTurtleAdditionalImages = async (
   const token = getToken();
   const headers: Record<string, string> = {};
   if (token) headers['Authorization'] = `Bearer ${token}`;
+  const prepared = await Promise.all(
+    files.map(async (f) => ({ ...f, file: await prepareImageForUpload(f.file) })),
+  );
   const formData = new FormData();
   formData.append('turtle_id', turtleId);
   if (sheetName) formData.append('sheet_name', sheetName);
   if (primaryId) formData.append('primary_id', primaryId);
   if (opts?.bioId) formData.append('bio_id', opts.bioId);
-  files.forEach((f, i) => {
+  prepared.forEach((f, i) => {
     formData.append(`file_${i}`, f.file);
     formData.append(`type_${i}`, f.type);
     if (f.labels?.length) {

--- a/frontend/src/types/piexifjs.d.ts
+++ b/frontend/src/types/piexifjs.d.ts
@@ -1,0 +1,20 @@
+declare module 'piexifjs' {
+  export interface ExifDict {
+    '0th'?: Record<number, unknown>;
+    Exif?: Record<number, unknown>;
+    GPS?: Record<number, unknown>;
+    Interop?: Record<number, unknown>;
+    '1st'?: Record<number, unknown>;
+    thumbnail?: string | null;
+  }
+
+  const piexif: {
+    load: (data: string) => ExifDict;
+    dump: (exifDict: ExifDict) => string;
+    insert: (exifBytes: string, jpeg: string) => string;
+    remove: (jpeg: string) => string;
+    ImageIFD: { Orientation: number };
+  };
+
+  export default piexif;
+}

--- a/frontend/src/utils/fileValidation.ts
+++ b/frontend/src/utils/fileValidation.ts
@@ -1,9 +1,11 @@
 /**
  * File validation for photo uploads (size, type).
- * Used before sending files to the real backend API.
+ * Used after client-side optimization and before sending to the API.
  */
 
-const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+import { MAX_UPLOAD_BYTES } from './uploadConstants';
+
+const MAX_SIZE = MAX_UPLOAD_BYTES;
 const VALID_TYPES = [
   'image/jpeg',
   'image/jpg',

--- a/frontend/src/utils/prepareImageForUpload.ts
+++ b/frontend/src/utils/prepareImageForUpload.ts
@@ -16,6 +16,17 @@ const COMPRESSIBLE_TYPES = new Set([
 ]);
 const COMPRESSIBLE_EXT = new Set(['jpg', 'jpeg', 'png', 'webp', 'gif']);
 
+/** Files already optimized by prepareImageForUpload (e.g. via acceptUploadFile). */
+const preparedUploadFiles = new WeakSet<File>();
+
+export function isUploadFilePrepared(file: File): boolean {
+  return preparedUploadFiles.has(file);
+}
+
+function markUploadFilePrepared(file: File): void {
+  preparedUploadFiles.add(file);
+}
+
 function outputName(originalName: string): string {
   const base = originalName.replace(/\.[^.]+$/, '') || 'upload';
   return `${base}.jpg`;
@@ -129,6 +140,10 @@ function canvasToJpegFile(
  * HEIC/HEIF is passed through when the browser cannot decode it (server normalizes).
  */
 export async function prepareImageForUpload(file: File): Promise<File> {
+  if (preparedUploadFiles.has(file)) {
+    return file;
+  }
+
   if (file.size > MAX_RAW_FILE_BYTES) {
     throw new Error(
       `File is too large (${(MAX_RAW_FILE_BYTES / 1024 / 1024).toFixed(0)} MB max from device).`,
@@ -137,6 +152,7 @@ export async function prepareImageForUpload(file: File): Promise<File> {
 
   if (!canDecodeInBrowser(file)) {
     if (file.size <= MAX_UPLOAD_BYTES) {
+      markUploadFilePrepared(file);
       return file;
     }
     throw new Error(
@@ -148,9 +164,11 @@ export async function prepareImageForUpload(file: File): Promise<File> {
     try {
       const img = await loadImageFromFile(file);
       if (Math.max(img.naturalWidth, img.naturalHeight) <= UPLOAD_MAX_DIMENSION) {
+        markUploadFilePrepared(file);
         return file;
       }
     } catch {
+      markUploadFilePrepared(file);
       return file;
     }
   }
@@ -189,6 +207,7 @@ export async function prepareImageForUpload(file: File): Promise<File> {
     throw new Error('Image is still too large after optimization. Try a smaller photo.');
   }
 
+  markUploadFilePrepared(out);
   return out;
 }
 

--- a/frontend/src/utils/prepareImageForUpload.ts
+++ b/frontend/src/utils/prepareImageForUpload.ts
@@ -1,0 +1,134 @@
+import {
+  MAX_RAW_FILE_BYTES,
+  MAX_UPLOAD_BYTES,
+  UPLOAD_JPEG_QUALITY,
+  UPLOAD_MAX_DIMENSION,
+  UPLOAD_SKIP_COMPRESS_BELOW_BYTES,
+} from './uploadConstants';
+
+const COMPRESSIBLE_TYPES = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+]);
+const COMPRESSIBLE_EXT = new Set(['jpg', 'jpeg', 'png', 'webp', 'gif']);
+
+function outputName(originalName: string): string {
+  const base = originalName.replace(/\.[^.]+$/, '') || 'upload';
+  return `${base}.jpg`;
+}
+
+function canDecodeInBrowser(file: File): boolean {
+  const typeOk = file.type && COMPRESSIBLE_TYPES.has(file.type);
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  return typeOk || COMPRESSIBLE_EXT.has(ext);
+}
+
+function loadImageFromFile(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('decode_failed'));
+    };
+    img.src = url;
+  });
+}
+
+function canvasToJpegFile(
+  canvas: HTMLCanvasElement,
+  name: string,
+  quality: number,
+): Promise<File> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error('encode_failed'));
+          return;
+        }
+        resolve(new File([blob], name, { type: 'image/jpeg', lastModified: Date.now() }));
+      },
+      'image/jpeg',
+      quality,
+    );
+  });
+}
+
+/**
+ * Resize and re-encode photos before upload so smartphone originals (often 5–15 MB)
+ * fit server limits without raising the attack surface.
+ * HEIC/HEIF is passed through when the browser cannot decode it (server normalizes).
+ */
+export async function prepareImageForUpload(file: File): Promise<File> {
+  if (file.size > MAX_RAW_FILE_BYTES) {
+    throw new Error(
+      `File is too large (${(MAX_RAW_FILE_BYTES / 1024 / 1024).toFixed(0)} MB max from device).`,
+    );
+  }
+
+  if (!canDecodeInBrowser(file)) {
+    if (file.size <= MAX_UPLOAD_BYTES) {
+      return file;
+    }
+    throw new Error(
+      'This image format could not be optimized in the browser. Save as JPEG or PNG and try again.',
+    );
+  }
+
+  if (file.size <= UPLOAD_SKIP_COMPRESS_BELOW_BYTES) {
+    try {
+      const img = await loadImageFromFile(file);
+      if (Math.max(img.naturalWidth, img.naturalHeight) <= UPLOAD_MAX_DIMENSION) {
+        return file;
+      }
+    } catch {
+      return file;
+    }
+  }
+
+  const img = await loadImageFromFile(file);
+  const srcW = img.naturalWidth;
+  const srcH = img.naturalHeight;
+  if (!srcW || !srcH) {
+    throw new Error('Could not read image dimensions.');
+  }
+
+  const scale = Math.min(1, UPLOAD_MAX_DIMENSION / Math.max(srcW, srcH));
+  const dstW = Math.max(1, Math.round(srcW * scale));
+  const dstH = Math.max(1, Math.round(srcH * scale));
+
+  const canvas = document.createElement('canvas');
+  canvas.width = dstW;
+  canvas.height = dstH;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Could not prepare image for upload.');
+  }
+  ctx.drawImage(img, 0, 0, dstW, dstH);
+
+  let out = await canvasToJpegFile(canvas, outputName(file.name), UPLOAD_JPEG_QUALITY);
+
+  if (out.size > MAX_UPLOAD_BYTES) {
+    out = await canvasToJpegFile(canvas, outputName(file.name), 0.72);
+  }
+  if (out.size > MAX_UPLOAD_BYTES) {
+    out = await canvasToJpegFile(canvas, outputName(file.name), 0.58);
+  }
+  if (out.size > MAX_UPLOAD_BYTES) {
+    throw new Error('Image is still too large after optimization. Try a smaller photo.');
+  }
+
+  return out;
+}
+
+export async function prepareImagesForUpload(files: File[]): Promise<File[]> {
+  return Promise.all(files.map((f) => prepareImageForUpload(f)));
+}

--- a/frontend/src/utils/prepareImageForUpload.ts
+++ b/frontend/src/utils/prepareImageForUpload.ts
@@ -1,3 +1,4 @@
+import piexif, { type ExifDict } from 'piexifjs';
 import {
   MAX_RAW_FILE_BYTES,
   MAX_UPLOAD_BYTES,
@@ -26,6 +27,64 @@ function canDecodeInBrowser(file: File): boolean {
   return typeOk || COMPRESSIBLE_EXT.has(ext);
 }
 
+function isJpegFile(file: File): boolean {
+  const type = file.type.toLowerCase();
+  if (type === 'image/jpeg' || type === 'image/jpg') return true;
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  return ext === 'jpg' || ext === 'jpeg';
+}
+
+function arrayBufferToBinaryString(buf: ArrayBuffer): string {
+  const u8 = new Uint8Array(buf);
+  const chunk = 0x8000;
+  let out = '';
+  for (let i = 0; i < u8.length; i += chunk) {
+    out += String.fromCharCode(...u8.subarray(i, i + chunk));
+  }
+  return out;
+}
+
+function binaryStringToArrayBuffer(binary: string): ArrayBuffer {
+  const len = binary.length;
+  const out = new Uint8Array(len);
+  for (let i = 0; i < len; i++) out[i] = binary.charCodeAt(i);
+  return out.buffer;
+}
+
+/** Read EXIF from original JPEG bytes (before canvas strips it). */
+async function readExifFromJpegFile(file: File): Promise<ExifDict | null> {
+  if (!isJpegFile(file)) return null;
+  try {
+    const buf = await file.arrayBuffer();
+    return piexif.load(arrayBufferToBinaryString(buf));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Canvas draw applies orientation; reset tag so backend exif_transpose does not rotate again.
+ */
+function exifForCanvasOutput(exifObj: ExifDict): ExifDict {
+  const copy = JSON.parse(JSON.stringify(exifObj)) as ExifDict;
+  if (copy['0th']) {
+    copy['0th'][piexif.ImageIFD.Orientation] = 1;
+  }
+  return copy;
+}
+
+async function injectExifIntoJpegBlob(blob: Blob, sourceExif: ExifDict | null): Promise<Blob> {
+  if (!sourceExif) return blob;
+  try {
+    const jpegBinary = arrayBufferToBinaryString(await blob.arrayBuffer());
+    const exifBytes = piexif.dump(exifForCanvasOutput(sourceExif));
+    const withExif = piexif.insert(exifBytes, jpegBinary);
+    return new Blob([binaryStringToArrayBuffer(withExif)], { type: 'image/jpeg' });
+  } catch {
+    return blob;
+  }
+}
+
 function loadImageFromFile(file: File): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const url = URL.createObjectURL(file);
@@ -46,15 +105,17 @@ function canvasToJpegFile(
   canvas: HTMLCanvasElement,
   name: string,
   quality: number,
+  sourceExif: ExifDict | null,
 ): Promise<File> {
   return new Promise((resolve, reject) => {
     canvas.toBlob(
-      (blob) => {
+      async (blob) => {
         if (!blob) {
           reject(new Error('encode_failed'));
           return;
         }
-        resolve(new File([blob], name, { type: 'image/jpeg', lastModified: Date.now() }));
+        const withExif = await injectExifIntoJpegBlob(blob, sourceExif);
+        resolve(new File([withExif], name, { type: 'image/jpeg', lastModified: Date.now() }));
       },
       'image/jpeg',
       quality,
@@ -114,13 +175,15 @@ export async function prepareImageForUpload(file: File): Promise<File> {
   }
   ctx.drawImage(img, 0, 0, dstW, dstH);
 
-  let out = await canvasToJpegFile(canvas, outputName(file.name), UPLOAD_JPEG_QUALITY);
+  const sourceExif = await readExifFromJpegFile(file);
+
+  let out = await canvasToJpegFile(canvas, outputName(file.name), UPLOAD_JPEG_QUALITY, sourceExif);
 
   if (out.size > MAX_UPLOAD_BYTES) {
-    out = await canvasToJpegFile(canvas, outputName(file.name), 0.72);
+    out = await canvasToJpegFile(canvas, outputName(file.name), 0.72, sourceExif);
   }
   if (out.size > MAX_UPLOAD_BYTES) {
-    out = await canvasToJpegFile(canvas, outputName(file.name), 0.58);
+    out = await canvasToJpegFile(canvas, outputName(file.name), 0.58, sourceExif);
   }
   if (out.size > MAX_UPLOAD_BYTES) {
     throw new Error('Image is still too large after optimization. Try a smaller photo.');

--- a/frontend/src/utils/uploadConstants.ts
+++ b/frontend/src/utils/uploadConstants.ts
@@ -1,0 +1,14 @@
+/** Max bytes accepted from the device before client-side optimization. */
+export const MAX_RAW_FILE_BYTES = 25 * 1024 * 1024;
+
+/** Max bytes after optimization (must stay ≤ backend MAX_FILE_SIZE). */
+export const MAX_UPLOAD_BYTES = 8 * 1024 * 1024;
+
+/** Longest edge (px) for photos sent to the API. */
+export const UPLOAD_MAX_DIMENSION = 2048;
+
+/** JPEG quality for upload optimization (0–1). */
+export const UPLOAD_JPEG_QUALITY = 0.82;
+
+/** Skip re-encoding when already small and likely within dimension budget. */
+export const UPLOAD_SKIP_COMPRESS_BELOW_BYTES = 400 * 1024;

--- a/frontend/src/utils/uploadFilePipeline.ts
+++ b/frontend/src/utils/uploadFilePipeline.ts
@@ -1,0 +1,23 @@
+import { validateFile } from './fileValidation';
+import { prepareImageForUpload } from './prepareImageForUpload';
+
+export interface AcceptUploadFileResult {
+  isValid: boolean;
+  file?: File;
+  error?: string;
+}
+
+/** Optimize then validate — use for every user-selected upload file. */
+export async function acceptUploadFile(file: File): Promise<AcceptUploadFileResult> {
+  try {
+    const prepared = await prepareImageForUpload(file);
+    const validation = validateFile(prepared);
+    if (!validation.isValid) {
+      return { isValid: false, error: validation.error };
+    }
+    return { isValid: true, file: prepared };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Could not prepare image for upload';
+    return { isValid: false, error: message };
+  }
+}


### PR DESCRIPTION
### Added

- **Upload image optimization**: Photos are resized/compressed in the browser before upload (max 2048 px edge, JPEG ~82%) so smartphone originals and microhabitat shots no longer hit size limits. Server enforces an 8 MB per-file cap, 12 MB request body limit, ingest downscaling for bypassed clients, and per-IP rate limits (community vs admin) on all multipart image endpoints.

### Changed

- **Upload UX copy**: Homepage dropzone accepts up to 25 MB from the device and explains that photos are optimized automatically.