### PR TITLE
Carapace-only quick check (admin, read-only) — v2.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.21] - 2026-07-07 — Carapace-only quick check
+
+### Added
+
+- **Carapace-only quick check (admin)**: a new switch on the photo-upload screen, just below "Mortality without plastron ID", puts the page into a clearly-marked read-only carapace mode. The admin picks a location scope and uploads a photo exactly like normal, but matching runs against **only the carapace reference pool** and returns the usual ranked candidates; clicking a candidate opens the same enlarged side-by-side comparison used on the match page. The whole mode is strictly read-only — no review-queue packet is created, the query photo is never stored (server temp deleted immediately after matching), and no select/approve/create-turtle/replace-reference/add-images action exists anywhere in the flow. Backing out returns to the normal plastron flow (mode and results reset; the chosen location is kept). Backend: new admin-only `POST /api/match/quick-check` endpoint that reuses the existing carapace matcher and the case-insensitive `.pt`→image lookup.
+
 ## [2.0.20] - 2026-07-07 — Streaming offline-backup ZIP download
 
 ### Fixed
@@ -615,7 +621,9 @@ Major bump merging the SuperPoint implementation: **VLAD/FAISS → SuperPoint + 
 - **Documentation**: README with quick start (Docker and local), functionality overview, and versioning guide in `docs/VERSION_AND_RELEASES.md`.
 - Version control and release process: `CHANGELOG.md`, version in `frontend/package.json`, and guide in `docs/VERSION_AND_RELEASES.md`.
 
-[Unreleased]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.19...HEAD
+[Unreleased]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.21...HEAD
+[2.0.21]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.20...v2.0.21
+[2.0.20]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.19...v2.0.20
 [2.0.19]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.18...v2.0.19
 [2.0.18]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.17...v2.0.18
 [2.0.17]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.16...v2.0.17

--- a/README.md
+++ b/README.md
@@ -208,29 +208,35 @@ You need to run **all three services** simultaneously:
    - If a carapace photo is attached as an additional image, a **Cross-check carapace** button runs a parallel carapace search and displays both result sets side-by-side, flagging disagreements
    - Admin selects the best match (optionally marking the upload as the new reference) or creates a new turtle
 
-2. **Review Queue**:
+2. **Carapace-only quick check (read-only)**:
+
+   - A switch below "Mortality without plastron ID" puts the upload page into a clearly-marked carapace-only mode (orange banner)
+   - Pick a location scope and upload a carapace photo like normal — matching runs against **only the carapace reference pool** and returns the ranked candidates; clicking one opens the same enlarged side-by-side comparison as the match page
+   - Strictly read-only: nothing is saved (no review-queue packet, no stored query photo) and no select/approve/create/replace action exists in this mode; backing out returns to the normal plastron flow
+
+3. **Review Queue**:
 
    - Admin sees all community uploads, ordered by upload date
    - Community photos arrive as `unclassified` — admin classifies each as **Plastron** or **Carapace** (or trashes it) before matching runs against the correct VRAM cache
    - Each upload lists its top 5 suggested matches and any additional photos the community user included
    - Cross-check flow: if the community upload also has a plastron additional image, **Cross-check with plastron** runs both searches
 
-3. **Google Sheets Browser (Turtle Records)**:
+4. **Google Sheets Browser (Turtle Records)**:
    - Browse all turtles from Google Sheets with primary plastron thumbnails
    - Select a turtle to edit its sheet data and manage its photos end-to-end
    - **Additional Turtle Photos** section: drop new plastron, carapace, microhabitat, condition, or generic additional photos onto a turtle. *Every* photo-type button routes through the **Pending photos (uncommitted)** box first — nothing is written to the turtle until the admin presses **Update Turtle**. Plastron and Carapace uploads additionally open a modal asking whether to replace the existing reference (**Yes, replace** archives the old reference to `plastron/Old References/` or `carapace/Old References/`; **No, save as Other** routes the photo to the Other folder). The pending box has a reserved slot for the tagging UI (rename-on-commit).
    - The Additional pane resets every calendar day — it only lists uploads from the current local date. Older day-folders remain visible via **View Old Turtle Photos** below.
    - **View Old Turtle Photos** section: a date dropdown lists every date this turtle has a photo on file (EXIF "when taken" dates preferred, upload dates as fallback). Selecting a date shows all thumbnails from that day alongside their source (`Old Plastron Ref`, `Other Carapace`, `Microhabitat`, etc.). Active plastron and carapace references are included under their capture date with a **(active)** badge.
 
-4. **Create New Turtle** (from either the Admin Match page or the Sheets Browser):
+5. **Create New Turtle** (from either the Admin Match page or the Sheets Browser):
    - Between the auto-generated Primary ID and the Google Sheets form, a **Photos for this upload** panel offers Microhabitat / Condition / Carapace / Additional upload buttons and displays any photos already attached to the packet. Admins can correct a forgotten photo at creation time instead of discovering the gap post-approval.
    - All sheet-data fields start **fully editable** — the per-field click-to-unlock flow only applies when *editing* an existing turtle.
 
-5. **Admin Match Page — Match Selected view**:
+6. **Admin Match Page — Match Selected view**:
    - Order top-to-bottom: uploaded-vs-candidate comparison → **Additional Photos** panel → **Replace plastron / carapace reference** checkboxes → Google Sheets data form → action buttons (Cancel / Save to Sheets & Confirm Match / Create New Turtle Instead). The replace-reference decision sits directly under the photos it affects.
    - Each candidate card (plastron and cross-checked carapace) shows the on-disk biology id, the turtle's **chosen name** from Google Sheets when set, and the auto-generated **Primary ID** when distinct from the biology id, plus location and confidence. Per-candidate name/Primary ID is read from Sheets in parallel after the match list resolves; Sheets writes are never made from this page.
 
-6. **Backup countdown overlay (staff + admin only)**:
+7. **Backup countdown overlay (staff + admin only)**:
    - Five minutes before the nightly chronodrop kicks off (`03:00` server time by default), an orange floating badge appears bottom-right on every admin page with a live `mm:ss` countdown and the message *"Server backup in X:XX — please save your work."*
    - At T-0 the overlay flips to a full-screen un-dismissable modal (*"Nightly backup is running — the system will resume automatically"*) that blocks interaction while the chronodrop runs and, when needed, while the backend container restarts to pick up renamed turtle folders.
    - The modal polls the backend's health endpoint every 5 seconds and dismisses itself the moment the server is back up *and* the expected duration has elapsed. After 10 minutes of stalled maintenance it surfaces a contact-admin hint.

--- a/backend/image_utils.py
+++ b/backend/image_utils.py
@@ -194,7 +194,9 @@ def _repair_to_jpeg(path: str, original_exc: Exception | None = None) -> str:
     try:
         rgb = _to_rgb(im)
         dest = _save_ingest_jpeg(rgb, path, quality=90)
-        if dest != path and os.path.isfile(path):
+        # normcase: on Windows 'X.JPG' and 'X.jpg' are the SAME file — a plain
+        # string compare would delete the JPEG that was just written.
+        if os.path.normcase(dest) != os.path.normcase(path) and os.path.isfile(path):
             try:
                 os.remove(path)
             except OSError:
