### PR TITLE
fix(backend): born-canonical turtle naming under Sheets outages + Release 2.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A transient Google Sheets outage can no longer create a non-canonical turtle folder**: when the Sheets service was momentarily unavailable while approving/uploading a new turtle, the folder could be born with a bio-only name (e.g. `F276`, `F276_F276`) instead of canonical `<bio_id>_<primary_id>`. Because biology IDs repeat across sheets (Kansas `F102` ≠ Nebraska `F102`), a bio-only folder is a cross-sheet contamination risk. New-turtle creation now: (a) generates the globally-unique `primary_id` **locally** (no network) so the folder always carries a real primary — worst case a safe primary-only folder, never bio-only; (b) runs the biology-ID lookup and the sheet-row write through a **bounded retry** that re-establishes a dropped connection; and (c) if Sheets stays down, returns a retryable **503** and creates nothing, rather than degrading to a bad name. The canonical-folder resolver also **fails loud** (with a clear, retryable message) rather than creating a bio-only folder when a primary can't be obtained. A "Null" turtle (a sheet row with a biology ID but no Primary ID) now has a primary minted and written to its row on its first reference photo, so its folder is born canonical. (#240)
+- **`generate_primary_id` collision hardened**: replaced the millisecond-timestamp + 5-digit (`randint`) tail — which produced confirmed same-millisecond collisions — with a 9-digit cryptographic (`secrets`) tail, making a same-millisecond collision negligibly unlikely. IDs remain `T` + digits. (#240)
+- **`generate_biology_id` no longer mints a duplicate `001` on a read error**: a failed Sheets read of the ID column previously returned `0`, producing a duplicate low biology ID (e.g. a second `F001`). It now raises on a genuine read failure (transient → retried/`503`), reserving `0` for a truly-empty sheet. (#240)
+
 ## [2.0.15] - 2026-06-05 — Stale-location turtle folder resolution
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.16] - 2026-06-12 — Born-canonical turtle naming under Sheets outages
+
 ### Fixed
 
 - **A transient Google Sheets outage can no longer create a non-canonical turtle folder**: when the Sheets service was momentarily unavailable while approving/uploading a new turtle, the folder could be born with a bio-only name (e.g. `F276`, `F276_F276`) instead of canonical `<bio_id>_<primary_id>`. Because biology IDs repeat across sheets (Kansas `F102` ≠ Nebraska `F102`), a bio-only folder is a cross-sheet contamination risk. New-turtle creation now: (a) generates the globally-unique `primary_id` **locally** (no network) so the folder always carries a real primary — worst case a safe primary-only folder, never bio-only; (b) runs the biology-ID lookup and the sheet-row write through a **bounded retry** that re-establishes a dropped connection; and (c) if Sheets stays down, returns a retryable **503** and creates nothing, rather than degrading to a bad name. The canonical-folder resolver also **fails loud** (with a clear, retryable message) rather than creating a bio-only folder when a primary can't be obtained. A "Null" turtle (a sheet row with a biology ID but no Primary ID) now has a primary minted and written to its row on its first reference photo, so its folder is born canonical. (#240)

--- a/backend/app.py
+++ b/backend/app.py
@@ -76,6 +76,17 @@ def handle_http_exception(err: HTTPException):
         {'Content-Type': 'application/json'},
     )
 
+@app.errorhandler(manager_service.SheetsServiceUnavailableError)
+def handle_sheets_unavailable(err):
+    """A transient Google Sheets outage that survived bounded retry -> 503
+    (retryable). Keeps a flaky connection from silently degrading a new turtle
+    into a non-canonical folder; the client can simply retry."""
+    return (
+        {'error': getattr(err, 'message', str(err)) or 'Google Sheets is temporarily unavailable.'},
+        getattr(err, 'status_code', 503),
+        {'Content-Type': 'application/json'},
+    )
+
 @app.errorhandler(Exception)
 def handle_exception(err):
     """Log unhandled exceptions and return JSON (works in debug mode too)."""

--- a/backend/google_sheets_service.py
+++ b/backend/google_sheets_service.py
@@ -218,8 +218,15 @@ class GoogleSheetsService:
                     )
             return created
     
