### PR TITLE
Open the carapace quick check to staff accounts — v2.0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.22] - 2026-07-10 — Carapace quick check opened to staff
+
+### Changed
+
+- **Carapace-only quick check is now available to staff accounts** (was admin-only in 2.0.21): the toggle on the photo-upload screen now shows for every staff and admin user, and the backend `POST /api/match/quick-check` endpoint accepts staff tokens (community and anonymous still rejected). The mode itself is unchanged — strictly read-only, carapace pool only.
+
 ## [2.0.21] - 2026-07-07 — Carapace-only quick check
 
 ### Added
@@ -621,7 +627,8 @@ Major bump merging the SuperPoint implementation: **VLAD/FAISS → SuperPoint + 
 - **Documentation**: README with quick start (Docker and local), functionality overview, and versioning guide in `docs/VERSION_AND_RELEASES.md`.
 - Version control and release process: `CHANGELOG.md`, version in `frontend/package.json`, and guide in `docs/VERSION_AND_RELEASES.md`.
 
-[Unreleased]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.21...HEAD
+[Unreleased]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.22...HEAD
+[2.0.22]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.21...v2.0.22
 [2.0.21]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.20...v2.0.21
 [2.0.20]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.19...v2.0.20
 [2.0.19]: https://github.com/Lxkasmehl/PicTur/compare/v2.0.18...v2.0.19

--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ You need to run **all three services** simultaneously:
    - If a carapace photo is attached as an additional image, a **Cross-check carapace** button runs a parallel carapace search and displays both result sets side-by-side, flagging disagreements
    - Admin selects the best match (optionally marking the upload as the new reference) or creates a new turtle
 
-2. **Carapace-only quick check (read-only)**:
+2. **Carapace-only quick check (read-only, staff + admin)**:
 
-   - A switch below "Mortality without plastron ID" puts the upload page into a clearly-marked carapace-only mode (orange banner)
+   - A switch below "Mortality without plastron ID" puts the upload page into a clearly-marked carapace-only mode (orange banner); available to staff and admin accounts (everyone except community)
    - Pick a location scope and upload a carapace photo like normal — matching runs against **only the carapace reference pool** and returns the ranked candidates; clicking one opens the same enlarged side-by-side comparison as the match page
    - Strictly read-only: nothing is saved (no review-queue packet, no stored query photo) and no select/approve/create/replace action exists in this mode; backing out returns to the normal plastron flow
 

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -14,7 +14,7 @@ import uuid
 from flask import request, jsonify
 from werkzeug.utils import secure_filename
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
-from auth import optional_auth, check_auth_revocation, require_admin_only
+from auth import optional_auth, check_auth_revocation, require_admin
 from image_utils import UploadImageError
 from upload_rate_limit import upload_rate_limit_ok, upload_rate_limit_response
 from upload_validation import ingest_saved_upload, log_upload_rejection, upload_error_response
@@ -457,9 +457,9 @@ def register_upload_routes(app):
             }), 500
 
     @app.route('/api/match/quick-check', methods=['POST'])
-    @require_admin_only
+    @require_admin
     def quick_check_match():
-        """Carapace-only quick check (admin only, strictly read-only).
+        """Carapace-only quick check (staff + admin, strictly read-only).
 
         Runs a fresh photo against the carapace VRAM cache and returns the
         ranked candidates. Unlike /api/upload, this persists NOTHING: no

--- a/backend/tests/test_quick_check_route.py
+++ b/backend/tests/test_quick_check_route.py
@@ -1,9 +1,9 @@
 """
-Unit tests for POST /api/match/quick-check — the admin-only, strictly
-read-only carapace quick check. Pins: strict-admin auth (staff must be
-rejected), carapace photo_type forwarding, cross-check-style response shape,
-case-insensitive .pt→image resolution, zero review-queue writes, and
-temp-file cleanup on success and error paths.
+Unit tests for POST /api/match/quick-check — the staff/admin, strictly
+read-only carapace quick check. Pins: staff-or-admin auth (community and
+anonymous rejected), carapace photo_type forwarding, cross-check-style
+response shape, case-insensitive .pt→image resolution, zero review-queue
+writes, and temp-file cleanup on success and error paths.
 """
 
 import io
@@ -78,26 +78,27 @@ def test_requires_token(app_client, quick_check_env):
     assert r.status_code == 401
 
 
-@pytest.mark.parametrize("role", ["community", "staff"])
-def test_non_admin_forbidden(app_client, quick_check_env, role):
-    """Staff must be rejected too — the quick check is strict-admin."""
+def test_community_forbidden(app_client, quick_check_env):
+    """Community users must be rejected — the quick check is staff/admin only."""
     r = app_client.post(
         "/api/match/quick-check",
         data=_file_payload(),
         content_type="multipart/form-data",
-        headers=_auth(role),
+        headers=_auth("community"),
     )
     assert r.status_code == 403
     assert quick_check_env["manager"].search_for_matches.call_count == 0
 
 