@@ -230,7 +232,9 @@ def _resize_ingest_if_needed(path):
             dest = os.path.splitext(path)[0] + '.jpg'
             _save_ingest_jpeg(im, dest, quality=88)
 
-        if dest != path and os.path.isfile(path):
+        # normcase: on Windows 'X.JPG' and 'X.jpg' are the SAME file — a plain
+        # string compare would delete the JPEG that was just written.
+        if os.path.normcase(dest) != os.path.normcase(path) and os.path.isfile(path):
             try:
                 os.remove(path)
             except OSError:

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -14,7 +14,7 @@ import uuid
 from flask import request, jsonify
 from werkzeug.utils import secure_filename
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
-from auth import optional_auth, check_auth_revocation
+from auth import optional_auth, check_auth_revocation, require_admin_only
 from image_utils import UploadImageError
 from upload_rate_limit import upload_rate_limit_ok, upload_rate_limit_response
 from upload_validation import ingest_saved_upload, log_upload_rejection, upload_error_response
@@ -455,3 +455,117 @@ def register_upload_routes(app):
                 'code': 'processing_failed',
                 'details': error_trace if app.debug else None,
             }), 500
+
+    @app.route('/api/match/quick-check', methods=['POST'])
+    @require_admin_only
+    def quick_check_match():
+        """Carapace-only quick check (admin only, strictly read-only).
+
+        Runs a fresh photo against the carapace VRAM cache and returns the
+        ranked candidates. Unlike /api/upload, this persists NOTHING: no
+        review-queue packet, no metadata.json, no candidate copies — the
+        temp upload is deleted in the finally block.
+        """
+        if not manager_service.manager_ready.wait(timeout=30):
+            return jsonify({'error': 'TurtleManager is still initializing. Please try again in a moment.'}), 503
+
+        if manager_service.manager is None:
+            return jsonify({'error': 'TurtleManager is not ready. Please try again in a moment.'}), 503
+
+        if 'file' not in request.files:
+            return jsonify({'error': 'No file provided'}), 400
+
+        file = request.files['file']
+        if not file.filename:
+            return jsonify({'error': 'No file selected'}), 400
+
+        if not allowed_file(file.filename):
+            log_upload_rejection(
+                context='api/match/quick-check',
+                path=None,
+                code='invalid_extension',
+                message='Invalid file type',
+                filename=file.filename,
+            )
+            return jsonify({
+                'error': 'Invalid file type. Allowed: JPEG, PNG, GIF, WEBP, HEIC.',
+                'code': 'invalid_extension',
+            }), 400
+
+        file.seek(0, os.SEEK_END)
+        file_size = file.tell()
+        file.seek(0)
+        if file_size > MAX_FILE_SIZE:
+            log_upload_rejection(
+                context='api/match/quick-check',
+                path=None,
+                code='file_too_large',
+                message=f'File exceeds {MAX_FILE_SIZE} bytes',
+                filename=file.filename,
+            )
+            return jsonify({
+                'error': 'File too large (max 8MB after optimization).',
+                'code': 'file_too_large',
+            }), 400
+
+        match_sheet = (request.form.get('match_sheet') or '').strip() or None
+
+        # Unique temp prefix: the backend serves requests concurrently
+        # (threaded=True), so the bare secure_filename pattern used by
+        # /api/upload could collide across simultaneous quick checks. The
+        # prefix also drives cleanup: ingest may RENAME the temp (e.g.
+        # .HEIC/.JPG → .jpg) before failing, so deleting only temp_path
+        # could orphan the converted sibling.
+        filename = secure_filename(file.filename)
+        temp_prefix = f"quickcheck_{uuid.uuid4().hex[:8]}_"
+        temp_path = os.path.join(UPLOAD_FOLDER, temp_prefix + filename)
+        try:
+            file.save(temp_path)
+            try:
+                temp_path = ingest_saved_upload(
+                    temp_path, context='api/match/quick-check', filename=file.filename,
+                )
+            except UploadImageError as img_err:
+                return upload_error_response(img_err)
+
+            results, elapsed = manager_service.manager.search_for_matches(
+                temp_path,
+                location_filter=match_sheet,
+                photo_type='carapace',
+                expand_to_all_when_short=True,
+            )
+
+            formatted = []
+            for match in results:
+                pt_path = match.get('file_path', '') or ''
+                formatted.append({
+                    'turtle_id': match.get('site_id', 'Unknown'),
+                    'location': (match.get('location') or 'Unknown').strip() or 'Unknown',
+                    'confidence': float(match.get('confidence', 0.0)),
+                    'score': int(match.get('score', 0)),
+                    # Case-insensitive .pt→image lookup (Linux prod is
+                    # case-sensitive; carapace refs are often .JPG).
+                    'image_path': find_image_for_pt(pt_path),
+                })
+
+            return jsonify({
+                'success': True,
+                'photo_type': 'carapace',
+                'matches': formatted,
+                'elapsed': round(elapsed, 2),
+            })
+        except Exception as e:
+            error_trace = traceback.format_exc()
+            sys.stderr.write(f"[QUICK CHECK 500] {str(e)}\n{error_trace}")
+            sys.stderr.flush()
+            return jsonify({'error': f'Quick check failed: {str(e)}'}), 500
+        finally:
+            try:
+                for fname in os.listdir(UPLOAD_FOLDER):
+                    if fname.startswith(temp_prefix):
+                        try:
+                            os.remove(os.path.join(UPLOAD_FOLDER, fname))
+                        except OSError:
+                            pass
+            except OSError:
+                pass

--- a/backend/tests/test_image_utils.py
+++ b/backend/tests/test_image_utils.py
@@ -166,6 +166,25 @@ def test_process_uploaded_image_shrinks_oversized_jpeg(tmp_path):
         assert max(im.size) <= 2560
 
 
+def test_process_uploaded_image_uppercase_jpg_survives_resize(tmp_path):
+    """Oversized '.JPG' input: the resized output must survive.
+
+    On a case-insensitive filesystem (Windows dev) 'big.JPG' and the resize
+    destination 'big.jpg' are the SAME file — the old plain string compare
+    deleted the freshly written JPEG, so matching later read nothing.
+
+    NOTE: this only catches the regression when run on a case-insensitive
+    filesystem (Windows/macOS dev) — on Linux CI the old code also passed,
+    because there the two names really are different files.
+    """
+    path = tmp_path / 'big.JPG'
+    Image.new('RGB', (4000, 3000)).save(str(path), 'JPEG', quality=95)
+    result = process_uploaded_image(str(path))
+    assert os.path.isfile(result)
+    with Image.open(result) as im:
+        assert max(im.size) <= 2560
+
+
 # ---------- Module exports ----------
 
 