-    def update_turtle_data(self, primary_id: str, turtle_data: Dict[str, Any], sheet_name: str, state: Optional[str] = None, location: Optional[str] = None) -> bool:
-        """Update existing turtle data in Google Sheets."""
+    def update_turtle_data(self, primary_id: str, turtle_data: Dict[str, Any], sheet_name: str, state: Optional[str] = None, location: Optional[str] = None, bio_id: Optional[str] = None) -> bool:
+        """Update existing turtle data in Google Sheets.
+
+        ``bio_id`` lets a "Null" turtle (a row that has a biology id but no
+        Primary ID yet) be located by its biology id when ``primary_id`` is a
+        freshly-minted value not yet present in the sheet -- so the new primary
+        gets written into that row. Scoped to ``sheet_name`` (biology ids repeat
+        across sheets, so a bio-id row lookup must never broaden past one tab).
+        """
         with self._api_lock:
             if turtle_data.get('deceased') is not None:
                 sheet_management.ensure_deceased_column(
@@ -232,7 +239,7 @@ class GoogleSheetsService:
             ok = crud.update_turtle_data(
                 self.service, self.spreadsheet_id, primary_id, turtle_data, sheet_name, state, location,
                 self._ensure_primary_id_column, self._find_row_by_primary_id, self._get_all_column_indices,
-                self._invalidate_column_indices_cache,
+                self._invalidate_column_indices_cache, bio_id=bio_id,
             )
             if ok and not self.apply_general_location_sheet_validation:
                 try:

--- a/backend/routes/review.py
+++ b/backend/routes/review.py
@@ -18,6 +18,7 @@ from image_utils import UploadImageError
 from upload_rate_limit import upload_rate_limit_ok, upload_rate_limit_response
 from upload_validation import ingest_saved_upload
 from turtle_manager import canonical_new_turtle_folder_id  # re-exported for callers/tests
+from sheets.migration import generate_primary_id as gen_primary_id  # pure (no network)
 from routes.upload import find_image_for_pt  # case-insensitive .pt→image sibling lookup
 from general_locations_catalog import (
     get_sheet_default,
@@ -483,29 +484,34 @@ def register_review_routes(app):
             id_sheet = (sd.get('sheet_name') or '').strip() or (new_location or '')
             id_state = (sd.get('general_location') or '').strip()
             id_location = (sd.get('location') or '').strip()
-            try:
-                id_service = (
-                    get_community_sheets_service() if is_community_upload
-                    else get_sheets_service()
-                )
-            except Exception as svc_err:
-                print(f"⚠️ Could not load Sheets service for id pre-resolution: {svc_err}")
-                id_service = None
-            if id_service:
-                if not canonical_primary_id:
-                    try:
-                        canonical_primary_id = id_service.generate_primary_id(id_state, id_location)
-                    except Exception as id_err:
-                        print(f"⚠️ Could not pre-generate primary_id for new turtle: {id_err}")
-                if not bio_id and id_sheet:
-                    try:
+            # Primary id is generated LOCALLY (pure timestamp+random, no network)
+            # so a Google Sheets outage can NEVER leave the new folder without a
+            # primary -> it is never born bio-only (the cross-sheet-collision
+            # case). Worst case, with no biology id, is a primary-only folder,
+            # which is globally unique and safe. The SAME value flows into the
+            # sheet row below (canonical_primary_id is reused), so folder and row
+            # always carry the same primary.
+            if not canonical_primary_id:
+                canonical_primary_id = gen_primary_id(None, None, state=id_state, location=id_location)
+            # Biology id, when the submitter didn't supply one, needs a live sheet
+            # read. Best-effort under bounded retry: a transient outage retries,
+            # and any failure just yields a primary-only folder rather than
+            # blocking the approval or minting a duplicate <gender>001.
+            if not bio_id and id_sheet:
+                try:
+                    def _gen_bio(service):
+                        if service is None:
+                            return ''
                         sex = (sd.get('sex') or '').strip().upper()
                         gender = sex if sex in ('M', 'F', 'J') else 'U'
-                        bio_id = id_service.generate_biology_id(gender, id_sheet)
-                        if isinstance(sheets_data, dict):
-                            sheets_data['id'] = bio_id
-                    except Exception as id_err:
-                        print(f"⚠️ Could not pre-generate biology id for new turtle: {id_err}")
+                        return service.generate_biology_id(gender, id_sheet)
+                    bio_id = manager_service.call_sheets_with_retry(
+                        _gen_bio, community=is_community_upload
+                    ) or bio_id
+                    if bio_id and isinstance(sheets_data, dict):
+                        sheets_data['id'] = bio_id
+                except Exception as id_err:
+                    print(f"⚠️ Could not pre-generate biology id for new turtle: {id_err}")
             new_turtle_id = canonical_new_turtle_folder_id(bio_id, canonical_primary_id, new_turtle_id)
 
         try:
@@ -530,6 +536,7 @@ def register_review_routes(app):
                 # New turtle: create row in the correct spreadsheet (research vs community).
                 # For new turtles, Sheets sync must succeed — otherwise roll back disk and keep packet.
                 sheets_sync_error = None
+                sheets_sync_exc = None
                 if is_new_turtle:
                     sheet_name = (isinstance(sheets_data, dict) and sheets_data.get('sheet_name')) or new_location
                     state = (isinstance(sheets_data, dict) and sheets_data.get('general_location')) or ''
@@ -561,6 +568,7 @@ def register_review_routes(app):
                                     print(f"✅ Created community spreadsheet entry for new turtle {new_turtle_id} with Primary ID {primary_id}")
                             except Exception as comm_err:
                                 sheets_sync_error = f"Community Google Sheets sync failed: {comm_err}"
+                                sheets_sync_exc = comm_err
                     else:
                         service = get_sheets_service()
                         if not service:
@@ -597,6 +605,7 @@ def register_review_routes(app):
                                     print(f"✅ Created Google Sheets entry for new turtle {new_turtle_id} with Primary ID {primary_id} (fallback)")
                             except Exception as sheets_error:
                                 sheets_sync_error = f"Google Sheets sync failed: {sheets_error}"
+                                sheets_sync_exc = sheets_error
 
                     # If Sheets sync failed, roll back the turtle from disk/VRAM and keep the packet
                     if sheets_sync_error:
@@ -604,6 +613,13 @@ def register_review_routes(app):
                         manager_service.manager.rollback_new_turtle(
                             new_turtle_id, new_location, photo_type=photo_type,
                         )
+                        if sheets_sync_exc is not None and manager_service.is_transient_sheets_error(sheets_sync_exc):
+                            # Transient outage: nothing was saved, so the client
+                            # can simply retry. The packet is preserved (deleted
+                            # only on success below), so the retry re-uses it.
+                            return jsonify({
+                                'error': 'Google Sheets is temporarily unavailable; nothing was saved. Please re-upload in a moment.'
+                            }), 503
                         return jsonify({
                             'error': f'Upload could not be fully completed. {sheets_sync_error}. Please re-upload.'
                         }), 500

--- a/backend/routes/sheets.py
+++ b/backend/routes/sheets.py
@@ -10,7 +10,7 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from flask import request, jsonify
 from auth import require_admin
-from services.manager_service import get_sheets_service, get_community_sheets_service
+from services.manager_service import get_sheets_service, get_community_sheets_service, is_transient_sheets_error
 from general_locations_catalog import resolve_general_location_from_sheet_and_value
 from sheets import sheet_management
 from sheets import lookup as sheets_lookup
@@ -291,6 +291,10 @@ def register_sheets_routes(app):
             except UnicodeEncodeError:
                 print(f"[ERROR] Error generating turtle ID: {str(e)}")
             print(f"Traceback:\n{error_trace}")
+            if is_transient_sheets_error(e):
+                # A genuine Sheets read failure now raises (no silent duplicate
+                # biology id) -> surface a retryable 503 instead of a bare 500.
+                return jsonify({'error': 'Google Sheets is temporarily unavailable. Please try again.'}), 503
             return jsonify({'error': f'Failed to generate turtle ID: {str(e)}'}), 500
 
     @app.route('/api/sheets/turtle', methods=['POST'])
@@ -374,6 +378,8 @@ def register_sheets_routes(app):
             except UnicodeEncodeError:
                 print(f"[ERROR] Error creating turtle data in sheets: {str(e)}")
             print(f"Traceback:\n{error_trace}")
+            if is_transient_sheets_error(e):
+                return jsonify({'error': 'Google Sheets is temporarily unavailable. Please try again.'}), 503
             return jsonify({'error': f'Failed to create turtle data: {str(e)}'}), 500
 
     @app.route('/api/sheets/turtle/<primary_id>', methods=['PUT'])
@@ -533,6 +539,8 @@ def register_sheets_routes(app):
             except UnicodeEncodeError:
                 print(f"[ERROR] Error updating turtle data in sheets: {str(e)}")
             print(f"Traceback:\n{error_trace}")
+            if is_transient_sheets_error(e):
+                return jsonify({'error': 'Google Sheets is temporarily unavailable. Please try again.'}), 503
             return jsonify({'error': f'Failed to update turtle data: {str(e)}'}), 500
 
     # Path must NOT be under /api/sheets/turtle/<id> or "lookup-options" is matched as a primary_id on some stacks.

--- a/backend/routes/turtles.py
+++ b/backend/routes/turtles.py
@@ -30,6 +30,56 @@ from turtle_folder_images import (
 )
 
 
+def _ensure_primary_for_new_sheet_turtle(turtle_id, bio_id, sheet_name):
+    """Return a real primary_id so a Sheets-browser upload that CREATES a new
+    folder makes it canonical (``<bio_id>_<primary_id>``) -- never bio-only.
+
+    Reads the turtle's sheet row by biology id (scoped to the tab = first
+    segment of the folder hint, since biology ids repeat across sheets); if the
+    row already has a Primary ID, returns it; otherwise mints one and writes it
+    into that row. Runs under bounded Sheets retry, so a transient outage raises
+    ``SheetsServiceUnavailableError`` (-> 503) instead of letting a bio-only
+    folder be created. Returns None when it can't resolve without Sheets config
+    (the caller then fails loud via the canonical-folder gate). Call this ONLY
+    when no folder exists yet and no primary_id was supplied -- minting a primary
+    for a turtle that already has a folder would diverge the sheet from disk.
+    """
+    tab = (sheet_name or '').split('/')[0].strip()
+    bio = (bio_id or turtle_id or '').strip()
+    if not tab or not bio:
+        return None
+
+    def _work(service):
+        if service is None:
+            return None
+        row = service.get_turtle_data(bio, tab)
+        if row is None:
+            # The CRUD layer swallows a transient read HttpError to None, so a
+            # None here means "couldn't read the row" (transient outage) or "row
+            # absent". Either way we must NOT mint a primary + create a folder the
+            # sheet doesn't know about -- raise so call_sheets_with_retry retries
+            # a blip and ultimately surfaces a 503, never a sheet-divergent folder.
+            raise manager_service.SheetsServiceUnavailableError(
+                "Could not read the turtle's sheet row to assign a Primary ID. Please try again."
+            )
+        existing = (row or {}).get('primary_id')
+        if existing and str(existing).strip():
+            return str(existing).strip()
+        new_pid = service.generate_primary_id()
+        # update_turtle_data returns False (it swallows a transient HttpError)
+        # rather than raising -> we MUST check it. Returning new_pid after a
+        # failed write would create a folder whose name carries a primary the
+        # sheet row never received (silent disk/sheet divergence). Raise instead
+        # so the write is retried and, if Sheets stays down, the caller gets 503.
+        if not service.update_turtle_data(new_pid, {'primary_id': new_pid}, tab, bio_id=bio):
+            raise manager_service.SheetsServiceUnavailableError(
+                "Could not write the new Primary ID to the turtle's sheet row. Please try again."
+            )
+        return new_pid
+
+    return manager_service.call_sheets_with_retry(_work)
+
+
 def register_turtle_routes(app):
     """Register turtle-related routes"""
 
@@ -468,6 +518,17 @@ def register_turtle_routes(app):
                     pass
             return upload_error_response(img_err)
         try:
+            # Null-turtle first reference photo (no folder, no primary yet):
+            # ensure a real primary so the new folder is born canonical, never
+            # bio-only. Only when no folder exists -- minting for an existing
+            # folder would diverge the sheet from disk. 503 if Sheets is down.
+            if create_if_missing and not primary_id and sheet_name:
+                mgr = manager_service.manager
+                existing = mgr._get_turtle_folder(turtle_id, sheet_name)
+                if not (existing and os.path.isdir(existing)) and bio_id and bio_id != turtle_id:
+                    existing = mgr._get_turtle_folder(bio_id, sheet_name)
+                if not (existing and os.path.isdir(existing)):
+                    primary_id = _ensure_primary_for_new_sheet_turtle(turtle_id, bio_id, sheet_name)
             success, msg = manager_service.manager.replace_turtle_reference(
                 turtle_id, temp_path, photo_type=photo_type, sheet_name=sheet_name,
                 primary_id=primary_id, create_if_missing=create_if_missing, bio_id=bio_id,
@@ -475,6 +536,8 @@ def register_turtle_routes(app):
             if not success:
                 return jsonify({'error': msg or 'Failed to replace reference'}), 400
             return jsonify({'success': True, 'message': msg})
+        except manager_service.SheetsServiceUnavailableError as e:
+            return jsonify({'error': e.message}), e.status_code
         finally:
             if os.path.isfile(temp_path):
                 try:
@@ -505,11 +568,23 @@ def register_turtle_routes(app):
         sheet_name = (request.form.get('sheet_name') or request.args.get('sheet_name') or '').strip() or None
         # Optional primary_id tried first during folder resolution.
         primary_id = (request.form.get('primary_id') or request.args.get('primary_id') or '').strip() or None
+        bio_id = (request.form.get('bio_id') or request.args.get('bio_id') or '').strip() or None
         mode = (request.form.get('mode') or request.args.get('mode') or '').strip().lower()
         if not turtle_id:
             return jsonify({'error': 'turtle_id required'}), 400
         if mode not in ('set_if_missing', 'replace'):
             return jsonify({'error': 'mode must be set_if_missing or replace'}), 400
+        # Defensive: this endpoint is not the Null-turtle first-photo path
+        # (that's /replace-reference, which auto-assigns a primary). If it would
+        # CREATE a brand-new folder, require a primary_id so the folder is born
+        # canonical (<bio_id>_<primary_id>) rather than bio-only.
+        if not primary_id:
+            existing_dir = manager_service.manager._get_turtle_folder(turtle_id, sheet_name)
+            if not (existing_dir and os.path.isdir(existing_dir)):
+                return jsonify({
+                    'error': 'primary_id is required to create a new turtle folder.',
+                    'code': 'primary_id_required',
+                }), 400
 
         if 'file' not in request.files:
             return jsonify({'error': 'No file provided'}), 400

--- a/backend/services/manager_service.py
+++ b/backend/services/manager_service.py
@@ -2,9 +2,15 @@
 Turtle Manager and Google Sheets Service initialization
 """
 
+import http.client
 import os
+import socket
+import ssl
 import threading
 import time
+
+from googleapiclient.errors import HttpError
+
 from google_sheets_service import GoogleSheetsService
 
 # Initialize Turtle Manager in background thread to avoid blocking server start
@@ -69,6 +75,110 @@ def reset_sheets_service():
     sheets_service = None
     community_sheets_service = None
     return get_sheets_service()
+
+
+# --- Sheets availability with bounded retry -------------------------------
+# A transient Sheets outage must never cause a NEW turtle to be born with a
+# non-canonical (bio-only) folder. New-turtle create points run their Sheets
+# work through call_sheets_with_retry, which retries TRANSIENT failures and,
+# if the connection can't be re-established, raises a 503 so the caller aborts
+# and creates nothing -- rather than degrading to a bio-only folder.
+
+SHEETS_RETRY_MAX_ATTEMPTS = int(os.environ.get('SHEETS_RETRY_MAX_ATTEMPTS', '3'))
+SHEETS_RETRY_BACKOFF_SEC = float(os.environ.get('SHEETS_RETRY_BACKOFF_SEC', '1.5'))
+
+
+class SheetsServiceUnavailableError(Exception):
+    """Google Sheets was reachable-but-flaky and stayed unavailable after a
+    bounded retry. Maps to HTTP 503 (retryable). PERMANENT config errors
+    (missing credentials, unset community spreadsheet id) do NOT raise this."""
+
+    def __init__(self,
+                 message="Google Sheets is temporarily unavailable. Please try again in a moment.",
+                 status_code=503):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def is_transient_sheets_error(exc):
+    """True for outages worth retrying (network/server), False for permanent
+    config/auth errors that won't fix themselves in a few seconds. Permanent
+    cases are checked FIRST because FileNotFoundError is itself an OSError."""
+    if isinstance(exc, SheetsServiceUnavailableError):
+        return True
+    # PERMANENT — never retry.
+    if isinstance(exc, (FileNotFoundError, ValueError)):
+        return False
+    msg = str(exc).lower()
+    if 'credentials' in msg and 'not found' in msg:
+        return False
+    if isinstance(exc, HttpError):
+        status = getattr(getattr(exc, 'resp', None), 'status', None)
+        try:
+            status = int(status)
+        except (TypeError, ValueError):
+            status = None
+        return status in (429, 500, 502, 503, 504)  # 401/403/404 -> permanent
+    # TRANSIENT — network/socket/SSL drops (OSError catch-all last).
+    if isinstance(exc, (ssl.SSLError, socket.timeout, http.client.IncompleteRead,
+                        ConnectionError, TimeoutError, OSError)):
+        return True
+    return False
+
+
+def _research_service_strict():
+    """Research Sheets service, constructing if needed and RAISING on failure
+    (so call_sheets_with_retry can classify/retry) instead of swallowing to
+    None like get_sheets_service()."""
+    global sheets_service
+    if sheets_service is None:
+        sheets_service = GoogleSheetsService()
+    return sheets_service
+
+
+def _community_service_strict():
+    """Community Sheets service, or None when the community spreadsheet is not
+    configured (the shipped default -- caller treats None as a skip, not an
+    error). Raises on a configured-but-failing construction."""
+    community_id = os.environ.get('GOOGLE_SHEETS_COMMUNITY_SPREADSHEET_ID', '').strip()
+    if not community_id:
+        return None
+    global community_sheets_service
+    if community_sheets_service is None:
+        community_sheets_service = GoogleSheetsService(
+            spreadsheet_id=community_id,
+            apply_general_location_sheet_validation=False,
+        )
+    return community_sheets_service
+
+
+def call_sheets_with_retry(func, *, community=False, max_attempts=None, backoff=None):
+    """Run ``func(service)`` with bounded retry on TRANSIENT Sheets failures.
+
+    ``service`` is the live GoogleSheetsService, or None when ``community`` is
+    set but the community spreadsheet is unconfigured (the caller handles that
+    as today's skip). PERMANENT errors (missing creds, 401/403/404, bad config)
+    propagate immediately so the caller maps them as it does today. When
+    transient retries are exhausted, raises ``SheetsServiceUnavailableError``
+    (HTTP 503). Between attempts the cached client is reset so the next
+    construction re-establishes a dropped connection.
+    """
+    attempts = max_attempts or SHEETS_RETRY_MAX_ATTEMPTS
+    wait = backoff if backoff is not None else SHEETS_RETRY_BACKOFF_SEC
+    last_exc = None
+    for attempt in range(attempts):
+        try:
+            service = _community_service_strict() if community else _research_service_strict()
+            return func(service)
+        except Exception as exc:  # noqa: BLE001 - classified below
+            last_exc = exc
+            if not is_transient_sheets_error(exc):
+                raise
+            if attempt < attempts - 1:
+                reset_sheets_service()
+                time.sleep(wait * (attempt + 1))
+    raise SheetsServiceUnavailableError() from last_exc
 
 
 def check_and_run_migration():

--- a/backend/sheets/crud.py
+++ b/backend/sheets/crud.py
@@ -219,7 +219,8 @@ def update_turtle_data(service, spreadsheet_id: str, primary_id: str, turtle_dat
                       state: Optional[str] = None, location: Optional[str] = None,
                       ensure_primary_id_column_func=None, find_row_by_primary_id_func=None,
                       get_all_column_indices_func=None,
-                      invalidate_column_indices_cache_func=None) -> bool:
+                      invalidate_column_indices_cache_func=None,
+                      bio_id: Optional[str] = None) -> bool:
     """
     Update existing turtle data in Google Sheets.
     
@@ -253,6 +254,13 @@ def update_turtle_data(service, spreadsheet_id: str, primary_id: str, turtle_dat
         row_idx = find_row_by_primary_id_func(sheet_name, primary_id, 'Primary ID')
         if not row_idx:
             row_idx = find_row_by_primary_id_func(sheet_name, primary_id, 'ID')
+        if not row_idx and bio_id and str(bio_id).strip():
+            # "Null" turtle: the row carries a biology id but no Primary ID yet,
+            # so a freshly-minted primary_id matches neither column. Locate the
+            # row by its biology id (scoped to this sheet -- biology ids repeat
+            # across sheets) so the new primary_id in turtle_data is written into
+            # the Primary ID cell below.
+            row_idx = find_row_by_primary_id_func(sheet_name, str(bio_id).strip(), 'ID')
         if not row_idx:
             return False
 

--- a/backend/sheets/migration.py
+++ b/backend/sheets/migration.py
@@ -3,6 +3,7 @@ Migration functions for Google Sheets
 """
 
 import re
+import secrets
 import time
 import random
 from typing import Dict, Optional, Tuple
@@ -101,11 +102,14 @@ def generate_primary_id(service, spreadsheet_id: str, list_sheets_func=None, fin
     Returns:
         New unique primary ID
     """
-    # Generate ID from timestamp + random. No need to scan all sheets (saves many API reads
-    # and avoids rate limit when adding multiple turtles). Collision probability is negligible.
+    # Millisecond timestamp + a 9-digit CRYPTOGRAPHIC random tail. The old
+    # ms + 5-digit randint(10000,99999) form had only a 90k bucket and produced
+    # confirmed same-millisecond collisions in production (Apr-22 burst); a
+    # 9-digit secrets tail makes a same-ms collision ~1e-9. Still "T" + digits,
+    # so every _PRIMARY_ID_RE / ^T\d{10,}$ matcher keeps working. No sheet scan.
     timestamp = int(time.time() * 1000)
-    random_part = random.randint(10000, 99999)
-    return f"T{timestamp}{random_part}"
+    random_part = secrets.randbelow(1_000_000_000)
+    return f"T{timestamp}{random_part:09d}"
 
 
 def get_max_biology_id_number(service, spreadsheet_id: str, sheet_name: str,
@@ -169,11 +173,14 @@ def get_max_biology_id_number(service, spreadsheet_id: str, sheet_name: str,
                     print(f"Rate limit (429) reading ID column from sheet '{sheet_name}', waiting {wait_sec}s before retry ({attempt + 1}/{SHEETS_RATE_LIMIT_MAX_RETRIES})")
                     time.sleep(wait_sec)
                     continue
-                print(f"Warning: Error reading ID column from sheet '{sheet_name}': {e}")
-                return 0
+                # A genuine (non-429) read failure must NOT silently fall through
+                # to 0 -- returning 0 mints a duplicate low biology id
+                # (<gender>001). Propagate so callers retry (transient) or fail
+                # loud. 0 is reserved for a truly-empty sheet / no ID column.
+                raise
         else:
             if last_error:
-                print(f"Warning: Error reading ID column from sheet '{sheet_name}': {last_error}")
+                raise last_error
             return 0
 
         max_num = 0
@@ -191,11 +198,13 @@ def get_max_biology_id_number(service, spreadsheet_id: str, sheet_name: str,
                 max_num = num
         return max_num
     except HttpError as e:
-        print(f"Warning: Error reading ID column from sheet '{sheet_name}': {e}")
-        return 0
+        # Do not swallow to 0 (see the inner handler) -- a Sheets read failure
+        # must not cause a duplicate biology id. Propagate to the caller.
+        print(f"Error reading ID column from sheet '{sheet_name}' (propagating, not returning 0): {e}")
+        raise
     except Exception as e:
-        print(f"Warning: Error scanning sheet '{sheet_name}' for biology ID: {e}")
-        return 0
+        print(f"Error scanning sheet '{sheet_name}' for biology ID (propagating, not returning 0): {e}")
+        raise
 
 
 def generate_biology_id(service, spreadsheet_id: str, sheet_name: str,

--- a/backend/tests/test_sheets_retry.py
+++ b/backend/tests/test_sheets_retry.py
@@ -1,0 +1,227 @@
+"""PR-A: Sheets outage must never birth a non-canonical turtle folder.
+
+Covers the new prevention layer:
+- transient/permanent classification + bounded retry (manager_service)
+- generate_primary_id collision-resistant format (migration)
+- get_max_biology_id_number raises on a read error instead of minting a dup 001
+- update_turtle_data locates a "Null" (bio-only) row via the bio_id fallback
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+import ssl
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services import manager_service as ms
+from sheets import crud, migration
+
+
+# ── transient vs permanent classification ──────────────────────────────────
+
+
+def test_is_transient_true_for_network_errors():
+    assert ms.is_transient_sheets_error(ConnectionError("drop"))
+    assert ms.is_transient_sheets_error(TimeoutError())
+    assert ms.is_transient_sheets_error(socket.timeout())
+    assert ms.is_transient_sheets_error(ssl.SSLError("handshake"))
+    assert ms.is_transient_sheets_error(ms.SheetsServiceUnavailableError())
+
+
+def test_is_transient_false_for_permanent_config_errors():
+    # FileNotFoundError is itself an OSError -> must be classified permanent.
+    assert not ms.is_transient_sheets_error(FileNotFoundError("creds.json"))
+    assert not ms.is_transient_sheets_error(ValueError("Spreadsheet ID must be provided"))
+    assert not ms.is_transient_sheets_error(Exception("Credentials file not found: x"))
+
+
+# ── call_sheets_with_retry ──────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sheets(monkeypatch):
+    """Never construct a real GoogleSheetsService or sleep in these tests."""
+    monkeypatch.setattr(ms, "_research_service_strict", lambda: object())
+    monkeypatch.setattr(ms, "reset_sheets_service", lambda: None)
+    monkeypatch.setattr(ms.time, "sleep", lambda _s: None)
+
+
+def test_retry_permanent_error_propagates_without_retrying():
+    calls = {"n": 0}
+
+    def func(_svc):
+        calls["n"] += 1
+        raise ValueError("must be provided")  # permanent
+
+    with pytest.raises(ValueError):
+        ms.call_sheets_with_retry(func, max_attempts=3)
+    assert calls["n"] == 1  # no retry on a permanent error
+
+
+def test_retry_transient_then_success():
+    calls = {"n": 0}
+
+    def func(_svc):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionError("drop")
+        return "ok"
+
+    assert ms.call_sheets_with_retry(func, max_attempts=3) == "ok"
+    assert calls["n"] == 3
+
+
+def test_retry_exhausted_raises_503():
+    def func(_svc):
+        raise ConnectionError("drop")
+
+    with pytest.raises(ms.SheetsServiceUnavailableError) as ei:
+        ms.call_sheets_with_retry(func, max_attempts=2)
+    assert ei.value.status_code == 503
+
+
+def test_retry_community_unset_passes_none_no_retry(monkeypatch):
+    monkeypatch.delenv("GOOGLE_SHEETS_COMMUNITY_SPREADSHEET_ID", raising=False)
+    seen = {}
+
+    def func(service):
+        seen["service"] = service
+        return "skip-handled-by-caller"
+
+    assert ms.call_sheets_with_retry(func, community=True) == "skip-handled-by-caller"
+    assert seen["service"] is None  # unconfigured community sheet -> None sentinel
+
+
+# ── generate_primary_id format / uniqueness ─────────────────────────────────
+
+
+def test_generate_primary_id_shape_and_uniqueness():
+    pid = migration.generate_primary_id(None, None)
+    assert re.match(r"^T\d{10,}$", pid)  # every _PRIMARY_ID_RE matcher still works
+    assert len(pid) >= 1 + 13 + 9  # ms timestamp + 9-digit secrets tail
+    # 9-digit cryptographic tail -> same-millisecond burst does not collide.
+    ids = {migration.generate_primary_id(None, None) for _ in range(200)}
+    assert len(ids) == 200
+
+
+# ── get_max_biology_id_number: raise on read error, 0 only when truly empty ──
+
+
+def test_get_max_biology_id_raises_on_read_error():
+    def boom(_sheet):
+        raise RuntimeError("transient column-index read failure")
+
+    with pytest.raises(RuntimeError):
+        migration.get_max_biology_id_number(object(), "sid", "Kansas", boom)
+
+
+def test_get_max_biology_id_zero_when_no_id_column():
+    # A genuinely-empty sheet (no 'ID' column) still returns 0 -> not an error.
+    assert migration.get_max_biology_id_number(object(), "sid", "Kansas", lambda _s: {}) == 0
+
+
+# ── update_turtle_data: locate a Null (bio-only) row by bio_id ───────────────
+
+
+@patch("sheets.crud.apply_deceased_row_background")
+@patch("sheets.crud.sheet_management.ensure_missing_columns_for_turtle_write")
+def test_update_turtle_data_bio_id_fallback_writes_new_primary(mock_ensure, mock_deceased):
+    """A freshly-minted primary isn't in the sheet yet, so it matches neither
+    the Primary ID nor the ID column -- the bio_id fallback must locate the row
+    so the new primary gets written into it."""
+    new_primary = "T" + "1" * 22
+    lookups = []
+
+    def fake_find(_sheet, value, col):
+        lookups.append((value, col))
+        return 7 if (value == "F900" and col == "ID") else None
+
+    indices = {"Primary ID": 0, "ID": 2}
+    service = MagicMock()
+    service.spreadsheets().values().get().execute.return_value = {"values": [["", "", "F900"]]}
+
+    ok = crud.update_turtle_data(
+        service, "sid", new_primary, {"primary_id": new_primary}, "Kansas",
+        ensure_primary_id_column_func=lambda _s: True,
+        find_row_by_primary_id_func=fake_find,
+        get_all_column_indices_func=lambda _s: indices,
+        invalidate_column_indices_cache_func=lambda _s=None: None,
+        bio_id="F900",
+    )
+
+    assert ok is True
+    assert ("F900", "ID") in lookups  # used the bio fallback
+    # the new primary was written into the Primary ID cell (col 0) of the row
+    written = service.spreadsheets().values().update.call_args.kwargs["body"]["values"][0]
+    assert written[0] == new_primary
+
+
+@patch("sheets.crud.apply_deceased_row_background")
+@patch("sheets.crud.sheet_management.ensure_missing_columns_for_turtle_write")
+def test_update_turtle_data_without_bio_id_still_returns_false_when_unmatched(mock_ensure, mock_deceased):
+    """No bio_id supplied + primary not in the sheet -> unchanged behavior (False)."""
+    ok = crud.update_turtle_data(
+        object(), "sid", "Tnope", {"primary_id": "Tnope"}, "Kansas",
+        ensure_primary_id_column_func=lambda _s: True,
+        find_row_by_primary_id_func=lambda *_a: None,
+        get_all_column_indices_func=lambda _s: {"Primary ID": 0, "ID": 2},
+        invalidate_column_indices_cache_func=lambda _s=None: None,
+    )
+    assert ok is False
+
+
+# ── _ensure_primary_for_new_sheet_turtle (Null-turtle mint) ─────────────────
+# The CRUD layer SWALLOWS a transient read/write HttpError to None/False (it
+# does not raise), so the helper must check those returns -- otherwise a Sheets
+# outage would mint a primary, create the on-disk folder, and leave the sheet
+# row's Primary ID empty (silent disk/sheet divergence). Caught in the PR-A
+# bug-check; these lock the fix.
+
+
+def _fake_service(**returns):
+    svc = MagicMock()
+    for name, value in returns.items():
+        getattr(svc, name).return_value = value
+    return svc
+
+
+def test_ensure_primary_returns_existing_without_writing(monkeypatch):
+    from routes import turtles as turtles_mod
+    svc = _fake_service(get_turtle_data={"id": "F900", "primary_id": "T9999999999"})
+    monkeypatch.setattr(ms, "_research_service_strict", lambda: svc)
+    pid = turtles_mod._ensure_primary_for_new_sheet_turtle("F900", "F900", "Kansas/Lawrence")
+    assert pid == "T9999999999"
+    svc.update_turtle_data.assert_not_called()
+
+
+def test_ensure_primary_mints_writes_and_scopes_to_tab(monkeypatch):
+    from routes import turtles as turtles_mod
+    svc = _fake_service(get_turtle_data={"id": "F900"},
+                        generate_primary_id="T1234567890123", update_turtle_data=True)
+    monkeypatch.setattr(ms, "_research_service_strict", lambda: svc)
+    pid = turtles_mod._ensure_primary_for_new_sheet_turtle("F900", "F900", "NebraskaCPBS/CPBS/Shredder")
+    assert pid == "T1234567890123"
+    # the sheet write is scoped to the TAB (first hint segment), not the sub-site
+    call = svc.update_turtle_data.call_args
+    assert call.args[2] == "NebraskaCPBS"
+    assert call.kwargs["bio_id"] == "F900"
+
+
+def test_ensure_primary_503_when_write_silently_fails(monkeypatch):
+    from routes import turtles as turtles_mod
+    svc = _fake_service(get_turtle_data={"id": "F900"},
+                        generate_primary_id="T1234567890123", update_turtle_data=False)
+    monkeypatch.setattr(ms, "_research_service_strict", lambda: svc)
+    with pytest.raises(ms.SheetsServiceUnavailableError):
+        turtles_mod._ensure_primary_for_new_sheet_turtle("F900", "F900", "Kansas/Lawrence")
+
+
+def test_ensure_primary_503_when_row_unreadable(monkeypatch):
+    from routes import turtles as turtles_mod
+    svc = _fake_service(get_turtle_data=None)  # swallowed transient read -> None
+    monkeypatch.setattr(ms, "_research_service_strict", lambda: svc)
+    with pytest.raises(ms.SheetsServiceUnavailableError):
+        turtles_mod._ensure_primary_for_new_sheet_turtle("F900", "F900", "Kansas/Lawrence")

--- a/backend/tests/test_turtle_plastron_upload.py
+++ b/backend/tests/test_turtle_plastron_upload.py
@@ -59,6 +59,36 @@ def test_resolve_or_create_canonical_clamps_deep_location(mgr):
     )
 
 
+def test_resolve_or_create_canonical_gate_requires_primary_for_new_folder(mgr):
+    """Born-canonical-or-fail-loud: CREATING a new folder with a bio_id but no
+    primary_id must fail loud (never a bio-only 'F901' or doubled 'F901_F901'),
+    while resolving an EXISTING folder by bare bio_id still works without a
+    primary (the gate is create-only)."""
+    # No folder yet + bio_id + no primary -> refuse, with a clear reason.
+    turtle_dir, created, reason = mgr.resolve_or_create_canonical_turtle_dir(
+        "F901", "Kansas/Lawrence", primary_id=None, bio_id="F901"
+    )
+    assert turtle_dir is None and created is False
+    assert reason and "Primary ID" in reason
+    assert not os.path.isdir(os.path.join(mgr.base_dir, "Kansas", "Lawrence", "F901"))
+    assert not os.path.isdir(os.path.join(mgr.base_dir, "Kansas", "Lawrence", "F901_F901"))
+
+    # With a primary it is born canonical.
+    turtle_dir, created, reason = mgr.resolve_or_create_canonical_turtle_dir(
+        "F901", "Kansas/Lawrence", primary_id="T1771234901", bio_id="F901"
+    )
+    assert created is True and reason is None
+    expected = os.path.join(mgr.base_dir, "Kansas", "Lawrence", "F901_T1771234901")
+    assert os.path.normpath(turtle_dir) == os.path.normpath(expected)
+
+    # An EXISTING folder still resolves by bare bio_id with no primary.
+    again, created2, reason2 = mgr.resolve_or_create_canonical_turtle_dir(
+        "F901", "Kansas/Lawrence", primary_id=None, bio_id="F901"
+    )
+    assert created2 is False and reason2 is None
+    assert os.path.normpath(again) == os.path.normpath(expected)
+
+
 def test_set_identifier_first_plastron(mgr, tmp_path):
     src = tmp_path / "in.jpg"
     src.write_bytes(b"\xff\xd8\xff fakejpeg")

--- a/backend/turtle_manager.py
+++ b/backend/turtle_manager.py
@@ -2570,6 +2570,17 @@ class TurtleManager:
         location_dir = _resolved_path_under_base(self.base_dir, *rel_parts)
         if not location_dir:
             return None, False, "could not resolve a safe folder path"
+        # Born-canonical-or-fail-loud: never CREATE a new folder named by bio_id
+        # alone. bio_ids repeat across sheets, so a bio-only ("F276" / "F276_F276")
+        # folder is a cross-sheet collision risk -- require the globally-unique
+        # primary_id. The existing-folder branch above already returned, so
+        # resolving a KNOWN turtle by a bare bio_id still works without a primary.
+        if (bio_id or '').strip() and not (primary_id or '').strip():
+            return None, False, (
+                "Can't create a canonical turtle folder without a Primary ID. "
+                "If Google Sheets was momentarily unavailable, try again in a "
+                "moment; otherwise assign this turtle a Primary ID first."
+            )
         folder_name = canonical_new_turtle_folder_id(bio_id, primary_id, tid)
         turtle_dir = _resolved_path_under_base(location_dir, folder_name)
         if not turtle_dir:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picturfrontend",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picturfrontend",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "dependencies": {
         "@mantine/code-highlight": "^8.3.5",
         "@mantine/core": "^8.3.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "picturfrontend",
   "private": true,
-  "version": "2.0.15",
+  "version": "2.0.16",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

A transient Google Sheets outage while approving or uploading a new turtle could create a folder with a **bio-only** name (`F276`, `F276_F276`) instead of canonical `<bio_id>_<primary_id>`. Because biology IDs repeat across sheets (Kansas `F102` ≠ Nebraska `F102`), a bio-only folder is a cross-sheet contamination risk. This makes new-turtle creation **born-canonical-or-fail-loud**, never degrading to a bad name when Sheets is flaky. Addresses the in-app code portion of #240 (the existing-data cleanup remains manual).

- **Bounded Sheets retry** (`services/manager_service.py`): `call_sheets_with_retry` + a transient/permanent classifier + `SheetsServiceUnavailableError`; a central `app.py` handler maps it to a retryable **503**. New-turtle create points retry a transient blip and, if Sheets stays down, abort and create nothing.
- **`review.py` new-turtle approve**: the `primary_id` is generated **locally** (pure timestamp+random, no network) so the folder always carries a real primary — worst case a safe primary-only folder, never bio-only. The biology ID is fetched under bounded retry; a transient sheet-row write rolls back disk and returns 503.
- **`resolve_or_create_canonical_turtle_dir`**: the *create* branch fails loud (clear, retryable message) when a `bio_id` is present but `primary_id` is empty — never `F276`/`F276_F276`. Existing-folder resolution is unchanged.
- **Null-turtle first photo**: mints + writes a `primary_id` to the turtle's sheet row (`update_turtle_data` gains a scoped `bio_id` row-lookup fallback) so the folder is born canonical. The mint helper **raises** (→ retry → 503) instead of returning a primary the sheet never received, so an outage can't diverge disk from sheet.
- **ID hardening**: `generate_primary_id` now uses a 9-digit `secrets` tail (was a 5-digit `randint` — the source of confirmed same-millisecond collisions); `get_max_biology_id_number` raises on a genuine read error instead of returning `0` (which minted a duplicate `<gender>001`). The four `sheets.py` create-turtle endpoints return a retryable 503 on a transient blip.

Cross-sheet fail-closed scoping and the `State/Location/<turtle>` folder-depth clamp are preserved. 235 backend unit tests pass, including a new `test_sheets_retry.py`. Reviewed via the multi-agent bug-check; the one blocker it surfaced (an unchecked `update_turtle_data` return that could diverge disk from sheet during an outage) is fixed in this branch.

Refs #240