### PR TITLE
fix(backend): recover stale-location turtle folders (false "No photos on disk") + Release 2.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sheets Browser falsely flagged turtles as "No photos on disk"**: a turtle whose Google Sheet `Location` names a sub-site its folder doesn't actually live under (e.g. `Location=Shredder` while the folder sits directly under `.../CPBS/`) failed folder resolution. `_get_turtle_folder` scoped the walk to the deepest *existing* prefix (`.../CPBS/Shredder`), missed the turtle, and returned `None`, so the browser showed a red "No photos on disk" badge even though the turtle matches fine and has reference images on disk. It now falls back to a full unscoped walk for a globally-unique `primary_id` when the scoped walk misses (bare biology IDs stay scoped — they repeat across sheets), recovering the correct folder. This also lets the admin upload resolvers find the existing folder instead of creating a duplicate under the stale sub-site.
+
 ## [2.0.14] - 2026-06-03 — Turtle folder merge utility
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.15] - 2026-06-05 — Stale-location turtle folder resolution
+
 ### Fixed
 
 - **Sheets Browser falsely flagged turtles as "No photos on disk"**: a turtle whose Google Sheet `Location` names a sub-site its folder doesn't actually live under (e.g. `Location=Shredder` while the folder sits directly under `.../CPBS/`) failed folder resolution. `_get_turtle_folder` scoped the walk to the deepest *existing* prefix (`.../CPBS/Shredder`), missed the turtle, and returned `None`, so the browser showed a red "No photos on disk" badge even though the turtle matches fine and has reference images on disk. It now falls back to a full unscoped walk for a globally-unique `primary_id` when the scoped walk misses (bare biology IDs stay scoped — they repeat across sheets), recovering the correct folder. This also lets the admin upload resolvers find the existing folder instead of creating a duplicate under the stale sub-site.

--- a/backend/tests/test_turtle_plastron_upload.py
+++ b/backend/tests/test_turtle_plastron_upload.py
@@ -245,6 +245,37 @@ def test_get_turtle_folder_no_hint_primary_id_resolves_across_tree(mgr):
     assert os.path.normpath(mgr._get_turtle_folder("T1771234567", None)) == os.path.normpath(pj)
 
 
+def test_get_turtle_folder_primary_recovers_when_sheet_location_is_stale(mgr):
+    """Sheet Location names a sub-site the turtle's folder does NOT live under
+    (e.g. Location='Shredder' while the folder sits directly under .../CPBS/).
+    The scoped walk misses it, but a globally-unique primary_id recovers via the
+    unscoped fallback. A bare bio_id must stay scoped (it repeats across sheets)
+    and fail closed. Mirrors the live F286 'No photos on disk' incident."""
+    target = _make_turtle(mgr, "NebraskaCPBS", "CPBS", "F286_T1771234567")
+    # A real sub-site exists but holds a DIFFERENT turtle, so the deepest existing
+    # prefix (.../CPBS/Shredder) is walked first and misses F286.
+    _make_turtle(mgr, "NebraskaCPBS", "CPBS", "Shredder", "F128_T1770000001")
+    stale_hint = "NebraskaCPBS/CPBS/Shredder"
+    assert os.path.normpath(mgr._get_turtle_folder("T1771234567", stale_hint)) == os.path.normpath(target)
+    assert mgr._get_turtle_folder("F286", stale_hint) is None
+
+
+def test_get_turtle_folder_genuinely_nested_turtle_still_resolves(mgr):
+    """A turtle that really lives in a sub-site is still found by the recursive
+    scoped walk, for both its primary id and its bio id (no regression)."""
+    nested = _make_turtle(mgr, "NebraskaCPBS", "CPBS", "Shredder", "F128_T1770000001")
+    hint = "NebraskaCPBS/CPBS/Shredder"
+    assert os.path.normpath(mgr._get_turtle_folder("T1770000001", hint)) == os.path.normpath(nested)
+    assert os.path.normpath(mgr._get_turtle_folder("F128", hint)) == os.path.normpath(nested)
+
+
+def test_get_turtle_folder_primary_fallback_returns_none_when_absent(mgr):
+    """The unscoped primary fallback must not invent a match: a primary that
+    exists nowhere still resolves to None."""
+    _make_turtle(mgr, "NebraskaCPBS", "CPBS", "F286_T1771234567")
+    assert mgr._get_turtle_folder("T9999999999", "NebraskaCPBS/CPBS/Shredder") is None
+
+
 def test_resolve_upload_bare_general_location_stays_in_sheet(mgr):
     """resolve_turtle_dir_for_sheet_upload must not cross sheets when the hint
     is a bare general_location and the same bio_id exists in another sheet."""

--- a/backend/turtle_manager.py
+++ b/backend/turtle_manager.py
@@ -2333,6 +2333,24 @@ class TurtleManager:
         except OSError:
             pass
 
+        # The hint scoped us to a subtree that doesn't actually hold this turtle.
+        # This happens when the sheet's Location names a sub-site the turtle's
+        # folder doesn't live under (e.g. Location="Shredder" while the folder is
+        # directly under .../CPBS/), so the scoped walk misses it -- even though
+        # matching finds it via the unscoped VRAM index. A globally-unique
+        # primary_id is safe to recover with a full unscoped walk; bio_ids are
+        # NOT (they repeat across sheets), so this fallback is primary-only. Skip
+        # it when the walk was already unscoped (no usable hint -> base_dir).
+        if (not candidates
+                and _looks_like_primary_id(tid)
+                and self.base_dir not in walk_roots):
+            try:
+                for root, dirs, files in os.walk(self.base_dir):
+                    if _basename_matches_turtle_id(os.path.basename(root), tid):
+                        add_candidate(root)
+            except OSError:
+                pass
+
         if not candidates:
             return None
         # No usable hint + a bare biology id matching more than one folder is

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picturfrontend",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picturfrontend",
-      "version": "2.0.14",
+      "version": "2.0.15",
       "dependencies": {
         "@mantine/code-highlight": "^8.3.5",
         "@mantine/core": "^8.3.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "picturfrontend",
   "private": true,
-  "version": "2.0.14",
+  "version": "2.0.15",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

A turtle whose Google Sheet `Location` names a sub-site its folder doesn't actually live under (e.g. `Location=Shredder` while the folder sits directly under `.../CPBS/`) was failing folder resolution in `_get_turtle_folder`: the walk scoped to the deepest *existing* prefix (`.../CPBS/Shredder`), missed the turtle, and returned `None`. The Sheets Browser's reference-gap detector then showed a red **"No photos on disk"** badge even though the turtle matches fine and has reference images on disk (matching works because the VRAM index walks all of `data/` unscoped).

The fix adds a final fallback in `_get_turtle_folder`: when the scoped walk finds nothing and the id is a globally-unique `primary_id` (`T` + 10+ digits), do one unscoped walk of `data/`. Bare biology IDs stay scoped (they repeat across sheets, so broadening them could serve the wrong turtle), and the fallback is skipped when the walk was already unscoped. This also lets the admin upload resolvers (`resolve_turtle_dir_for_sheet_upload`, `resolve_or_create_canonical_turtle_dir`) find the existing folder instead of creating a duplicate under the stale sub-site.

Confirmed against live prod: `NebraskaCPBS/CPBS/F286_T177517700352641077` has `Location=Shredder` in the sheet but lives directly under `CPBS`; a real `Shredder/` sub-site exists holding different turtles. Includes regression tests (stale-sub-site recovery, genuinely-nested resolution, absent-primary fail-closed). All 219 backend unit tests pass. Cuts Release 2.0.15.