--- a/backend/tests/test_quick_check_route.py
+++ b/backend/tests/test_quick_check_route.py
@@ -1,0 +1,325 @@
+"""
+Unit tests for POST /api/match/quick-check — the admin-only, strictly
+read-only carapace quick check. Pins: strict-admin auth (staff must be
+rejected), carapace photo_type forwarding, cross-check-style response shape,
+case-insensitive .pt→image resolution, zero review-queue writes, and
+temp-file cleanup on success and error paths.
+"""
+
+import io
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+
+import config
+from image_utils import UploadImageError
+
+
+def _bearer(role):
+    token = jwt.encode(
+        {"role": role, "sub": f"pytest-quick-check-{role}"},
+        config.JWT_SECRET,
+        algorithm="HS256",
+    )
+    return token if isinstance(token, str) else token.decode("ascii")
+
+
+def _auth(role):
+    return {"Authorization": f"Bearer {_bearer(role)}"}
+
+
+def _file_payload(name="query.jpg", extra=None):
+    payload = {"file": (io.BytesIO(b"\xff\xd8\xff\xe0 fake jpeg bytes"), name)}
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+@pytest.fixture
+def app_client():
+    from app import app
+
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+@pytest.fixture
+def quick_check_env(tmp_path):
+    """Patched upload folder, identity ingest, revocation OK, ready mock manager."""
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+    review_dir = tmp_path / "review_queue"
+    review_dir.mkdir()
+
+    mock_manager = MagicMock()
+    mock_manager.review_queue_dir = str(review_dir)
+    mock_manager.search_for_matches.return_value = ([], 0.42)
+
+    with patch("auth.check_auth_revocation", return_value=(True, None)), \
+            patch("routes.upload.UPLOAD_FOLDER", str(upload_dir)), \
+            patch("routes.upload.ingest_saved_upload", side_effect=lambda p, **kw: p), \
+            patch("routes.upload.manager_service.manager", mock_manager), \
+            patch("routes.upload.manager_service.manager_ready") as ready:
+        ready.wait.return_value = True
+        yield {
+            "manager": mock_manager,
+            "upload_dir": upload_dir,
+            "review_dir": review_dir,
+        }
+
+
+def test_requires_token(app_client, quick_check_env):
+    r = app_client.post(
+        "/api/match/quick-check",
+        data=_file_payload(),
+        content_type="multipart/form-data",
+    )
+    assert r.status_code == 401
+
+
+@pytest.mark.parametrize("role", ["community", "staff"])
+def test_non_admin_forbidden(app_client, quick_check_env, role):
+    """Staff must be rejected too — the quick check is strict-admin."""
+    r = app_client.post(
+        "/api/match/quick-check",
+        data=_file_payload(),
+        content_type="multipart/form-data",
+        headers=_auth(role),
+    )
+    assert r.status_code == 403
+    assert quick_check_env["manager"].search_for_matches.call_count == 0
+
+
+def test_admin_ok_and_forwards_carapace_scope(app_client, quick_check_env):
+    manager = quick_check_env["manager"]
+    r = app_client.post(
+        "/api/match/quick-check",
+        data=_file_payload(extra={"match_sheet": "Kansas"}),
+        content_type="multipart/form-data",
+        headers=_auth("admin"),
+    )
+    assert r.status_code == 200, r.get_json()
+    body = r.get_json()
+    assert body["success"] is True
+    assert body["photo_type"] == "carapace"
+    assert body["matches"] == []
+    assert "elapsed" in body
+
+    manager.search_for_matches.assert_called_once()
+    kwargs = manager.search_for_matches.call_args.kwargs
+    assert kwargs["location_filter"] == "Kansas"
+    assert kwargs["photo_type"] == "carapace"
+    assert kwargs["expand_to_all_when_short"] is True
+
+
+def test_empty_match_sheet_means_all_locations(app_client, quick_check_env):
+    manager = quick_check_env["manager"]
+    r = app_client.post(
+        "/api/match/quick-check",
+        data=_file_payload(extra={"match_sheet": ""}),
+        content_type="multipart/form-data",
+        headers=_auth("admin"),
+    )
+    assert r.status_code == 200
+    assert manager.search_for_matches.call_args.kwargs["location_filter"] is None
+
+
+def test_response_shape_and_uppercase_jpg_resolution(
+    app_client, quick_check_env, tmp_path
+):
+    """image_path must resolve .pt → sibling image case-insensitively (real helper)."""
+    ref_dir = tmp_path / "Kansas" / "North Topeka" / "F128_T123" / "carapace"
+    ref_dir.mkdir(parents=True)
+    pt_path = ref_dir / "F128.pt"
+    pt_path.write_bytes(b"pt")
+    (ref_dir / "F128.JPG").write_bytes(b"jpg")
+
+    quick_check_env["manager"].search_for_matches.return_value = (
+        [
+            {
+                "site_id": "F128",
+                "location": "Kansas/North Topeka",
+                "confidence": 0.87,
+                "score": 412,
+                "file_path": str(pt_path),
+            }
+        ],
+        1.234,
+    )
+    r = app_client.post(
+        "/api/match/quick-check",
+        data=_file_payload(),
+        content_type="multipart/form-data",
+        headers=_auth("admin"),
+    )
+    assert r.status_code == 200
+    match = r.get_json()["matches"][0]
+    assert match["turtle_id"] == "F128"
+    assert match["location"] == "Kansas/North Topeka"
+    assert match["confidence"] == pytest.approx(0.87)
+    assert match["score"] == 412
+    assert match["image_path"].endswith("F128.JPG")
+
+
+def test_no_review_queue_writes(app_client, quick_check_env):
+    manager = quick_check_env["manager"]
+    r = app_client.post(
+        "/api/match/quick-check",
+        data=_file_payload(extra={"match_sheet": "Kansas"}),
+        content_type="multipart/form-data",
+        headers=_auth("admin"),
+    )
+    assert r.status_code == 200
+    assert list(quick_check_env["review_dir"].iterdir()) == []
+    manager.create_review_packet.assert_not_called()
+    manager.add_additional_images_to_packet.assert_not_called()
+    manager.approve_review_packet.assert_not_called()
+
+
+def test_temp_cleaned_after_success(app_client, quick_check_env):
+    r = app_client.post(
+        "/api/match/quick-check",
+        data=_file_payload(),
+        content_type="multipart/form-data",
+        headers=_auth("admin"),
+    )
+    assert r.status_code == 200
+    assert list(quick_check_env["upload_dir"].iterdir()) == []
+
+
+def test_temp_sweep_spares_other_uploads(app_client, quick_check_env):
+    """The finally-sweep must be scoped to THIS request's unique prefix —
+    other in-flight uploads' temps (including other quick checks) survive."""
+    foreign_plain = quick_check_env["upload_dir"] / "someone_elses_upload.jpg"
+    foreign_plain.write_bytes(b"other request temp")
+    foreign_quickcheck = quick_check_env["upload_dir"] / "quickcheck_deadbeef_other.jpg"
+    foreign_quickcheck.write_bytes(b"concurrent quick check temp")
+
+    r = app_client.post(
+        "/api/match/quick-check",
+        data=_file_payload(),
+        content_type="multipart/form-data",
+        headers=_auth("admin"),
+    )
+    assert r.status_code == 200
+    survivors = sorted(p.name for p in quick_check_env["upload_dir"].iterdir())
+    assert survivors == ["quickcheck_deadbeef_other.jpg", "someone_elses_upload.jpg"]
+
+
+def test_temp_cleaned_after_matcher_error(app_client, quick_check_env):
+    quick_check_env["manager"].search_for_matches.side_effect = RuntimeError("boom")
+    r = app_client.post(
+        "/api/match/quick-check",
+        data=_file_payload(),
+        content_type="multipart/form-data",
+        headers=_auth("admin"),
+    )
+    assert r.status_code == 500
+    assert "Quick check failed" in r.get_json()["error"]
+    assert list(quick_check_env["upload_dir"].iterdir()) == []
+
+
+def test_oversized_file_rejected(app_client, quick_check_env):
+    with patch("routes.upload.MAX_FILE_SIZE", 10):
+        r = app_client.post(
+            "/api/match/quick-check",
+            data=_file_payload(),
+            content_type="multipart/form-data",
+            headers=_auth("admin"),
+        )
+    assert r.status_code == 400
+    assert r.get_json()["code"] == "file_too_large"
+    assert list(quick_check_env["upload_dir"].iterdir()) == []
+
+
+def test_full_file_saved_after_size_probe(app_client, quick_check_env):
+    """The size check seeks to EOF; without the seek(0) rewind the saved temp
+    would be 0 bytes and matching would silently see an empty file."""
+    import os
+
+    saved_sizes = []
+
+    def record_size(path, **kwargs):
+        saved_sizes.append(os.path.getsize(path))
+        return path
+
+    payload = _file_payload()
+    expected_size = payload["file"][0].getbuffer().nbytes
+    with patch("routes.upload.ingest_saved_upload", side_effect=record_size):
+        r = app_client.post(
+            "/api/match/quick-check",
+            data=payload,
+            content_type="multipart/form-data",
+            headers=_auth("admin"),
+        )
+    assert r.status_code == 200
+    assert saved_sizes == [expected_size]
+    assert expected_size > 0
+
+
+def test_missing_file_rejected(app_client, quick_check_env):
+    r = app_client.post(
+        "/api/match/quick-check",
+        data={},
+        content_type="multipart/form-data",
+        headers=_auth("admin"),
+    )
+    assert r.status_code == 400
+
+
+def test_bad_extension_rejected(app_client, quick_check_env):
+    r = app_client.post(
+        "/api/match/quick-check",
+        data={"file": (io.BytesIO(b"not an image"), "notes.txt")},
+        content_type="multipart/form-data",
+        headers=_auth("admin"),
+    )
+    assert r.status_code == 400
+    assert r.get_json()["code"] == "invalid_extension"
+    assert list(quick_check_env["upload_dir"].iterdir()) == []
+
+
+def test_ingest_error_returns_structured_400_and_cleans_temp(
+    app_client, quick_check_env
+):
+    with patch(
+        "routes.upload.ingest_saved_upload",
+        side_effect=UploadImageError(
+            "image_unreadable", "Uploaded image could not be decoded."
+        ),
+    ):
+        r = app_client.post(
+            "/api/match/quick-check",
+            data=_file_payload(),
+            content_type="multipart/form-data",
+            headers=_auth("admin"),
+        )
+    assert r.status_code == 400
+    assert r.get_json()["code"] == "image_unreadable"
+    assert list(quick_check_env["upload_dir"].iterdir()) == []
+
+
+def test_ingest_rename_then_crash_returns_json_500_and_sweeps_temp(
+    app_client, quick_check_env
+):
+    """Ingest can RENAME the temp (HEIC/.JPG → .jpg) and then raise a
+    non-UploadImageError (e.g. disk full). The route must still return the
+    structured JSON 500 and sweep the renamed sibling, not orphan it."""
+    import os
+
+    def rename_then_boom(path, **kwargs):
+        renamed = os.path.splitext(path)[0] + ".jpg.partial"
+        os.rename(path, renamed)
+        raise OSError(28, "No space left on device")
+
+    with patch("routes.upload.ingest_saved_upload", side_effect=rename_then_boom):
+        r = app_client.post(
+            "/api/match/quick-check",
+            data=_file_payload(),
+            content_type="multipart/form-data",
+            headers=_auth("admin"),
+        )
+    assert r.status_code == 500
+    assert "Quick check failed" in r.get_json()["error"]
+    assert list(quick_check_env["upload_dir"].iterdir()) == []

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picturfrontend",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picturfrontend",
-      "version": "2.0.20",
+      "version": "2.0.21",
       "dependencies": {
         "@mantine/code-highlight": "^8.3.5",
         "@mantine/core": "^8.3.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "picturfrontend",
   "private": true,
-  "version": "2.0.20",
+  "version": "2.0.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/CarapaceQuickCheckResults.tsx
+++ b/frontend/src/components/CarapaceQuickCheckResults.tsx
@@ -1,0 +1,200 @@
+import {
+  Alert,
+  Badge,
+  Button,
+  Center,
+  Divider,
+  Group,
+  Loader,
+  Paper,
+  SimpleGrid,
+  Stack,
+  Text,
+} from '@mantine/core';
+import { IconArrowLeft, IconEyeCheck, IconAlertCircle } from '@tabler/icons-react';
+import { MatchCandidateCard } from '../pages/AdminTurtleMatch/MatchCandidateCard';
+import { TurtleImageComparePair } from './TurtleImageComparePair';
+import { getImageUrl } from '../services/api';
+import type { QuickCheckMatch } from '../services/api';
+import type { QuickCheckStatus } from '../hooks/useCarapaceQuickCheck';
+
+interface CarapaceQuickCheckResultsProps {
+  status: Exclude<QuickCheckStatus, 'idle'>;
+  error: string | null;
+  /** Local preview data URL of the uploaded photo — rendered raw, never persisted. */
+  queryPreviewUrl: string;
+  matches: QuickCheckMatch[];
+  elapsed: number | null;
+  selectedIndex: number | null;
+  onSelect: (index: number | null) => void;
+  onBack: () => void;
+}
+
+/** True when the backend found no sibling image for the reference tensor. */
+function hasNoImage(match: QuickCheckMatch): boolean {
+  return !match.image_path || match.image_path.endsWith('.pt');
+}
+
+/**
+ * Read-only results for the carapace quick check. Reuses the live match-page
+ * components (MatchCandidateCard, TurtleImageComparePair) but exposes no
+ * write affordance: view and click-to-compare only.
+ */
+export function CarapaceQuickCheckResults({
+  status,
+  error,
+  queryPreviewUrl,
+  matches,
+  elapsed,
+  selectedIndex,
+  onSelect,
+  onBack,
+}: CarapaceQuickCheckResultsProps) {
+  if (status === 'running') {
+    return (
+      <Paper shadow='sm' p='xl' radius='md' withBorder>
+        <Center>
+          <Stack align='center' gap='sm'>
+            <Loader size='lg' color='orange' />
+            <Text c='dimmed'>Running carapace quick check…</Text>
+          </Stack>
+        </Center>
+      </Paper>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Paper shadow='sm' p='md' radius='md' withBorder>
+        <Stack gap='md'>
+          <Alert icon={<IconAlertCircle size={18} />} color='red' radius='md'>
+            {error ?? 'Quick check failed.'}
+          </Alert>
+          <Button
+            variant='light'
+            leftSection={<IconArrowLeft size={16} />}
+            onClick={onBack}
+          >
+            Back to upload
+          </Button>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  const selected = selectedIndex != null ? matches[selectedIndex] : null;
+
+  if (selected) {
+    return (
+      <Paper shadow='sm' p='md' radius='md' withBorder>
+        <Stack gap='sm'>
+          <Group justify='space-between'>
+            <Button
+              variant='light'
+              leftSection={<IconArrowLeft size={16} />}
+              onClick={() => onSelect(null)}
+            >
+              Back to matches
+            </Button>
+            <Badge color='teal' size='lg'>
+              Rank {selectedIndex! + 1}
+            </Badge>
+          </Group>
+          <Divider />
+          <TurtleImageComparePair
+            leftLabel='Your photo (not saved)'
+            leftSrc={queryPreviewUrl}
+            rightLabel={`Carapace ref: ${selected.turtle_id}`}
+            rightSrc={hasNoImage(selected) ? null : getImageUrl(selected.image_path)}
+            rightPlaceholder={
+              <Text size='xs' c='dimmed' mt='sm'>
+                No carapace reference image on file for this turtle.
+              </Text>
+            }
+          />
+          <Group gap='xl'>
+            <div>
+              <Text size='xs' c='dimmed'>
+                Turtle ID
+              </Text>
+              <Text size='sm' fw={500}>
+                {selected.turtle_id}
+              </Text>
+            </div>
+            <div>
+              <Text size='xs' c='dimmed'>
+                Location
+              </Text>
+              <Text size='sm' fw={500}>
+                {selected.location}
+              </Text>
+            </div>
+            <div>
+              <Text size='xs' c='dimmed'>
+                Confidence
+              </Text>
+              <Text size='sm' fw={500}>
+                {selected.confidence <= 1
+                  ? `${(selected.confidence * 100).toFixed(1)}%`
+                  : `${Math.round(selected.confidence)}%`}
+              </Text>
+            </div>
+          </Group>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper shadow='sm' p='md' radius='md' withBorder>
+      <Stack gap='md'>
+        <Alert icon={<IconEyeCheck size={18} />} color='orange' radius='md'>
+          Read-only result — nothing was saved. Click a match to compare side by
+          side.
+        </Alert>
+
+        {matches.length === 0 ? (
+          <Text c='dimmed' ta='center' py='lg'>
+            No carapace matches found. The selected scope may have no carapace
+            references on file.
+          </Text>
+        ) : (
+          <>
+            <Text fw={500} size='lg'>
+              Top Carapace Matches
+            </Text>
+            <SimpleGrid cols={{ base: 1, xs: 2, md: 3, lg: 5 }} spacing='md'>
+              {matches.map((match, index) => (
+                <MatchCandidateCard
+                  key={`${match.turtle_id}-${index}`}
+                  rank={index + 1}
+                  turtleId={match.turtle_id}
+                  location={match.location || ''}
+                  confidence={match.confidence}
+                  imagePath={hasNoImage(match) ? null : match.image_path}
+                  badgeColor='teal'
+                  onSelect={() => onSelect(index)}
+                />
+              ))}
+            </SimpleGrid>
+          </>
+        )}
+
+        <Group justify='space-between'>
+          <Button
+            variant='light'
+            leftSection={<IconArrowLeft size={16} />}
+            onClick={onBack}
+          >
+            Back to upload
+          </Button>
+          {elapsed != null && (
+            <Text size='xs' c='dimmed'>
+              Matched in {elapsed.toFixed(2)}s
+            </Text>
+          )}
+        </Group>
+      </Stack>
+    </Paper>
+  );
+}

--- a/frontend/src/components/PreviewCard.tsx
+++ b/frontend/src/components/PreviewCard.tsx
@@ -74,6 +74,8 @@ interface PreviewCardProps {
   setExtraFiles?: (files: UploadExtraFile[] | ((prev: UploadExtraFile[]) => UploadExtraFile[])) => void;
   onUpload: () => void;
   onRemove: () => void;
+  /** Label for the submit button (default: 'Upload Photo'). */
+  uploadLabel?: string;
 }
 
 export function PreviewCard({
@@ -99,6 +101,7 @@ export function PreviewCard({
   setExtraFiles,
   onUpload,
   onRemove,
+  uploadLabel = 'Upload Photo',
 }: PreviewCardProps) {
   const [stillAtLocation, setStillAtLocation] = useState<'yes' | 'no' | null>(null);
   const [manualLat, setManualLat] = useState('');
@@ -681,7 +684,7 @@ export function PreviewCard({
                       size='md'
                       fullWidth
                     >
-                      Upload Photo
+                      {uploadLabel}
                     </Button>
                   )}
                   <Button

--- a/frontend/src/hooks/useCarapaceQuickCheck.ts
+++ b/frontend/src/hooks/useCarapaceQuickCheck.ts
@@ -1,0 +1,65 @@
+import { useCallback, useState } from 'react';
+import { quickCheckCarapaceMatch } from '../services/api';
+import type { QuickCheckMatch } from '../services/api';
+
+export type QuickCheckStatus = 'idle' | 'running' | 'done' | 'error';
+
+/**
+ * State for the admin-only, read-only carapace quick check.
+ *
+ * `run` is the ONLY submit path in carapace mode — it never touches
+ * localStorage, navigation, or the review queue, so no write path from the
+ * normal upload flow is reachable while the mode is active.
+ */
+export function useCarapaceQuickCheck() {
+  const [enabled, setEnabled] = useState(false);
+  const [status, setStatus] = useState<QuickCheckStatus>('idle');
+  const [matches, setMatches] = useState<QuickCheckMatch[]>([]);
+  const [elapsed, setElapsed] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+
+  const run = useCallback(async (file: File, matchSheet: string) => {
+    setStatus('running');
+    setError(null);
+    setMatches([]);
+    setElapsed(null);
+    setSelectedIndex(null);
+    try {
+      const response = await quickCheckCarapaceMatch(file, matchSheet);
+      setMatches(response.matches ?? []);
+      setElapsed(response.elapsed ?? null);
+      setStatus('done');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Quick check failed.');
+      setStatus('error');
+    }
+  }, []);
+
+  const select = useCallback((index: number | null) => {
+    setSelectedIndex(index);
+  }, []);
+
+  /** Full exit: clears results and turns carapace mode OFF (normal flow restored). */
+  const reset = useCallback(() => {
+    setEnabled(false);
+    setStatus('idle');
+    setMatches([]);
+    setElapsed(null);
+    setError(null);
+    setSelectedIndex(null);
+  }, []);
+
+  return {
+    enabled,
+    setEnabled,
+    status,
+    matches,
+    elapsed,
+    error,
+    selectedIndex,
+    run,
+    select,
+    reset,
+  };
+}

--- a/frontend/src/hooks/usePhotoUpload.tsx
+++ b/frontend/src/hooks/usePhotoUpload.tsx
@@ -60,6 +60,8 @@ interface UsePhotoUploadReturn {
   handleDrop: (acceptedFiles: FileWithPath[]) => void;
   handleUpload: () => Promise<void>;
   handleRemove: () => void;
+  /** Clear a finished (success/error) upload result but keep the staged photo. */
+  resetUploadStatus: () => void;
 }
 
 export function usePhotoUpload({
@@ -349,6 +351,15 @@ export function usePhotoUpload({
     setExtraFiles([]);
   }, []);
 
+  const resetUploadStatus = useCallback((): void => {
+    setUploadState('idle');
+    setUploadProgress(0);
+    setUploadResponse(null);
+    setImageId(null);
+    setIsDuplicate(false);
+    setPreviousUploadDate(null);
+  }, []);
+
   // Clear any in-progress upload state when the session ends so a logged-out
   // user (or whoever logs in next on this device) doesn't inherit the previous
   // session's file, preview, flags, and extra photos. Only fires on the
@@ -382,6 +393,7 @@ export function usePhotoUpload({
     setPhysicalFlag,
     extraFiles,
     setExtraFiles,
+    resetUploadStatus,
     handleDrop,
     handleUpload,
     handleRemove,

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -10,6 +10,8 @@ import {
   Loader,
   Modal,
   ActionIcon,
+  Switch,
+  Alert,
 } from '@mantine/core';
 import type { ComboboxData, ComboboxItem, ComboboxItemGroup } from '@mantine/core';
 import { Dropzone } from '@mantine/dropzone';
@@ -26,14 +28,17 @@ import {
   IconSkull,
   IconStar,
   IconStarFilled,
+  IconEyeCheck,
 } from '@tabler/icons-react';
 import { useRef, useState, useEffect, useLayoutEffect, useMemo, useCallback } from 'react';
 import { MAX_RAW_FILE_BYTES } from '../utils/uploadConstants';
 import { dropzoneRejectionMessage } from '../utils/uploadErrorMessages';
 import { useUser } from '../hooks/useUser';
 import { usePhotoUpload } from '../hooks/usePhotoUpload';
-import { isStaffRole } from '../services/api/auth';
+import { isStaffRole, isAdminRole } from '../services/api/auth';
 import { PreviewCard } from '../components/PreviewCard';
+import { CarapaceQuickCheckResults } from '../components/CarapaceQuickCheckResults';
+import { useCarapaceQuickCheck } from '../hooks/useCarapaceQuickCheck';
 import { InstructionsModal } from '../components/InstructionsModal';
 import {
   getLocations,
@@ -87,6 +92,9 @@ export default function HomePage() {
   const pendingRewards = useAppSelector((s) => s.communityGame.pendingRewards);
   const { role, isLoggedIn, authChecked } = useUser();
   const isStaff = isStaffRole(role);
+  const isAdmin = isAdminRole(role);
+  const quickCheck = useCarapaceQuickCheck();
+  const carapaceMode = isAdmin && quickCheck.enabled;
   const canUseObserverGamification = authChecked && isLoggedIn;
   const isMobile = useMediaQuery('(max-width: 768px)', undefined, { getInitialValueInEffect: false });
   const cameraInputRef = useRef<HTMLInputElement>(null);
@@ -382,6 +390,7 @@ export default function HomePage() {
     setPhysicalFlag,
     extraFiles,
     setExtraFiles,
+    resetUploadStatus,
     handleDrop,
     handleUpload,
     handleRemove,
@@ -448,6 +457,19 @@ export default function HomePage() {
     }
   };
 
+  /** Carapace mode submit: read-only quick check instead of the normal upload. */
+  const handleQuickCheckRun = (): void => {
+    const file = files[0];
+    if (!file) return;
+    void quickCheck.run(file, matchSheetForUpload ?? '');
+  };
+
+  /** Full exit from carapace mode: results + staged photo cleared, toggle off. */
+  const handleQuickCheckExit = (): void => {
+    quickCheck.reset();
+    handleRemove();
+  };
+
   return (
     <Container size='sm' py={{ base: 'md', sm: 'xl' }} px={{ base: 'xs', sm: 'md' }}>
       <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
@@ -491,6 +513,31 @@ export default function HomePage() {
                 </Button>
               )}
             </Group>
+            {isAdmin && (
+              <Switch
+                label='Carapace-only quick check'
+                color='orange'
+                size='sm'
+                checked={quickCheck.enabled}
+                disabled={uploadState === 'uploading' || quickCheck.status === 'running'}
+                onChange={(event) => {
+                  if (event.currentTarget.checked) {
+                    // A stale success/error from a previous normal upload would
+                    // otherwise suppress the "Run quick check" button (PreviewCard
+                    // only shows the submit button while uploadState is 'idle').
+                    if (uploadState !== 'idle') {
+                      resetUploadStatus();
+                    }
+                    quickCheck.setEnabled(true);
+                  } else if (quickCheck.status === 'idle') {
+                    // Nothing ran — leave the mode but keep the staged photo.
+                    quickCheck.reset();
+                  } else {
+                    handleQuickCheckExit();
+                  }
+                }}
+              />
+            )}
           </Stack>
 
           {/* Staff/Admin: select which location (backend folder / state) to test against */}
@@ -520,7 +567,7 @@ export default function HomePage() {
                   }
                   allowDeselect={false}
                   required
-                  disabled={uploadState === 'uploading'}
+                  disabled={uploadState === 'uploading' || quickCheck.status === 'running'}
                   renderOption={({ option }) => {
                     const isFav = favoriteLocations.includes(option.value);
                     return (
@@ -563,6 +610,35 @@ export default function HomePage() {
             </Stack>
           )}
 
+          {carapaceMode && (
+            <Alert
+              icon={<IconEyeCheck size={18} />}
+              color='orange'
+              radius='md'
+              variant='light'
+            >
+              <Text fw={600} size='sm'>
+                Carapace-only mode — read-only
+              </Text>
+              <Text size='sm'>
+                Matches run against carapace references only; nothing is saved.
+              </Text>
+            </Alert>
+          )}
+
+          {carapaceMode && quickCheck.status !== 'idle' ? (
+            <CarapaceQuickCheckResults
+              status={quickCheck.status}
+              error={quickCheck.error}
+              queryPreviewUrl={preview ?? ''}
+              matches={quickCheck.matches}
+              elapsed={quickCheck.elapsed}
+              selectedIndex={quickCheck.selectedIndex}
+              onSelect={quickCheck.select}
+              onBack={handleQuickCheckExit}
+            />
+          ) : (
+            <>
           {/* Hidden file inputs for mobile */}
           <input
             ref={cameraInputRef}
@@ -586,6 +662,7 @@ export default function HomePage() {
             <Stack gap='md'>
               <Button
                 size='lg'
+                color={carapaceMode ? 'orange' : undefined}
                 leftSection={<IconCamera size={20} />}
                 onClick={handleCameraClick}
                 disabled={uploadState === 'uploading'}
@@ -596,6 +673,7 @@ export default function HomePage() {
               <Button
                 size='lg'
                 variant='light'
+                color={carapaceMode ? 'orange' : undefined}
                 leftSection={<IconPhoto size={20} />}
                 onClick={handleFileSelectClick}
                 disabled={uploadState === 'uploading'}
@@ -617,6 +695,11 @@ export default function HomePage() {
               }}
               multiple={false}
               disabled={uploadState === 'uploading'}
+              style={
+                carapaceMode
+                  ? { borderColor: 'var(--mantine-color-orange-6)' }
+                  : undefined
+              }
             >
               <Group
                 justify='center'
@@ -665,18 +748,21 @@ export default function HomePage() {
             isGettingLocation={isGettingLocation}
             locationPermissionDenied={locationPermissionDenied}
             role={role}
-            locationHint={locationHint}
-            setLocationHint={setLocationHint}
-            requestLocationHint={requestLocationHint}
-            collectedToLab={collectedToLab}
-            setCollectedToLab={setCollectedToLab}
-            physicalFlag={physicalFlag}
-            setPhysicalFlag={setPhysicalFlag}
-            extraFiles={extraFiles}
-            setExtraFiles={setExtraFiles}
-            onUpload={handleUpload}
+            locationHint={carapaceMode ? null : locationHint}
+            setLocationHint={carapaceMode ? undefined : setLocationHint}
+            requestLocationHint={carapaceMode ? undefined : requestLocationHint}
+            collectedToLab={carapaceMode ? null : collectedToLab}
+            setCollectedToLab={carapaceMode ? undefined : setCollectedToLab}
+            physicalFlag={carapaceMode ? null : physicalFlag}
+            setPhysicalFlag={carapaceMode ? undefined : setPhysicalFlag}
+            extraFiles={carapaceMode ? undefined : extraFiles}
+            setExtraFiles={carapaceMode ? undefined : setExtraFiles}
+            onUpload={carapaceMode ? handleQuickCheckRun : handleUpload}
             onRemove={handleRemove}
+            uploadLabel={carapaceMode ? 'Run quick check' : undefined}
           />
+            </>
+          )}
         </Stack>
       </Paper>
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -48,6 +48,7 @@ export type {
 
 export {
   uploadTurtlePhoto,
+  quickCheckCarapaceMatch,
   getReviewQueue,
   uploadReviewPacketAdditionalImages,
   getReviewPacket,
@@ -77,6 +78,8 @@ export type {
   PhotoType,
   TurtleMatch,
   UploadPhotoResponse,
+  QuickCheckMatch,
+  QuickCheckResponse,
   LocationHint,
   AdditionalImage,
   ReviewQueueItem,

--- a/frontend/src/services/api/turtle/index.ts
+++ b/frontend/src/services/api/turtle/index.ts
@@ -2,7 +2,7 @@
  * PicTur API – photo upload, review queue, matching, turtle images
  */
 
-export { uploadTurtlePhoto } from './upload';
+export { uploadTurtlePhoto, quickCheckCarapaceMatch } from './upload';
 
 export {
   getReviewQueue,
@@ -39,6 +39,8 @@ export type {
   TurtleMatch,
   PhotoType,
   UploadPhotoResponse,
+  QuickCheckMatch,
+  QuickCheckResponse,
   LocationHint,
   AdditionalImageType,
   AdditionalImage,

--- a/frontend/src/services/api/turtle/types.ts
+++ b/frontend/src/services/api/turtle/types.ts
@@ -19,6 +19,23 @@ export interface UploadPhotoResponse {
   message: string;
 }
 
+/** One row from the read-only carapace quick check (mirrors cross-check shape). */
+export interface QuickCheckMatch {
+  turtle_id: string;
+  location: string;
+  confidence: number;
+  score: number;
+  /** May still be a `.pt` path when no sibling image exists — treat as "no image". */
+  image_path: string;
+}
+
+export interface QuickCheckResponse {
+  success: boolean;
+  photo_type: 'carapace';
+  matches: QuickCheckMatch[];
+  elapsed: number;
+}
+
 /** Location hint from community (never stored in sheets, queue/display only) */
 export interface LocationHint {
   latitude: number;

--- a/frontend/src/services/api/turtle/upload.ts
+++ b/frontend/src/services/api/turtle/upload.ts
@@ -4,6 +4,7 @@ import { parseUploadApiErrorBody } from '../../../utils/uploadErrorMessages';
 import { authHeaders } from './http';
 import type {
   LocationHint,
+  QuickCheckResponse,
   UploadExtraFile,
   UploadFlagOptions,
   UploadPhotoResponse,
@@ -86,6 +87,40 @@ export const uploadTurtlePhoto = async (
     if (import.meta.env.DEV && code) {
       console.error('Upload error code:', code);
     }
+    throw new Error(message);
+  }
+
+  return await response.json();
+};
+
+/**
+ * Read-only carapace quick check (admin only). Matches the photo against the
+ * carapace pool and returns ranked candidates; the backend persists nothing.
+ */
+export const quickCheckCarapaceMatch = async (
+  file: File,
+  /** Sheet/location scope; '' = test against all locations */
+  matchSheet: string,
+): Promise<QuickCheckResponse> => {
+  const prepared = await prepareImageForUpload(file);
+
+  const formData = new FormData();
+  formData.append('file', prepared);
+  formData.append('match_sheet', matchSheet);
+
+  const response = await fetch(`${TURTLE_API_BASE_URL}/match/quick-check`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: formData,
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      removeToken();
+      throw new Error('Authentication failed. Please try again.');
+    }
+    const body = await response.json().catch(() => ({}));
+    const { message } = parseUploadApiErrorBody(body);
     throw new Error(message);
   }
 

--- a/frontend/tests/e2e/admin-carapace-quick-check.spec.ts
+++ b/frontend/tests/e2e/admin-carapace-quick-check.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  loginAsAdmin,
+  loginAsCommunity,
+  loginAsStaff,
+  grantLocationPermission,
+  getTestImageBuffer,
+} from './fixtures';
+
+/**
+ * Carapace-only quick check (admin-only, strictly read-only).
+ *
+ * The quick-check endpoint and image serving are mocked, so these tests need
+ * no carapace fixture data on disk — they pin the frontend contract: admin
+ * gating, mode indication, read-only results, click-to-compare, and the
+ * full reset on back-out.
+ */
+
+const QUICK_CHECK_MATCHES = [
+  {
+    turtle_id: 'F128',
+    location: 'Kansas/North Topeka',
+    confidence: 0.87,
+    score: 412,
+    image_path: '/data/Kansas/North Topeka/F128_T1/carapace/F128.JPG',
+  },
+  {
+    turtle_id: 'M201',
+    location: 'Kansas/North Topeka',
+    confidence: 0.63,
+    score: 198,
+    image_path: '/data/Kansas/North Topeka/M201_T2/carapace/M201.JPG',
+  },
+];
+
+async function mockQuickCheckRoutes(page: Page, captured: { body: string | null }) {
+  await page.route('**/api/match/quick-check', async (route) => {
+    captured.body = route.request().postData();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        photo_type: 'carapace',
+        matches: QUICK_CHECK_MATCHES,
+        elapsed: 1.23,
+      }),
+    });
+  });
+  await page.route('**/api/images*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/png',
+      body: getTestImageBuffer(),
+    });
+  });
+}
+
+async function stagePhoto(page: Page, name: string) {
+  const fileInput = page.locator('input[type="file"]:not([capture])').first();
+  await fileInput.setInputFiles({
+    name,
+    mimeType: 'image/png',
+    buffer: getTestImageBuffer(),
+  });
+}
+
+test.describe('Carapace-only quick check', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await grantLocationPermission(page);
+  });
+
+  test('toggle is not visible for community users', async ({ page }) => {
+    await loginAsCommunity(page);
+    await expect(page.getByText('Photo Upload').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel('Carapace-only quick check')).toHaveCount(0);
+  });
+
+  test('toggle is not visible for staff users (admin only, not isStaff)', async ({ page }) => {
+    await loginAsStaff(page);
+    // Staff DO see the mortality button — the quick-check switch must not follow it
+    await expect(
+      page.getByRole('button', { name: 'Mortality without plastron ID' }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel('Carapace-only quick check')).toHaveCount(0);
+  });
+
+  test('full read-only flow: banner, results, compare, back-out reset', async ({ page }) => {
+    test.setTimeout(60_000);
+    const captured: { body: string | null } = { body: null };
+    await mockQuickCheckRoutes(page, captured);
+    await loginAsAdmin(page);
+
+    // Toggle ON → mode is clearly indicated (Mantine hides the native input,
+    // so interact via the visible label and assert state on the input)
+    const toggleLabel = page.getByText('Carapace-only quick check');
+    await expect(toggleLabel).toBeVisible({ timeout: 10_000 });
+    await toggleLabel.click();
+    await expect(page.getByLabel('Carapace-only quick check')).toBeChecked();
+    await expect(page.getByText(/Carapace-only mode/)).toBeVisible();
+
+    // Stage a photo and run the quick check
+    await stagePhoto(page, 'carapace-e2e.png');
+    const runButton = page.getByRole('button', { name: 'Run quick check' });
+    await expect(runButton).toBeVisible({ timeout: 10_000 });
+    await runButton.click();
+
+    // Read-only results from the mocked carapace pool
+    await expect(page.getByText('Read-only result — nothing was saved.', { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText('Top Carapace Matches')).toBeVisible();
+    await expect(page.getByText('F128')).toBeVisible();
+    await expect(page.getByText('M201')).toBeVisible();
+
+    // The scope field rode along in the multipart body with the mapped value
+    // (default "All locations" = MATCH_ALL sentinel → empty string)
+    const scopeField = (captured.body ?? '').match(/name="match_sheet"\r?\n\r?\n([^\r\n]*)/);
+    expect(scopeField).not.toBeNull();
+    expect(scopeField![1]).toBe('');
+
+    // No write affordance anywhere in this mode
+    await expect(
+      page.getByRole('button', {
+        name: /Create New Turtle|Save to Sheets|Replace|Approve|Upload \d+ photo/i,
+      }),
+    ).toHaveCount(0);
+
+    // Click a match → enlarged side-by-side comparison
+    await page.getByText('F128').first().click();
+    await expect(page.getByText('Your photo (not saved)')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Carapace ref: F128')).toBeVisible();
+    await expect(page.getByText('Rank 1')).toBeVisible();
+
+    // Back to the ranked list, then all the way out
+    await page.getByRole('button', { name: 'Back to matches' }).click();
+    await expect(page.getByText('Top Carapace Matches')).toBeVisible();
+    await page.getByRole('button', { name: 'Back to upload' }).click();
+
+    // Full reset: toggle OFF, banner gone, results gone, staged photo cleared
+    await expect(page.getByLabel('Carapace-only quick check')).not.toBeChecked();
+    await expect(page.getByText(/Carapace-only mode/)).toHaveCount(0);
+    await expect(page.getByText('Top Carapace Matches')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Run quick check' })).toHaveCount(0);
+  });
+
+  test('turning the switch off mid-mode restores the normal flow', async ({ page }) => {
+    const captured: { body: string | null } = { body: null };
+    await mockQuickCheckRoutes(page, captured);
+    await loginAsAdmin(page);
+
+    const toggleLabel = page.getByText('Carapace-only quick check');
+    await expect(toggleLabel).toBeVisible({ timeout: 10_000 });
+    await toggleLabel.click();
+    await expect(page.getByLabel('Carapace-only quick check')).toBeChecked();
+    await expect(page.getByText(/Carapace-only mode/)).toBeVisible();
+
+    await toggleLabel.click();
+    await expect(page.getByText(/Carapace-only mode/)).toHaveCount(0);
+    await expect(page.getByLabel('Carapace-only quick check')).not.toBeChecked();
+  });
+});


### PR DESCRIPTION
## Summary

- **Carapace-only quick check (admin-only, strictly read-only)**: a new switch on the HomePage upload screen, directly below "Mortality without plastron ID" (visible to admins only — staff keep the normal flow). When ON, the page shows an orange "Carapace-only mode — read-only" banner and an orange dropzone border; the admin picks a location scope and uploads a photo exactly like normal, but the submit button becomes "Run quick check" and matching runs against **only the carapace reference pool**. Results reuse the live match components (`MatchCandidateCard`, `TurtleImageComparePair`): a ranked top-5 list, click-to-compare enlarged side-by-side, and nothing else — no select/approve/create-turtle/replace-reference/add-images affordance exists anywhere in the mode. Backing out resets the results, staged photo, and toggle (location is kept).
- **New backend endpoint `POST /api/match/quick-check`** (`@require_admin_only`): modeled on the read-only cross-check route. Persists nothing — no Review-Queue packet, no metadata, no candidate copies; the temp upload uses a unique per-request prefix (safe under `threaded=True`) and is swept in a `finally` on every path, including when ingest renames the file (HEIC→jpg) before failing. Candidate images resolve through the case-insensitive `find_image_for_pt` (carapace refs are frequently uppercase `.JPG`; prod is Linux). Scope semantics are identical to normal matching, including the expand-to-all-locations fallback when the scoped pool yields fewer than 5 matches.
- **Bugfix (Windows dev only)**: `image_utils` resize/repair deleted its own freshly-written output when the input extension was uppercase `.JPG` on a case-insensitive filesystem, so oversized uppercase uploads silently returned zero matches locally. Fixed with `os.path.normcase` (identity on POSIX — no prod behavior change).
- Tests: 15 new backend unit tests for the route (auth matrix incl. staff→403, zero-writes, temp sweep scoping, uppercase-`.JPG` resolution, size-probe rewind, error paths) + an ingest-case regression test; new Playwright spec (mocked endpoint) covering admin/staff/community gating, the read-only flow, compare view, and reset semantics. Verified end-to-end against the real stack: a known carapace photo returns its own turtle top-1 (80% confidence) from the carapace pool with no Review-Queue writes, no leftover temps, and no `match_*` localStorage entries.
- Release 2.0.21 cut in this PR (CHANGELOG incl. previously-missing 2.0.20/2.0.21 compare links, package version bump).