-def test_admin_ok_and_forwards_carapace_scope(app_client, quick_check_env):
+@pytest.mark.parametrize("role", ["admin", "staff"])
+def test_admin_ok_and_forwards_carapace_scope(app_client, quick_check_env, role):
+    """Both admin and staff can run the quick check (everyone but community)."""
     manager = quick_check_env["manager"]
     r = app_client.post(
         "/api/match/quick-check",
         data=_file_payload(extra={"match_sheet": "Kansas"}),
         content_type="multipart/form-data",
-        headers=_auth("admin"),
+        headers=_auth(role),
     )
     assert r.status_code == 200, r.get_json()
     body = r.get_json()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picturfrontend",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picturfrontend",
-      "version": "2.0.21",
+      "version": "2.0.22",
       "dependencies": {
         "@mantine/code-highlight": "^8.3.5",
         "@mantine/core": "^8.3.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "picturfrontend",
   "private": true,
-  "version": "2.0.21",
+  "version": "2.0.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -35,7 +35,7 @@ import { MAX_RAW_FILE_BYTES } from '../utils/uploadConstants';
 import { dropzoneRejectionMessage } from '../utils/uploadErrorMessages';
 import { useUser } from '../hooks/useUser';
 import { usePhotoUpload } from '../hooks/usePhotoUpload';
-import { isStaffRole, isAdminRole } from '../services/api/auth';
+import { isStaffRole } from '../services/api/auth';
 import { PreviewCard } from '../components/PreviewCard';
 import { CarapaceQuickCheckResults } from '../components/CarapaceQuickCheckResults';
 import { useCarapaceQuickCheck } from '../hooks/useCarapaceQuickCheck';
@@ -92,9 +92,8 @@ export default function HomePage() {
   const pendingRewards = useAppSelector((s) => s.communityGame.pendingRewards);
   const { role, isLoggedIn, authChecked } = useUser();
   const isStaff = isStaffRole(role);
-  const isAdmin = isAdminRole(role);
   const quickCheck = useCarapaceQuickCheck();
-  const carapaceMode = isAdmin && quickCheck.enabled;
+  const carapaceMode = isStaff && quickCheck.enabled;
   const canUseObserverGamification = authChecked && isLoggedIn;
   const isMobile = useMediaQuery('(max-width: 768px)', undefined, { getInitialValueInEffect: false });
   const cameraInputRef = useRef<HTMLInputElement>(null);
@@ -513,7 +512,7 @@ export default function HomePage() {
                 </Button>
               )}
             </Group>
-            {isAdmin && (
+            {isStaff && (
               <Switch
                 label='Carapace-only quick check'
                 color='orange'

--- a/frontend/tests/e2e/admin-carapace-quick-check.spec.ts
+++ b/frontend/tests/e2e/admin-carapace-quick-check.spec.ts
@@ -8,12 +8,12 @@ import {
 } from './fixtures';
 
 /**
- * Carapace-only quick check (admin-only, strictly read-only).
+ * Carapace-only quick check (staff + admin, strictly read-only).
  *
  * The quick-check endpoint and image serving are mocked, so these tests need
- * no carapace fixture data on disk — they pin the frontend contract: admin
- * gating, mode indication, read-only results, click-to-compare, and the
- * full reset on back-out.
+ * no carapace fixture data on disk — they pin the frontend contract: role
+ * gating (staff and admin yes, community no), mode indication, read-only
+ * results, click-to-compare, and the full reset on back-out.
  */
 
 const QUICK_CHECK_MATCHES = [
@@ -77,13 +77,13 @@ test.describe('Carapace-only quick check', () => {
     await expect(page.getByLabel('Carapace-only quick check')).toHaveCount(0);
   });
 
-  test('toggle is not visible for staff users (admin only, not isStaff)', async ({ page }) => {
+  test('staff users can see and enable the toggle (everyone but community)', async ({ page }) => {
     await loginAsStaff(page);
-    // Staff DO see the mortality button — the quick-check switch must not follow it
-    await expect(
-      page.getByRole('button', { name: 'Mortality without plastron ID' }),
-    ).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByLabel('Carapace-only quick check')).toHaveCount(0);
+    const toggleLabel = page.getByText('Carapace-only quick check');
+    await expect(toggleLabel).toBeVisible({ timeout: 10_000 });
+    await toggleLabel.click();
+    await expect(page.getByLabel('Carapace-only quick check')).toBeChecked();
+    await expect(page.getByText(/Carapace-only mode/)).toBeVisible();
   });
 
   test('full read-only flow: banner, results, compare, back-out reset', async ({ page }) => {


### PR DESCRIPTION
## Summary

- **The carapace-only quick check is now available to staff accounts** (2.0.21 gated it to strict admin per the original spec; the intended audience is everyone except community). The HomePage toggle gate moves from `isAdminRole` to `isStaffRole` (staff + admin) and `POST /api/match/quick-check` moves from `@require_admin_only` to `@require_admin` — this codebase's staff-or-admin decorator. Community and anonymous users are still rejected, and the mode itself is unchanged: strictly read-only, carapace pool only.
- Tests flipped to pin the new contract: staff → 200 on the endpoint (parametrized alongside admin), community → 403 unchanged, and the Playwright spec now asserts a real staff login sees and can enable the toggle (verified green against a live stack, along with the full 252-test backend suite, tsc, and eslint).
- Release 2.0.22 cut in this PR (CHANGELOG + version bump).