### PR TITLE
fix(frontend): restore "Date Last Assayed" on the turtle profile form + Release 2.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.17] - 2026-06-17 — Restore "Date Last Assayed" on the profile form
+
 ### Fixed
 
 - **"Date Last Assayed" reappears on the turtle profile form**: the `Last Assay Date` field was missing from the Sheets Browser / Turtle Records (profile) form and only showed on the Turtle Match form. The April research-schema refactor split the single form field-order into separate full-sheet and Match lists and, in doing so, dropped `last_assay_date` from the full-sheet list while keeping it on Match. It is now restored to the profile form in canonical column order (after `iButton Last set`). Existing turtles' values were never lost — the field is read and written normally; it was only hidden from this form. (#239)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Date Last Assayed" reappears on the turtle profile form**: the `Last Assay Date` field was missing from the Sheets Browser / Turtle Records (profile) form and only showed on the Turtle Match form. The April research-schema refactor split the single form field-order into separate full-sheet and Match lists and, in doing so, dropped `last_assay_date` from the full-sheet list while keeping it on Match. It is now restored to the profile form in canonical column order (after `iButton Last set`). Existing turtles' values were never lost — the field is read and written normally; it was only hidden from this form. (#239)
+
 ## [2.0.16] - 2026-06-12 — Born-canonical turtle naming under Sheets outages
 
 ### Fixed

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picturfrontend",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picturfrontend",
-      "version": "2.0.16",
+      "version": "2.0.17",
       "dependencies": {
         "@mantine/code-highlight": "^8.3.5",
         "@mantine/core": "^8.3.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "picturfrontend",
   "private": true,
-  "version": "2.0.16",
+  "version": "2.0.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/turtleSheetsFormLayout.ts
+++ b/frontend/src/components/turtleSheetsFormLayout.ts
@@ -25,6 +25,7 @@ export const FULL_SHEET_FORM_FIELD_ORDER: TurtleFormOrderKey[] = [
   'name',
   'sex',
   'ibutton_last_set',
+  'last_assay_date',
   '__dates_refound__',
   'specific_location',
   'general_location',


### PR DESCRIPTION
## Summary

The **Last Assay Date** ("Date Last Assayed") field was missing from the Sheets Browser / Turtle Records (profile) form and only appeared on the Turtle Match form. The April research-schema refactor (`7c42055`) split the single form field-order into separate full-sheet and Match lists and, in doing so, dropped `last_assay_date` from the full-sheet list (`FULL_SHEET_FORM_FIELD_ORDER`) while keeping it on Match. This re-adds it in canonical column order (after `iButton Last set`).

Display-only fix — the field's data was always read and written (it's mapped in `backend/sheets/columns.py` and round-trips through the API and the field config already exists); it was only hidden from this form. A research sweep confirmed `last_assay_date` is the **only** field that refactor dropped from the profile form.

Cuts Release 2.0.17.

Closes #239