### PR TITLE
Staff groups foundation: schema, membership APIs, Team Lead API (1/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-20 — Staff groups foundation (auth-backend)
+
 ### Added
 
 - **Groups foundation for staff management (auth-backend)**: new `groups` and `group_areas` tables plus `users.group_id` / `users.group_role` columns (idempotent migrations; the `users.role` CHECK stays `community|staff|admin`). Two system super-groups are seeded — **Operations** (global, holds admins) and **Primary** (global today, re-scopable later) — and a one-time backfill routes every existing admin into Operations (as lead) and every existing staff into Primary (as member); community users stay unassigned. A Team Lead is simply a staff user whose membership carries `group_role='lead'`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Groups foundation for staff management (auth-backend)**: new `groups` and `group_areas` tables plus `users.group_id` / `users.group_role` columns (idempotent migrations; the `users.role` CHECK stays `community|staff|admin`). Two system super-groups are seeded — **Operations** (global, holds admins) and **Primary** (global today, re-scopable later) — and a one-time backfill routes every existing admin into Operations (as lead) and every existing staff into Primary (as member); community users stay unassigned. A Team Lead is simply a staff user whose membership carries `group_role='lead'`.
+- **Group management API (`/api/admin/groups`, admin-only)**: list groups with their areas and member counts; create/rename/re-scope/delete admin-created Sub-Area groups (scoped, with area path prefixes); and replace a group's area set (`PUT /:id/areas`) with trimmed/slash-stripped/`..`-rejecting/case-insensitively-deduped opaque prefixes. System groups can never be deleted and Operations can never leave global scope; Primary may be flipped to scoped (the future lever).
+- **Admin membership assignment (`PATCH /api/admin/users/:id/membership`)**: move a user between groups or unassign them, optionally setting their group rank. Existing sessions are revoked only when privileges are reduced (dropping the lead rank, or releasing a still-privileged staff/admin to Unassigned) — lateral moves and promotions never log the user out, so a one-step stray-user correction is painless.
+- **Team Lead API (`/api/lead`, staff leads only)**: a lead can view their group (metadata, areas, members), claim an unassigned community user into their group, promote/demote members one rung (community ↔ staff ↔ lead within the group), and release a member back to Unassigned. Guards prevent acting on themselves, on admins, or on users outside their group; demotions and releases revoke the affected member's tokens.
+- **Enriched `/api/auth/validate` and `/api/auth/me`**: both now return the user's resolved `group` (`{id,name,scope,system_key}` or null), `group_role`, and `areas`, with `role` re-read fresh from the DB. The JWT stays identity-only; these fields are purely additive so existing consumers are unaffected.
+- **Seeds + integration tests**: the e2e seed now also creates a scoped `KansasTeam` group (area `Kansas/Topeka`, a real fixture-data folder) with a team lead, a scoped staff member, and an unassigned community user; new `backend/tests/integration/test_groups_routes.py` covers group CRUD, area validation, the enriched auth payloads, admin membership moves, the full Team Lead matrix, and revocation/last-admin regressions.
+
 ## [2.0.22] - 2026-07-10 — Carapace quick check opened to staff
 
 ### Changed

--- a/auth-backend/src/db/database.ts
+++ b/auth-backend/src/db/database.ts
@@ -88,6 +88,84 @@ function migrateUserUiPreferencesTable(database: Database): void {
   `);
 }
 
+/**
+ * Groups + membership: the groups/group_areas tables and the users.group_id / users.group_role
+ * columns. Idempotent: CREATE TABLE IF NOT EXISTS and PRAGMA-guarded ALTERs. The users.role CHECK
+ * constraint is left untouched — roles stay community|staff|admin.
+ */
+function migrateGroupsSchema(database: Database): boolean {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS groups (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+      scope TEXT NOT NULL DEFAULT 'scoped' CHECK (scope IN ('global','scoped')),
+      system_key TEXT UNIQUE,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS group_areas (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      group_id INTEGER NOT NULL,
+      area TEXT NOT NULL,
+      FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE,
+      UNIQUE (group_id, area COLLATE NOCASE)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_group_areas_group ON group_areas(group_id);
+  `);
+
+  const userCols = database.prepare(`PRAGMA table_info(users)`).all() as { name: string }[];
+  const addedGroupColumns = !userCols.some((c) => c.name === 'group_id');
+  if (addedGroupColumns) {
+    // Nullable, no FK — the repo layer enforces membership integrity.
+    database.exec(`ALTER TABLE users ADD COLUMN group_id INTEGER`);
+  }
+  if (!userCols.some((c) => c.name === 'group_role')) {
+    database.exec(
+      `ALTER TABLE users ADD COLUMN group_role TEXT NOT NULL DEFAULT 'member' CHECK (group_role IN ('member','lead'))`
+    );
+  }
+  database.exec(`CREATE INDEX IF NOT EXISTS idx_users_group ON users(group_id)`);
+  return addedGroupColumns;
+}
+
+/**
+ * Seed the two system super-groups. INSERT OR IGNORE keeps this idempotent and — importantly —
+ * never clobbers an admin's later change (e.g. flipping Primary to 'scoped'): a matching name /
+ * system_key simply makes the insert a no-op.
+ */
+function migrateSeedSystemGroups(database: Database): void {
+  const insert = database.prepare(
+    `INSERT OR IGNORE INTO groups (name, scope, system_key) VALUES (?, 'global', ?)`
+  );
+  insert.run('Operations', 'operations');
+  insert.run('Primary', 'primary');
+}
+
+/**
+ * Membership backfill: route every still-unassigned admin into Operations (as lead) and every
+ * still-unassigned staff into Primary (as member). Community users stay unassigned. At boot this
+ * runs ONLY on the run that first adds the group columns — "unassigned staff/admin" is a
+ * deliberate, reachable state afterwards (admin membership PATCH with group_id null), and an
+ * every-boot backfill would silently resurrect memberships an admin explicitly removed. Also
+ * invoked explicitly by seeding/admin-bootstrap scripts, where routing fresh unassigned
+ * admins/staff into the system groups is exactly the intent.
+ */
+export function migrateBackfillMembership(database: Database): void {
+  database.exec(`
+    UPDATE users
+       SET group_id = (SELECT id FROM groups WHERE system_key = 'operations'),
+           group_role = 'lead'
+     WHERE role = 'admin' AND group_id IS NULL;
+
+    UPDATE users
+       SET group_id = (SELECT id FROM groups WHERE system_key = 'primary'),
+           group_role = 'member'
+     WHERE role = 'staff' AND group_id IS NULL;
+  `);
+}
+
 function setAutoincrementSeq(database: Database, table: string, maxId: number): void {
   if (maxId < 1) return;
   try {
@@ -235,7 +313,13 @@ const db: Database = new BetterSqlite3(dbPath);
 initSchema(db);
 migrateEmailVerificationsUsedAt(db);
 migrateUserUiPreferencesTable(db);
+const groupColumnsJustAdded = migrateGroupsSchema(db);
+// Seed + backfill run AFTER the legacy-JSON import so a first-boot import gets backfilled in the same run.
 maybeMigrateLegacyJson(db);
+migrateSeedSystemGroups(db);
+if (groupColumnsJustAdded) {
+  migrateBackfillMembership(db);
+}
 
 export function getCommunityGameForUser(userId: number): CommunityGamePersistedPayload | null {
   const row = db

--- a/auth-backend/src/db/groupsRepo.ts
+++ b/auth-backend/src/db/groupsRepo.ts
@@ -1,0 +1,158 @@
+/**
+ * Repository for groups, group areas, and per-user membership context.
+ *
+ * Invariants enforced here (belt-and-suspenders for the route layer): system groups cannot be
+ * deleted, and the Operations super-group cannot leave 'global' scope. Violations throw
+ * GroupInvariantError so callers can map them to a 400.
+ */
+import db from './database.js';
+import type { Group, GroupScope, GroupRole, MembershipContext } from '../types/group.js';
+
+export interface GroupWithMeta extends Group {
+  areas: string[];
+  member_count: number;
+}
+
+/** Thrown when a hard group invariant is violated (delete system group, Operations scope change). */
+export class GroupInvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GroupInvariantError';
+  }
+}
+
+const GROUP_COLUMNS = 'id, name, scope, system_key, created_at, updated_at';
+
+export function getGroup(id: number): Group | null {
+  const row = db.prepare(`SELECT ${GROUP_COLUMNS} FROM groups WHERE id = ?`).get(id) as
+    | Group
+    | undefined;
+  return row ?? null;
+}
+
+export function getGroupByName(name: string): Group | null {
+  const row = db
+    .prepare(`SELECT ${GROUP_COLUMNS} FROM groups WHERE name = ? COLLATE NOCASE`)
+    .get(name) as Group | undefined;
+  return row ?? null;
+}
+
+export function getGroupBySystemKey(key: string): Group | null {
+  const row = db
+    .prepare(`SELECT ${GROUP_COLUMNS} FROM groups WHERE system_key = ?`)
+    .get(key) as Group | undefined;
+  return row ?? null;
+}
+
+export function getGroupAreas(id: number): string[] {
+  const rows = db
+    .prepare('SELECT area FROM group_areas WHERE group_id = ? ORDER BY area COLLATE NOCASE')
+    .all(id) as { area: string }[];
+  return rows.map((r) => r.area);
+}
+
+export function countGroupMembers(id: number): number {
+  const row = db.prepare('SELECT COUNT(*) AS c FROM users WHERE group_id = ?').get(id) as {
+    c: number;
+  };
+  return row.c;
+}
+
+export function listGroupsWithMeta(): GroupWithMeta[] {
+  const groups = db
+    .prepare(`SELECT ${GROUP_COLUMNS} FROM groups ORDER BY (system_key IS NULL) ASC, name COLLATE NOCASE ASC`)
+    .all() as Group[];
+  return groups.map((g) => ({
+    ...g,
+    areas: getGroupAreas(g.id),
+    member_count: countGroupMembers(g.id),
+  }));
+}
+
+export function createGroup(name: string, scope: GroupScope): Group {
+  const info = db.prepare('INSERT INTO groups (name, scope) VALUES (?, ?)').run(name, scope);
+  const created = getGroup(Number(info.lastInsertRowid));
+  if (!created) {
+    throw new Error('Failed to load group after creation');
+  }
+  return created;
+}
+
+export function updateGroup(id: number, changes: { name?: string; scope?: GroupScope }): Group {
+  const group = getGroup(id);
+  if (!group) {
+    throw new GroupInvariantError('Group not found');
+  }
+  // Operations must always stay global-scope. Primary and Sub-Area groups may flip freely.
+  if (
+    changes.scope !== undefined &&
+    changes.scope !== 'global' &&
+    group.system_key === 'operations'
+  ) {
+    throw new GroupInvariantError('Operations must remain a global-scope group');
+  }
+  const nextName = changes.name !== undefined ? changes.name : group.name;
+  const nextScope = changes.scope !== undefined ? changes.scope : group.scope;
+  db.prepare(`UPDATE groups SET name = ?, scope = ?, updated_at = datetime('now') WHERE id = ?`).run(
+    nextName,
+    nextScope,
+    id
+  );
+  const updated = getGroup(id);
+  if (!updated) {
+    throw new Error('Failed to load group after update');
+  }
+  return updated;
+}
+
+export function deleteGroup(id: number): void {
+  const group = getGroup(id);
+  if (!group) {
+    throw new GroupInvariantError('Group not found');
+  }
+  if (group.system_key) {
+    throw new GroupInvariantError('System groups cannot be deleted');
+  }
+  // ON DELETE CASCADE clears group_areas rows for this group.
+  db.prepare('DELETE FROM groups WHERE id = ?').run(id);
+}
+
+/** Replace-set the group's areas. Input is assumed already validated/normalized by the caller. */
+export function setGroupAreas(id: number, areas: string[]): string[] {
+  const replace = db.transaction((groupId: number, list: string[]) => {
+    db.prepare('DELETE FROM group_areas WHERE group_id = ?').run(groupId);
+    const insert = db.prepare('INSERT INTO group_areas (group_id, area) VALUES (?, ?)');
+    for (const area of list) {
+      insert.run(groupId, area);
+    }
+  });
+  replace(id, areas);
+  return getGroupAreas(id);
+}
+
+/**
+ * Resolve a user's membership for the enriched /auth payloads. areas is [] for a global-scope
+ * group, an unassigned user, a dangling group_id, or a scoped group with no areas assigned.
+ */
+export function getMembershipContext(userId: number): MembershipContext {
+  const user = db.prepare('SELECT group_id, group_role FROM users WHERE id = ?').get(userId) as
+    | { group_id: number | null; group_role: GroupRole }
+    | undefined;
+  if (!user) {
+    return { group: null, group_role: 'member', areas: [] };
+  }
+  const groupRole: GroupRole = user.group_role === 'lead' ? 'lead' : 'member';
+  if (user.group_id == null) {
+    return { group: null, group_role: groupRole, areas: [] };
+  }
+  const group = getGroup(user.group_id);
+  if (!group) {
+    // group_id points at a deleted group (no DB FK) — treat as unassigned.
+    return { group: null, group_role: groupRole, areas: [] };
+  }
+  return {
+    group: { id: group.id, name: group.name, scope: group.scope, system_key: group.system_key },
+    group_role: groupRole,
+    areas: group.scope === 'global' ? [] : getGroupAreas(group.id),
+  };
+}

--- a/auth-backend/src/index.ts
+++ b/auth-backend/src/index.ts
@@ -32,6 +32,8 @@ import session from 'express-session';
 import authRoutes from './routes/auth.js';
 import googleAuthRoutes from './routes/googleAuth.js';
 import adminRoutes from './routes/admin.js';
+import groupRoutes from './routes/groups.js';
+import leadRoutes from './routes/lead.js';
 import communityGameRoutes from './routes/communityGame.js';
 import userUiPreferencesRoutes from './routes/userUiPreferences.js';
 import contactRoutes from './routes/contact.js';
@@ -93,6 +95,8 @@ app.use('/api/auth', communityGameRoutes);
 app.use('/api/auth', userUiPreferencesRoutes);
 app.use('/api/auth', googleAuthRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/admin/groups', groupRoutes);
+app.use('/api/lead', leadRoutes);
 app.use('/api', contactRoutes);
 app.use('/api', feedbackRoutes);
 

--- a/auth-backend/src/middleware/teamLead.ts
+++ b/auth-backend/src/middleware/teamLead.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction } from 'express';
+import db from '../db/database.js';
+import { AuthRequest } from './auth.js';
+import type { GroupRole } from '../types/group.js';
+
+/**
+ * Middleware: the caller must be a Team Lead — a staff user whose membership is group_role='lead'
+ * with a non-null group. Must run after authenticateToken + requireEmailVerified. The JWT carries no
+ * group data, so the caller's row is loaded fresh from the DB; the lead's group id is attached to
+ * the request as req.leadGroupId for the route handlers.
+ */
+export const requireTeamLead = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const authUser = (req as AuthRequest).user;
+  if (!authUser) {
+    res.status(401).json({ error: 'Authentication required' });
+    return;
+  }
+
+  const row = db
+    .prepare('SELECT role, group_id, group_role FROM users WHERE id = ?')
+    .get(authUser.id) as
+    | { role: string; group_id: number | null; group_role: GroupRole }
+    | undefined;
+
+  if (!row) {
+    res.status(404).json({ error: 'User not found' });
+    return;
+  }
+
+  if (row.role !== 'staff' || row.group_role !== 'lead' || row.group_id === null) {
+    res.status(403).json({ error: 'Team lead access required' });
+    return;
+  }
+
+  (req as AuthRequest).leadGroupId = row.group_id;
+  next();
+};

--- a/auth-backend/src/routes/admin.ts
+++ b/auth-backend/src/routes/admin.ts
@@ -1,10 +1,12 @@
 import express, { Request, Response } from 'express';
 import crypto from 'crypto';
 import db from '../db/database.js';
+import { getGroup } from '../db/groupsRepo.js';
 import { authenticateToken, AuthRequest, requireEmailVerified } from '../middleware/auth.js';
 import { requireAdmin } from '../middleware/admin.js';
 import { sendAdminPromotionEmail } from '../services/email.js';
 import type { User, UserRole } from '../types/user.js';
+import type { GroupRole } from '../types/group.js';
 
 const router = express.Router();
 
@@ -117,9 +119,16 @@ router.get(
     try {
       const users = db
         .prepare(
-          'SELECT id, email, name, role, created_at FROM users ORDER BY created_at DESC'
+          `SELECT u.id, u.email, u.name, u.role, u.created_at, u.group_id, u.group_role, g.name AS group_name
+             FROM users u
+             LEFT JOIN groups g ON g.id = u.group_id
+            ORDER BY u.created_at DESC`
         )
-        .all() as (Omit<User, 'google_id'>)[];
+        .all() as Array<
+          Pick<User, 'id' | 'email' | 'name' | 'role' | 'created_at' | 'group_id' | 'group_role'> & {
+            group_name: string | null;
+          }
+        >;
 
       res.json({
         success: true,
@@ -196,6 +205,105 @@ router.patch(
       });
     } catch (error) {
       console.error('Set role error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  }
+);
+
+// Set a user's group membership (admin only). One-step stray-user correction: lateral moves and
+// promotions do NOT log the user out. Revocation is bumped ONLY when privileges are reduced.
+router.patch(
+  '/users/:id/membership',
+  authenticateToken,
+  requireEmailVerified,
+  requireAdmin,
+  (req: Request, res: Response) => {
+    try {
+      const userId = Number(req.params.id);
+      if (!Number.isInteger(userId) || userId < 1) {
+        res.status(400).json({ error: 'Invalid user ID' });
+        return;
+      }
+
+      const body = req.body as { group_id?: unknown; group_role?: unknown };
+
+      // group_id is required and must be an integer group id or null.
+      if (!('group_id' in body) || (body.group_id !== null && !Number.isInteger(body.group_id))) {
+        res.status(400).json({ error: 'group_id must be a group id or null' });
+        return;
+      }
+      const newGroupId = body.group_id === null ? null : Number(body.group_id);
+
+      let requestedRole: GroupRole | undefined;
+      if (body.group_role !== undefined) {
+        if (body.group_role !== 'member' && body.group_role !== 'lead') {
+          res.status(400).json({ error: "group_role must be 'member' or 'lead'" });
+          return;
+        }
+        requestedRole = body.group_role;
+      }
+
+      const user = db
+        .prepare('SELECT id, email, role, group_id, group_role FROM users WHERE id = ?')
+        .get(userId) as
+        | { id: number; email: string; role: UserRole; group_id: number | null; group_role: GroupRole }
+        | undefined;
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      if (newGroupId !== null && !getGroup(newGroupId)) {
+        res.status(400).json({ error: 'Unknown group_id' });
+        return;
+      }
+
+      const prevGroupId = user.group_id;
+      const prevGroupRole: GroupRole = user.group_role === 'lead' ? 'lead' : 'member';
+
+      // Unassigning forces 'member'; otherwise honor an explicit request, else keep the current rank.
+      let newGroupRole: GroupRole;
+      if (newGroupId === null) {
+        newGroupRole = 'member';
+      } else if (requestedRole !== undefined) {
+        newGroupRole = requestedRole;
+      } else {
+        newGroupRole = prevGroupRole;
+      }
+
+      // Leads must be staff. Admins may hold 'lead' harmlessly; community users cannot.
+      if (newGroupRole === 'lead' && user.role === 'community') {
+        res.status(400).json({ error: 'Only staff or admin users can be group leads' });
+        return;
+      }
+
+      db.prepare(
+        'UPDATE users SET group_id = ?, group_role = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+      ).run(newGroupId, newGroupRole, userId);
+
+      // Revoke existing JWTs only when privileges are reduced: dropping the lead rank, or releasing a
+      // still-privileged (staff/admin) user to Unassigned. Lateral moves and promotions must not bump.
+      const demotedFromLead = prevGroupRole === 'lead' && newGroupRole !== 'lead';
+      const releasedToUnassigned =
+        prevGroupId !== null &&
+        newGroupId === null &&
+        (user.role === 'staff' || user.role === 'admin');
+      if (demotedFromLead || releasedToUnassigned) {
+        db.prepare('UPDATE users SET tokens_valid_after = CURRENT_TIMESTAMP WHERE id = ?').run(userId);
+      }
+
+      res.json({
+        success: true,
+        user: {
+          id: user.id,
+          email: user.email,
+          role: user.role,
+          group_id: newGroupId,
+          group_role: newGroupRole,
+        },
+      });
+    } catch (error) {
+      console.error('Set membership error:', error);
       res.status(500).json({ error: 'Internal server error' });
     }
   }

--- a/auth-backend/src/routes/auth.ts
+++ b/auth-backend/src/routes/auth.ts
@@ -3,6 +3,7 @@ import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import db from '../db/database.js';
+import { getMembershipContext } from '../db/groupsRepo.js';
 import { authenticateToken, AuthRequest } from '../middleware/auth.js';
 import { validatePassword } from '../utils/passwordPolicy.js';
 import { sendVerificationEmail } from '../services/email.js';
@@ -290,6 +291,9 @@ router.get('/me', authenticateToken, (req: Request, res: Response) => {
       return;
     }
 
+    // Additive group fields (PR-2's Flask consumer reads these; existing clients ignore them).
+    const membership = getMembershipContext(user.id);
+
     res.json({
       success: true,
       user: {
@@ -298,6 +302,9 @@ router.get('/me', authenticateToken, (req: Request, res: Response) => {
         name: user.name,
         role: user.role,
         email_verified: Boolean(user.email_verified),
+        group: membership.group,
+        group_role: membership.group_role,
+        areas: membership.areas,
       },
     });
   } catch (error) {
@@ -307,13 +314,37 @@ router.get('/me', authenticateToken, (req: Request, res: Response) => {
 });
 
 // Validate token (signature + revocation). Used by Flask backend to enforce demotion revocation.
+// role is re-read fresh from the DB (not the JWT claim) and the group fields are additive, so PR-2's
+// Flask consumer can authorize off this body while the JWT stays identity-only.
 router.post('/validate', authenticateToken, (req: Request, res: Response) => {
   const authUser = (req as AuthRequest).user;
   if (!authUser) {
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
-  res.json({ valid: true, user: authUser });
+
+  const user = db
+    .prepare('SELECT id, email, role, email_verified FROM users WHERE id = ?')
+    .get(authUser.id) as User | undefined;
+  if (!user) {
+    res.status(401).json({ error: 'Token has been revoked' });
+    return;
+  }
+
+  const membership = getMembershipContext(user.id);
+
+  res.json({
+    valid: true,
+    user: {
+      id: user.id,
+      email: user.email,
+      role: user.role,
+      email_verified: Boolean(user.email_verified),
+      group: membership.group,
+      group_role: membership.group_role,
+      areas: membership.areas,
+    },
+  });
 });
 
 // Logout (client-side token removal, but we can track it here if needed)

--- a/auth-backend/src/routes/groups.ts
+++ b/auth-backend/src/routes/groups.ts
@@ -1,0 +1,242 @@
+import express, { Request, Response } from 'express';
+import { authenticateToken, requireEmailVerified } from '../middleware/auth.js';
+import { requireAdmin } from '../middleware/admin.js';
+import {
+  listGroupsWithMeta,
+  getGroup,
+  getGroupByName,
+  countGroupMembers,
+  createGroup,
+  updateGroup,
+  deleteGroup,
+  setGroupAreas,
+  GroupInvariantError,
+} from '../db/groupsRepo.js';
+import type { GroupScope } from '../types/group.js';
+
+const router = express.Router();
+
+// Every group-management route is admin-only and requires a verified email.
+router.use(authenticateToken, requireEmailVerified, requireAdmin);
+
+function isValidScope(v: unknown): v is GroupScope {
+  return v === 'global' || v === 'scoped';
+}
+
+function parseGroupId(raw: string): number | null {
+  const id = Number(raw);
+  return Number.isInteger(id) && id >= 1 ? id : null;
+}
+
+type AreaResult = { ok: true; areas: string[] } | { ok: false; error: string };
+
+/**
+ * Normalize an incoming areas payload: array of non-empty trimmed strings, strip leading/trailing
+ * '/', reject '..' segments, dedupe case-insensitively. Areas are opaque path prefixes; the Flask
+ * backend validates that they map to real folders later.
+ */
+function normalizeAreas(input: unknown): AreaResult {
+  if (!Array.isArray(input)) {
+    return { ok: false, error: 'areas must be an array of strings' };
+  }
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of input) {
+    if (typeof raw !== 'string') {
+      return { ok: false, error: 'areas must be an array of strings' };
+    }
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return { ok: false, error: 'areas cannot be empty' };
+    }
+    const area = trimmed.replace(/^\/+/, '').replace(/\/+$/, '');
+    if (!area) {
+      return { ok: false, error: 'areas cannot be empty' };
+    }
+    if (area.split('/').some((seg) => seg.trim() === '..')) {
+      return { ok: false, error: 'areas cannot contain ".." segments' };
+    }
+    const key = area.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(area);
+  }
+  return { ok: true, areas: out };
+}
+
+// List all groups with their areas and member counts.
+router.get('/', (_req: Request, res: Response) => {
+  try {
+    const groups = listGroupsWithMeta().map((g) => ({
+      id: g.id,
+      name: g.name,
+      scope: g.scope,
+      system_key: g.system_key,
+      areas: g.areas,
+      member_count: g.member_count,
+      created_at: g.created_at,
+    }));
+    res.json({ success: true, groups });
+  } catch (error) {
+    console.error('List groups error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Create a Sub-Area group. system_key cannot be supplied (system groups are seeded, never created here).
+router.post('/', (req: Request, res: Response) => {
+  try {
+    const body = req.body as { name?: unknown; scope?: unknown; system_key?: unknown };
+
+    if (body.system_key != null) {
+      res.status(400).json({ error: 'system_key cannot be set' });
+      return;
+    }
+
+    const name = typeof body.name === 'string' ? body.name.trim() : '';
+    if (!name) {
+      res.status(400).json({ error: 'Group name is required' });
+      return;
+    }
+
+    const scope = body.scope === undefined ? 'scoped' : body.scope;
+    if (!isValidScope(scope)) {
+      res.status(400).json({ error: "scope must be 'global' or 'scoped'" });
+      return;
+    }
+
+    if (getGroupByName(name)) {
+      res.status(400).json({ error: 'A group with this name already exists' });
+      return;
+    }
+
+    const group = createGroup(name, scope);
+    res.status(201).json({ success: true, group });
+  } catch (error) {
+    console.error('Create group error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Rename / re-scope a group. Operations cannot leave 'global'; Primary may flip (the future lever).
+router.patch('/:id', (req: Request, res: Response) => {
+  try {
+    const id = parseGroupId(req.params.id);
+    if (id === null) {
+      res.status(400).json({ error: 'Invalid group ID' });
+      return;
+    }
+    const group = getGroup(id);
+    if (!group) {
+      res.status(404).json({ error: 'Group not found' });
+      return;
+    }
+
+    const body = req.body as { name?: unknown; scope?: unknown };
+    const changes: { name?: string; scope?: GroupScope } = {};
+
+    if (body.name !== undefined) {
+      const name = typeof body.name === 'string' ? body.name.trim() : '';
+      if (!name) {
+        res.status(400).json({ error: 'Group name is required' });
+        return;
+      }
+      const collision = getGroupByName(name);
+      if (collision && collision.id !== id) {
+        res.status(400).json({ error: 'A group with this name already exists' });
+        return;
+      }
+      changes.name = name;
+    }
+
+    if (body.scope !== undefined) {
+      if (!isValidScope(body.scope)) {
+        res.status(400).json({ error: "scope must be 'global' or 'scoped'" });
+        return;
+      }
+      changes.scope = body.scope;
+    }
+
+    if (
+      changes.scope !== undefined &&
+      changes.scope !== 'global' &&
+      group.system_key === 'operations'
+    ) {
+      res.status(400).json({ error: 'Operations must remain a global-scope group' });
+      return;
+    }
+
+    const updated = updateGroup(id, changes);
+    res.json({ success: true, group: updated });
+  } catch (error) {
+    if (error instanceof GroupInvariantError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    console.error('Update group error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Delete a group. System groups can never be deleted; a group with members returns 409.
+router.delete('/:id', (req: Request, res: Response) => {
+  try {
+    const id = parseGroupId(req.params.id);
+    if (id === null) {
+      res.status(400).json({ error: 'Invalid group ID' });
+      return;
+    }
+    const group = getGroup(id);
+    if (!group) {
+      res.status(404).json({ error: 'Group not found' });
+      return;
+    }
+    if (group.system_key) {
+      res.status(400).json({ error: 'System groups cannot be deleted' });
+      return;
+    }
+    const memberCount = countGroupMembers(id);
+    if (memberCount > 0) {
+      res.status(409).json({ error: 'Group still has members', member_count: memberCount });
+      return;
+    }
+    deleteGroup(id);
+    res.json({ success: true, message: `Group ${group.name} has been deleted` });
+  } catch (error) {
+    if (error instanceof GroupInvariantError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    console.error('Delete group error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Replace the group's assigned area path prefixes.
+router.put('/:id/areas', (req: Request, res: Response) => {
+  try {
+    const id = parseGroupId(req.params.id);
+    if (id === null) {
+      res.status(400).json({ error: 'Invalid group ID' });
+      return;
+    }
+    if (!getGroup(id)) {
+      res.status(404).json({ error: 'Group not found' });
+      return;
+    }
+    const normalized = normalizeAreas((req.body as { areas?: unknown }).areas);
+    if (!normalized.ok) {
+      res.status(400).json({ error: normalized.error });
+      return;
+    }
+    const areas = setGroupAreas(id, normalized.areas);
+    res.json({ success: true, areas });
+  } catch (error) {
+    console.error('Set group areas error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/auth-backend/src/routes/lead.ts
+++ b/auth-backend/src/routes/lead.ts
@@ -1,0 +1,253 @@
+import express, { Request, Response } from 'express';
+import db from '../db/database.js';
+import { getGroup, getGroupAreas } from '../db/groupsRepo.js';
+import { authenticateToken, AuthRequest, requireEmailVerified } from '../middleware/auth.js';
+import { requireTeamLead } from '../middleware/teamLead.js';
+import type { GroupRole } from '../types/group.js';
+import type { UserRole } from '../types/user.js';
+
+const router = express.Router();
+
+// Every lead route requires a verified email and a caller who is a Team Lead.
+router.use(authenticateToken, requireEmailVerified, requireTeamLead);
+
+interface MemberRow {
+  id: number;
+  email: string;
+  role: UserRole;
+  group_id: number | null;
+  group_role: GroupRole;
+}
+
+function leadContext(req: Request): { groupId: number; callerId: number } | null {
+  const authReq = req as AuthRequest;
+  const groupId = authReq.leadGroupId;
+  const callerId = authReq.user?.id;
+  if (groupId === undefined || callerId === undefined) {
+    return null;
+  }
+  return { groupId, callerId };
+}
+
+// The lead's own group: metadata, areas, and members ordered by join date.
+router.get('/group', (req: Request, res: Response) => {
+  try {
+    const ctx = leadContext(req);
+    if (!ctx) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const group = getGroup(ctx.groupId);
+    if (!group) {
+      res.status(404).json({ error: 'Group not found' });
+      return;
+    }
+    const members = db
+      .prepare(
+        'SELECT id, email, name, role, group_role, created_at FROM users WHERE group_id = ? ORDER BY created_at ASC'
+      )
+      .all(ctx.groupId) as Array<{
+      id: number;
+      email: string;
+      name: string | null;
+      role: UserRole;
+      group_role: GroupRole;
+      created_at: string;
+    }>;
+
+    res.json({
+      success: true,
+      group: { id: group.id, name: group.name, scope: group.scope, system_key: group.system_key },
+      areas: getGroupAreas(group.id),
+      members,
+    });
+  } catch (error) {
+    console.error('Lead get group error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Claim an unassigned community user into the lead's group as a plain member.
+router.post('/members/claim', (req: Request, res: Response) => {
+  try {
+    const ctx = leadContext(req);
+    if (!ctx) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const rawEmail = (req.body as { email?: unknown }).email;
+    const email = typeof rawEmail === 'string' ? rawEmail.trim().toLowerCase() : '';
+    if (!email) {
+      res.status(400).json({ error: 'Email is required' });
+      return;
+    }
+
+    const target = db
+      .prepare('SELECT id, email, role, group_id, group_role FROM users WHERE email = ?')
+      .get(email) as MemberRow | undefined;
+    if (!target) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+    if (target.group_id !== null || target.role !== 'community') {
+      res.status(400).json({ error: 'Only unassigned community users can be claimed' });
+      return;
+    }
+
+    db.prepare(
+      "UPDATE users SET group_id = ?, group_role = 'member', updated_at = CURRENT_TIMESTAMP WHERE id = ?"
+    ).run(ctx.groupId, target.id);
+
+    res.json({
+      success: true,
+      user: {
+        id: target.id,
+        email: target.email,
+        role: target.role,
+        group_id: ctx.groupId,
+        group_role: 'member',
+      },
+    });
+  } catch (error) {
+    console.error('Lead claim member error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Promote / demote a member one rung within the lead's group.
+router.patch('/members/:id/rank', (req: Request, res: Response) => {
+  try {
+    const ctx = leadContext(req);
+    if (!ctx) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const targetId = Number(req.params.id);
+    if (!Number.isInteger(targetId) || targetId < 1) {
+      res.status(400).json({ error: 'Invalid user ID' });
+      return;
+    }
+    const action = (req.body as { action?: unknown }).action;
+    if (action !== 'promote' && action !== 'demote') {
+      res.status(400).json({ error: "action must be 'promote' or 'demote'" });
+      return;
+    }
+
+    const target = db
+      .prepare('SELECT id, email, role, group_id, group_role FROM users WHERE id = ?')
+      .get(targetId) as MemberRow | undefined;
+    if (!target) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+    if (target.group_id !== ctx.groupId) {
+      res.status(403).json({ error: 'User is not in your group' });
+      return;
+    }
+    if (target.id === ctx.callerId) {
+      res.status(400).json({ error: 'You cannot change your own rank' });
+      return;
+    }
+    if (target.role === 'admin') {
+      res.status(403).json({ error: 'Cannot change the rank of an admin' });
+      return;
+    }
+
+    let newRole: UserRole = target.role;
+    let newGroupRole: GroupRole = target.group_role === 'lead' ? 'lead' : 'member';
+    let bump = false;
+
+    if (action === 'promote') {
+      if (target.role === 'community') {
+        newRole = 'staff';
+        newGroupRole = 'member';
+      } else if (target.role === 'staff' && newGroupRole === 'member') {
+        newGroupRole = 'lead';
+      } else {
+        // staff + lead
+        res.status(400).json({ error: 'User is already at the top rank' });
+        return;
+      }
+    } else {
+      // demote — reducing privileges always bumps revocation.
+      if (target.role === 'staff' && newGroupRole === 'lead') {
+        newGroupRole = 'member';
+        bump = true;
+      } else if (target.role === 'staff' && newGroupRole === 'member') {
+        newRole = 'community';
+        bump = true;
+      } else {
+        // community
+        res.status(400).json({ error: 'User is already at the bottom rank' });
+        return;
+      }
+    }
+
+    db.prepare(
+      'UPDATE users SET role = ?, group_role = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+    ).run(newRole, newGroupRole, target.id);
+    if (bump) {
+      db.prepare('UPDATE users SET tokens_valid_after = CURRENT_TIMESTAMP WHERE id = ?').run(target.id);
+    }
+
+    res.json({
+      success: true,
+      user: { id: target.id, email: target.email, role: newRole, group_role: newGroupRole },
+    });
+  } catch (error) {
+    console.error('Lead rank member error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Release a member back to Unassigned (staff are demoted to community, which bumps revocation).
+router.delete('/members/:id', (req: Request, res: Response) => {
+  try {
+    const ctx = leadContext(req);
+    if (!ctx) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const targetId = Number(req.params.id);
+    if (!Number.isInteger(targetId) || targetId < 1) {
+      res.status(400).json({ error: 'Invalid user ID' });
+      return;
+    }
+
+    const target = db
+      .prepare('SELECT id, email, role, group_id, group_role FROM users WHERE id = ?')
+      .get(targetId) as MemberRow | undefined;
+    if (!target) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+    if (target.group_id !== ctx.groupId) {
+      res.status(403).json({ error: 'User is not in your group' });
+      return;
+    }
+    if (target.id === ctx.callerId) {
+      res.status(400).json({ error: 'You cannot remove yourself from the group' });
+      return;
+    }
+    if (target.role === 'admin') {
+      res.status(403).json({ error: 'Cannot remove an admin' });
+      return;
+    }
+
+    const wasStaff = target.role === 'staff';
+    const newRole: UserRole = wasStaff ? 'community' : target.role;
+    db.prepare(
+      "UPDATE users SET group_id = NULL, group_role = 'member', role = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?"
+    ).run(newRole, target.id);
+    if (wasStaff) {
+      db.prepare('UPDATE users SET tokens_valid_after = CURRENT_TIMESTAMP WHERE id = ?').run(target.id);
+    }
+
+    res.json({ success: true, message: `${target.email} released to Unassigned` });
+  } catch (error) {
+    console.error('Lead remove member error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/auth-backend/src/scripts/create-initial-admin.ts
+++ b/auth-backend/src/scripts/create-initial-admin.ts
@@ -10,7 +10,7 @@
  *   INITIAL_ADMIN_NAME="Admin User"
  */
 
-import db from '../db/database.js';
+import db, { migrateBackfillMembership } from '../db/database.js';
 import bcrypt from 'bcryptjs';
 import type { User } from '../types/user.js';
 
@@ -40,6 +40,7 @@ async function createInitialAdmin() {
 
     if (existingUser) {
       if (existingUser.role === 'admin') {
+        migrateBackfillMembership(db);
         console.log(`User ${email} already exists and is already an admin.`);
         process.exit(0);
       } else {
@@ -48,6 +49,8 @@ async function createInitialAdmin() {
           'admin',
           existingUser.id
         );
+        // Route the (now unassigned-admin) user into Operations, like any bootstrap admin.
+        migrateBackfillMembership(db);
         console.log(`User ${email} has been promoted to admin.`);
         process.exit(0);
       }
@@ -64,6 +67,10 @@ async function createInitialAdmin() {
          VALUES (?, ?, ?, ?, 1, ?, ?, ?)`
       )
       .run(email.toLowerCase(), passwordHash, name, 'admin', now, now, now);
+
+    // Boot-time backfill only runs when the group columns are first added, so an
+    // admin created on an already-migrated DB is routed into Operations here.
+    migrateBackfillMembership(db);
 
     console.log('✅ Initial admin user created successfully!');
     console.log(`   Email: ${email}`);

--- a/auth-backend/src/scripts/seed-test-users.ts
+++ b/auth-backend/src/scripts/seed-test-users.ts
@@ -4,97 +4,21 @@
  * Usage:
  *   npm run seed-test-users
  *
- * Or set environment variables:
- *   E2E_ADMIN_EMAIL=admin@test.com
- *   E2E_ADMIN_PASSWORD=testpassword123
- *   E2E_COMMUNITY_EMAIL=community@test.com
- *   E2E_COMMUNITY_PASSWORD=testpassword123
- *   E2E_STAFF_EMAIL=staff@test.com (optional)
- *   E2E_STAFF_PASSWORD=testpassword123 (optional)
+ * Or set environment variables (email + password for each seeded user):
+ *   E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD
+ *   E2E_COMMUNITY_EMAIL / E2E_COMMUNITY_PASSWORD
+ *   E2E_STAFF_EMAIL / E2E_STAFF_PASSWORD
+ *   E2E_ROLE_TEST_EMAIL / E2E_ROLE_TEST_PASSWORD
+ *   E2E_TEAMLEAD_EMAIL / E2E_TEAMLEAD_PASSWORD
+ *   E2E_SCOPED_STAFF_EMAIL / E2E_SCOPED_STAFF_PASSWORD
+ *   E2E_UNASSIGNED_EMAIL / E2E_UNASSIGNED_PASSWORD
  */
 
-import db from '../db/database.js';
-import bcrypt from 'bcryptjs';
-import type { User } from '../types/user.js';
+import { seedTestUsers } from './seedTestData.js';
 
-const adminEmail = process.env.E2E_ADMIN_EMAIL || 'admin@test.com';
-const adminPassword = process.env.E2E_ADMIN_PASSWORD || 'testpassword123';
-const communityEmail = process.env.E2E_COMMUNITY_EMAIL || 'community@test.com';
-const communityPassword = process.env.E2E_COMMUNITY_PASSWORD || 'testpassword123';
-const staffEmail = process.env.E2E_STAFF_EMAIL || 'staff@test.com';
-const staffPassword = process.env.E2E_STAFF_PASSWORD || 'testpassword123';
-const roleTestEmail =
-  process.env.E2E_ROLE_TEST_EMAIL || 'role-test-community@test.com';
-const roleTestPassword =
-  process.env.E2E_ROLE_TEST_PASSWORD || 'testpassword123';
-
-async function createUser(
-  email: string,
-  password: string,
-  role: 'admin' | 'staff' | 'community',
-  name: string | null = null
-) {
-  // Check if user already exists
-  const existingUser = db
-    .prepare('SELECT id, role FROM users WHERE email = ?')
-    .get(email.toLowerCase()) as User | undefined;
-
-  if (existingUser) {
-    // Always set password and role to seed values so E2E credentials work regardless of prior state
-    const now = new Date().toISOString();
-    const passwordHash = await bcrypt.hash(password, 10);
-    db.prepare(
-      'UPDATE users SET password_hash = ?, role = ?, email_verified = ?, email_verified_at = ?, updated_at = ? WHERE id = ?'
-    ).run(passwordHash, role, 1, now, now, existingUser.id);
-    console.log(`✅ User ${email} updated (password + role) for e2e`);
-    return;
-  }
-
-  // Hash password
-  const passwordHash = await bcrypt.hash(password, 10);
-
-  // Create user
-  const result = db
-    .prepare('INSERT INTO users (email, password_hash, name, role) VALUES (?, ?, ?, ?)')
-    .run(email.toLowerCase(), passwordHash, name, role);
-
-  const now = new Date().toISOString();
-  const newId = Number(result.lastInsertRowid);
-  db.prepare(
-    'UPDATE users SET email_verified = ?, email_verified_at = ?, updated_at = ? WHERE id = ?'
-  ).run(1, now, now, newId);
-
-  console.log(`✅ Created ${role} user: ${email} (ID: ${newId})`);
-}
-
-async function seedTestUsers() {
-  try {
-    console.log('🌱 Seeding test users for e2e tests...\n');
-
-    // Create admin user
-    await createUser(adminEmail, adminPassword, 'admin', 'Test Admin');
-
-    // Create community user
-    await createUser(communityEmail, communityPassword, 'community', 'Test Community');
-
-    // Create staff user (same rights as admin except user management)
-    await createUser(staffEmail, staffPassword, 'staff', 'Test Staff');
-
-    // Dedicated user for "change role" E2E test (never use community@test.com so other tests are not affected)
-    await createUser(roleTestEmail, roleTestPassword, 'community', 'Role Test');
-
-    console.log('\n✅ Test users seeded successfully!');
-    console.log(`   Admin: ${adminEmail}`);
-    console.log(`   Staff: ${staffEmail}`);
-    console.log(`   Community: ${communityEmail}`);
-    console.log(`   Role test (community): ${roleTestEmail}`);
-    console.log(`   Password: ${adminPassword} (same for all)\n`);
-
-    process.exit(0);
-  } catch (error) {
+seedTestUsers()
+  .then(() => process.exit(0))
+  .catch((error) => {
     console.error('❌ Error seeding test users:', error);
     process.exit(1);
-  }
-}
-
-seedTestUsers();
+  });

--- a/auth-backend/src/scripts/seedTestData.ts
+++ b/auth-backend/src/scripts/seedTestData.ts
@@ -1,0 +1,168 @@
+/**
+ * Shared e2e/integration seed logic used by both `seed-test-users.ts` and `test-setup.ts`.
+ *
+ * Seeds the four base users (admin/community/staff/role-test), a scoped group `KansasTeam` whose one
+ * area maps to a real fixture-data folder, and three group-aware users (team lead, scoped staff,
+ * unassigned community). The base admin/staff are routed into the Operations/Primary system groups
+ * by the shared backfill migration rather than being assigned here, so their membership matches a
+ * real production boot.
+ */
+import db, { migrateBackfillMembership } from '../db/database.js';
+import bcrypt from 'bcryptjs';
+import { getGroupByName, createGroup, setGroupAreas } from '../db/groupsRepo.js';
+import type { GroupRole } from '../types/group.js';
+import type { User } from '../types/user.js';
+
+const adminEmail = process.env.E2E_ADMIN_EMAIL || 'admin@test.com';
+const adminPassword = process.env.E2E_ADMIN_PASSWORD || 'testpassword123';
+const communityEmail = process.env.E2E_COMMUNITY_EMAIL || 'community@test.com';
+const communityPassword = process.env.E2E_COMMUNITY_PASSWORD || 'testpassword123';
+const staffEmail = process.env.E2E_STAFF_EMAIL || 'staff@test.com';
+const staffPassword = process.env.E2E_STAFF_PASSWORD || 'testpassword123';
+const roleTestEmail = process.env.E2E_ROLE_TEST_EMAIL || 'role-test-community@test.com';
+const roleTestPassword = process.env.E2E_ROLE_TEST_PASSWORD || 'testpassword123';
+
+const teamLeadEmail = process.env.E2E_TEAMLEAD_EMAIL || 'teamlead@test.com';
+const teamLeadPassword = process.env.E2E_TEAMLEAD_PASSWORD || 'testpassword123';
+const scopedStaffEmail = process.env.E2E_SCOPED_STAFF_EMAIL || 'scoped-staff@test.com';
+const scopedStaffPassword = process.env.E2E_SCOPED_STAFF_PASSWORD || 'testpassword123';
+const unassignedEmail = process.env.E2E_UNASSIGNED_EMAIL || 'unassigned@test.com';
+const unassignedPassword = process.env.E2E_UNASSIGNED_PASSWORD || 'testpassword123';
+
+// KansasTeam's single area. Must map to a real folder under backend/tests/fixture-data so PR-2's
+// Flask area enforcement resolves it; `Kansas/Topeka` exists there.
+const KANSAS_TEAM_NAME = 'KansasTeam';
+const KANSAS_TEAM_AREA = 'Kansas/Topeka';
+
+/** Create or refresh a base user (password + role + verification). Group membership is untouched. */
+export async function createUser(
+  email: string,
+  password: string,
+  role: 'admin' | 'staff' | 'community',
+  name: string | null = null
+): Promise<void> {
+  const existingUser = db
+    .prepare('SELECT id, role FROM users WHERE email = ?')
+    .get(email.toLowerCase()) as User | undefined;
+
+  if (existingUser) {
+    // Always set password and role to seed values so e2e credentials work regardless of prior state.
+    const now = new Date().toISOString();
+    const passwordHash = await bcrypt.hash(password, 10);
+    db.prepare(
+      'UPDATE users SET password_hash = ?, role = ?, email_verified = ?, email_verified_at = ?, updated_at = ? WHERE id = ?'
+    ).run(passwordHash, role, 1, now, now, existingUser.id);
+    console.log(`✅ User ${email} updated (password + role) for e2e`);
+    return;
+  }
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  const result = db
+    .prepare('INSERT INTO users (email, password_hash, name, role) VALUES (?, ?, ?, ?)')
+    .run(email.toLowerCase(), passwordHash, name, role);
+
+  const now = new Date().toISOString();
+  const newId = Number(result.lastInsertRowid);
+  db.prepare(
+    'UPDATE users SET email_verified = ?, email_verified_at = ?, updated_at = ? WHERE id = ?'
+  ).run(1, now, now, newId);
+
+  console.log(`✅ Created ${role} user: ${email} (ID: ${newId})`);
+}
+
+/** Ensure a scoped group with exactly the given single area exists; returns its id. Idempotent. */
+function ensureScopedGroupWithArea(name: string, area: string): number {
+  let group = getGroupByName(name);
+  if (!group) {
+    group = createGroup(name, 'scoped');
+    console.log(`✅ Created group: ${name} (scoped)`);
+  }
+  setGroupAreas(group.id, [area]);
+  return group.id;
+}
+
+/** Create or refresh a group-aware user (password + role + verification + explicit membership). */
+async function upsertUserWithMembership(
+  email: string,
+  password: string,
+  role: 'staff' | 'community',
+  name: string | null,
+  groupId: number | null,
+  groupRole: GroupRole
+): Promise<void> {
+  const now = new Date().toISOString();
+  const passwordHash = await bcrypt.hash(password, 10);
+  const existing = db
+    .prepare('SELECT id FROM users WHERE email = ?')
+    .get(email.toLowerCase()) as { id: number } | undefined;
+
+  if (existing) {
+    db.prepare(
+      'UPDATE users SET password_hash = ?, role = ?, email_verified = 1, email_verified_at = ?, group_id = ?, group_role = ?, updated_at = ? WHERE id = ?'
+    ).run(passwordHash, role, now, groupId, groupRole, now, existing.id);
+    console.log(`✅ User ${email} updated (membership) for e2e`);
+    return;
+  }
+
+  const result = db
+    .prepare('INSERT INTO users (email, password_hash, name, role) VALUES (?, ?, ?, ?)')
+    .run(email.toLowerCase(), passwordHash, name, role);
+  const newId = Number(result.lastInsertRowid);
+  db.prepare(
+    'UPDATE users SET email_verified = 1, email_verified_at = ?, group_id = ?, group_role = ?, updated_at = ? WHERE id = ?'
+  ).run(now, groupId, groupRole, now, newId);
+  console.log(`✅ Created ${role} user: ${email} (group ${groupId ?? 'none'}, ${groupRole})`);
+}
+
+/** Seed all e2e users, the KansasTeam group, and backfill the base admin/staff into system groups. */
+export async function seedTestUsers(): Promise<void> {
+  console.log('🌱 Seeding test users for e2e tests...\n');
+
+  // Base users (roles only; system-group membership comes from the backfill below).
+  await createUser(adminEmail, adminPassword, 'admin', 'Test Admin');
+  await createUser(communityEmail, communityPassword, 'community', 'Test Community');
+  await createUser(staffEmail, staffPassword, 'staff', 'Test Staff');
+  // Dedicated user for "change role" e2e/integration tests (never community@test.com).
+  await createUser(roleTestEmail, roleTestPassword, 'community', 'Role Test');
+
+  // Scoped Sub-Area group + its members.
+  const kansasTeamId = ensureScopedGroupWithArea(KANSAS_TEAM_NAME, KANSAS_TEAM_AREA);
+  await upsertUserWithMembership(
+    teamLeadEmail,
+    teamLeadPassword,
+    'staff',
+    'Test Team Lead',
+    kansasTeamId,
+    'lead'
+  );
+  await upsertUserWithMembership(
+    scopedStaffEmail,
+    scopedStaffPassword,
+    'staff',
+    'Test Scoped Staff',
+    kansasTeamId,
+    'member'
+  );
+  await upsertUserWithMembership(
+    unassignedEmail,
+    unassignedPassword,
+    'community',
+    'Test Unassigned',
+    null,
+    'member'
+  );
+
+  // Route the freshly-created base admin/staff into Operations/Primary. The module-init backfill runs
+  // before these rows exist (migrations run at import), so re-run it here to assign them in one pass.
+  migrateBackfillMembership(db);
+
+  console.log('\n✅ Test users seeded successfully!');
+  console.log(`   Admin: ${adminEmail} (→ Operations)`);
+  console.log(`   Staff: ${staffEmail} (→ Primary)`);
+  console.log(`   Community: ${communityEmail}`);
+  console.log(`   Role test (community): ${roleTestEmail}`);
+  console.log(`   Team lead: ${teamLeadEmail} (→ ${KANSAS_TEAM_NAME}, lead)`);
+  console.log(`   Scoped staff: ${scopedStaffEmail} (→ ${KANSAS_TEAM_NAME}, member)`);
+  console.log(`   Unassigned: ${unassignedEmail}`);
+  console.log(`   Password: ${adminPassword} (same for all)\n`);
+}

--- a/auth-backend/src/scripts/test-setup.ts
+++ b/auth-backend/src/scripts/test-setup.ts
@@ -1,91 +1,13 @@
 /**
- * Test setup script that seeds test users and then starts the server
- * This is used by Playwright to ensure test users exist before tests run
+ * Test setup script that seeds test users and then exits so the next command (npm run dev) can run.
+ * Used by Playwright (`npm run test:dev`) to ensure test users exist before the server starts.
  */
 
-import db from '../db/database.js';
-import bcrypt from 'bcryptjs';
-import type { User } from '../types/user.js';
+import { seedTestUsers } from './seedTestData.js';
 
-const adminEmail = process.env.E2E_ADMIN_EMAIL || 'admin@test.com';
-const adminPassword = process.env.E2E_ADMIN_PASSWORD || 'testpassword123';
-const staffEmail = process.env.E2E_STAFF_EMAIL || 'staff@test.com';
-const staffPassword = process.env.E2E_STAFF_PASSWORD || 'testpassword123';
-const communityEmail = process.env.E2E_COMMUNITY_EMAIL || 'community@test.com';
-const communityPassword = process.env.E2E_COMMUNITY_PASSWORD || 'testpassword123';
-const roleTestEmail =
-  process.env.E2E_ROLE_TEST_EMAIL || 'role-test-community@test.com';
-const roleTestPassword =
-  process.env.E2E_ROLE_TEST_PASSWORD || 'testpassword123';
-
-async function createUser(
-  email: string,
-  password: string,
-  role: 'admin' | 'staff' | 'community',
-  name: string | null = null
-) {
-  // Check if user already exists
-  const existingUser = db
-    .prepare('SELECT id, role FROM users WHERE email = ?')
-    .get(email.toLowerCase()) as User | undefined;
-
-  if (existingUser) {
-    // Always set password and role to seed values so E2E credentials work regardless of prior state
-    const now = new Date().toISOString();
-    const passwordHash = await bcrypt.hash(password, 10);
-    db.prepare(
-      'UPDATE users SET password_hash = ?, role = ?, email_verified = ?, email_verified_at = ?, updated_at = ? WHERE id = ?'
-    ).run(passwordHash, role, 1, now, now, existingUser.id);
-    console.log(`✅ User ${email} updated (password + role) for e2e`);
-    return;
-  }
-
-  // Hash password
-  const passwordHash = await bcrypt.hash(password, 10);
-
-  // Create user
-  const result = db
-    .prepare('INSERT INTO users (email, password_hash, name, role) VALUES (?, ?, ?, ?)')
-    .run(email.toLowerCase(), passwordHash, name, role);
-
-  const now = new Date().toISOString();
-  const newId = Number(result.lastInsertRowid);
-  db.prepare(
-    'UPDATE users SET email_verified = ?, email_verified_at = ?, updated_at = ? WHERE id = ?'
-  ).run(1, now, now, newId);
-
-  console.log(`✅ Created ${role} user: ${email} (ID: ${newId})`);
-}
-
-async function seedTestUsers() {
-  try {
-    console.log('🌱 Seeding test users for e2e tests...\n');
-
-    // Create admin user
-    await createUser(adminEmail, adminPassword, 'admin', 'Test Admin');
-
-    // Create community user
-    await createUser(communityEmail, communityPassword, 'community', 'Test Community');
-
-    // Create staff user
-    await createUser(staffEmail, staffPassword, 'staff', 'Test Staff');
-
-    // Dedicated user for "change role" E2E test
-    await createUser(roleTestEmail, roleTestPassword, 'community', 'Role Test');
-
-    console.log('\n✅ Test users seeded successfully!');
-    console.log(`   Admin: ${adminEmail}`);
-    console.log(`   Staff: ${staffEmail}`);
-    console.log(`   Community: ${communityEmail}`);
-    console.log(`   Role test (community): ${roleTestEmail}`);
-    console.log(`   Password: ${adminPassword} (same for all)\n`);
-
-    // Exit successfully so the next command (npm run dev) can run
-    process.exit(0);
-  } catch (error) {
+seedTestUsers()
+  .then(() => process.exit(0))
+  .catch((error) => {
     console.error('❌ Error seeding test users:', error);
     process.exit(1);
-  }
-}
-
-seedTestUsers();
+  });

--- a/auth-backend/src/types/express.d.ts
+++ b/auth-backend/src/types/express.d.ts
@@ -13,6 +13,8 @@ declare global {
     }
     interface Request {
       user?: User;
+      /** Set by requireTeamLead: the calling lead's group id (JWT carries no group data). */
+      leadGroupId?: number;
     }
   }
 }

--- a/auth-backend/src/types/group.ts
+++ b/auth-backend/src/types/group.ts
@@ -1,0 +1,29 @@
+/**
+ * Groups + membership metadata.
+ *
+ * Three tiers: Operations (system super-group, always global, holds admins), Primary (system
+ * group, global today but flippable to scoped later), and admin-created Sub-Area groups (scoped,
+ * with area path prefixes). Roles stay community|staff|admin; a Team Lead is a staff user whose
+ * membership carries group_role='lead'. Unassigned users have group_id = NULL.
+ */
+export type GroupScope = 'global' | 'scoped';
+export type GroupRole = 'member' | 'lead';
+
+export interface Group {
+  id: number;
+  name: string;
+  scope: GroupScope;
+  system_key: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * A user's resolved membership, attached to the enriched /auth/validate and /auth/me payloads.
+ * areas is [] when the group is global-scope, when the user is unassigned, or when no areas are set.
+ */
+export interface MembershipContext {
+  group: Pick<Group, 'id' | 'name' | 'scope' | 'system_key'> | null;
+  group_role: GroupRole;
+  areas: string[];
+}

--- a/auth-backend/src/types/user.ts
+++ b/auth-backend/src/types/user.ts
@@ -1,3 +1,5 @@
+import type { GroupRole } from './group.js';
+
 /** User roles: community (default), staff (admin-like, no user management), admin (full, can manage users) */
 export type UserRole = 'community' | 'staff' | 'admin';
 
@@ -10,6 +12,10 @@ export interface User {
   created_at: string;
   email_verified: boolean;
   email_verified_at: string | null;
+  /** Group membership (nullable = unassigned). Enforced by the repo layer, no DB FK. */
+  group_id?: number | null;
+  /** Membership rank within the group; 'lead' marks a Team Lead (staff only). */
+  group_role?: GroupRole;
 }
 
 export interface UserWithoutPassword extends Omit<User, 'password_hash'> {}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -163,6 +163,51 @@ def community_token(auth_url, integration_env):
 
 
 @pytest.fixture(scope="session")
+def teamlead_token(auth_url, integration_env):
+    """Obtain team-lead JWT (staff + KansasTeam, group_role='lead'). Requires seeded team-lead user."""
+    if not integration_env:
+        return None
+    try:
+        return _login_token(
+            auth_url,
+            os.environ.get("E2E_TEAMLEAD_EMAIL", "teamlead@test.com"),
+            os.environ.get("E2E_TEAMLEAD_PASSWORD", "testpassword123"),
+        )
+    except Exception as e:
+        pytest.skip(f"Cannot get team-lead token from auth-backend at {auth_url}/auth/login: {e}")
+
+
+@pytest.fixture(scope="session")
+def scoped_staff_token(auth_url, integration_env):
+    """Obtain scoped-staff JWT (staff + KansasTeam, group_role='member'). Requires seeded scoped-staff user."""
+    if not integration_env:
+        return None
+    try:
+        return _login_token(
+            auth_url,
+            os.environ.get("E2E_SCOPED_STAFF_EMAIL", "scoped-staff@test.com"),
+            os.environ.get("E2E_SCOPED_STAFF_PASSWORD", "testpassword123"),
+        )
+    except Exception as e:
+        pytest.skip(f"Cannot get scoped-staff token from auth-backend at {auth_url}/auth/login: {e}")
+
+
+@pytest.fixture(scope="session")
+def unassigned_token(auth_url, integration_env):
+    """Obtain unassigned-community JWT (no group). Requires seeded unassigned test user."""
+    if not integration_env:
+        return None
+    try:
+        return _login_token(
+            auth_url,
+            os.environ.get("E2E_UNASSIGNED_EMAIL", "unassigned@test.com"),
+            os.environ.get("E2E_UNASSIGNED_PASSWORD", "testpassword123"),
+        )
+    except Exception as e:
+        pytest.skip(f"Cannot get unassigned token from auth-backend at {auth_url}/auth/login: {e}")
+
+
+@pytest.fixture(scope="session")
 def api_client(backend_url, admin_token, integration_env):
     """HTTP client for backend API with admin auth. Skip integration tests if BACKEND_URL/AUTH_URL not set."""
     if not integration_env or not admin_token:

--- a/backend/tests/integration/test_groups_routes.py
+++ b/backend/tests/integration/test_groups_routes.py
@@ -1,0 +1,835 @@
+"""
+Integration tests: auth-backend groups foundation (PR-1).
+
+Covers group CRUD + areas, the enriched /auth/validate & /auth/me membership payloads, admin
+membership moves, and the Team Lead API. Runs against auth-backend in Docker; requires AUTH_URL
+(BACKEND_URL only gates integration_env).
+
+Re-runnable against a persistent DB: throwaway groups use unique names and every mutated user is
+restored to its seed state in a finally block (mirrors test_admin_routes.py's reset pattern). The
+mutable target is the dedicated role-test-community user (never a user whose session token other
+tests depend on), so bumps from promote/demote/release never invalidate another test's fixture.
+
+Run with: BACKEND_URL=... AUTH_URL=... pytest tests/integration/test_groups_routes.py -v
+"""
+
+import os
+import time
+import uuid
+
+import pytest
+import requests
+
+TIMEOUT = 15
+
+ADMIN_EMAIL = os.environ.get("E2E_ADMIN_EMAIL", "admin@test.com")
+STAFF_EMAIL = os.environ.get("E2E_STAFF_EMAIL", "staff@test.com")
+COMMUNITY_EMAIL = os.environ.get("E2E_COMMUNITY_EMAIL", "community@test.com")
+ROLE_TEST_EMAIL = os.environ.get("E2E_ROLE_TEST_EMAIL", "role-test-community@test.com")
+ROLE_TEST_PASSWORD = os.environ.get("E2E_ROLE_TEST_PASSWORD", "testpassword123")
+TEAMLEAD_EMAIL = os.environ.get("E2E_TEAMLEAD_EMAIL", "teamlead@test.com")
+SCOPED_STAFF_EMAIL = os.environ.get("E2E_SCOPED_STAFF_EMAIL", "scoped-staff@test.com")
+UNASSIGNED_EMAIL = os.environ.get("E2E_UNASSIGNED_EMAIL", "unassigned@test.com")
+
+# A freshly-minted token can read as already-revoked ONLY when the app clock is behind UTC: the
+# auth middleware parses SQLite's TZ-less UTC `tokens_valid_after` via `new Date(...)` as local time,
+# shifting it into the future. This never happens in the Docker/UTC integration environment, where
+# these assertions run in full; on a non-UTC dev box we skip rather than emit a false failure.
+_REVOCATION_PRECONDITION_SKIP = (
+    "Fresh token already reads as revoked — app clock is behind UTC vs SQLite's UTC "
+    "tokens_valid_after (resolveBearerUser parses it as local time). Meaningful only under a UTC "
+    "app clock (Docker integration env)."
+)
+
+# The same local-time parse skews the other way on a clock AHEAD of UTC: the bumped cutoff lands in
+# the past, so the revoked token keeps validating. Skip (not fail) there too — the assertion is only
+# meaningful under a UTC app clock.
+_REVOCATION_TZ_AHEAD_SKIP = (
+    "Bumped token still validates on a non-UTC app clock (tokens_valid_after parsed as local time "
+    "lands in the past). Meaningful only under a UTC app clock (Docker integration env)."
+)
+
+
+def _assert_revoked_or_skip(base, tok):
+    """Assert the token now reads revoked; on a non-UTC clock, skip instead of false-failing."""
+    status = _validate(base, tok).status_code
+    if status != 403 and time.timezone != 0:
+        pytest.skip(_REVOCATION_TZ_AHEAD_SKIP)
+    assert status == 403
+
+
+# ----------------------------------------------------------------------------- helpers
+
+
+def _base(auth_url):
+    return auth_url.rstrip("/")
+
+
+def _hdr(token):
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+def _uniq(prefix="ZZTestGroup"):
+    return f"{prefix}_{uuid.uuid4().hex[:12]}"
+
+
+def _login(base, email, password):
+    r = requests.post(
+        f"{base}/auth/login", json={"email": email, "password": password}, timeout=TIMEOUT
+    )
+    r.raise_for_status()
+    return r.json()["token"]
+
+
+def _validate(base, token):
+    return requests.post(f"{base}/auth/validate", headers=_hdr(token), timeout=TIMEOUT)
+
+
+def _me(base, token):
+    return requests.get(f"{base}/auth/me", headers=_hdr(token), timeout=TIMEOUT)
+
+
+def _list_users(base, admin_token):
+    r = requests.get(f"{base}/admin/users", headers=_hdr(admin_token), timeout=TIMEOUT)
+    r.raise_for_status()
+    return r.json().get("users", [])
+
+
+def _find_user(base, admin_token, email):
+    email = email.lower()
+    for u in _list_users(base, admin_token):
+        if str(u.get("email", "")).lower() == email:
+            return u
+    return None
+
+
+def _user_id(base, admin_token, email):
+    u = _find_user(base, admin_token, email)
+    assert u is not None, f"seeded user {email} not found"
+    return u["id"]
+
+
+def _list_groups(base, admin_token):
+    r = requests.get(f"{base}/admin/groups", headers=_hdr(admin_token), timeout=TIMEOUT)
+    r.raise_for_status()
+    return r.json().get("groups", [])
+
+
+def _find_group(base, admin_token, name=None, system_key=None):
+    for g in _list_groups(base, admin_token):
+        if name is not None and g.get("name") == name:
+            return g
+        if system_key is not None and g.get("system_key") == system_key:
+            return g
+    return None
+
+
+def _create_group(base, admin_token, name, scope=None):
+    body = {"name": name}
+    if scope is not None:
+        body["scope"] = scope
+    return requests.post(
+        f"{base}/admin/groups", headers=_hdr(admin_token), json=body, timeout=TIMEOUT
+    )
+
+
+def _delete_group(base, admin_token, group_id):
+    return requests.delete(
+        f"{base}/admin/groups/{group_id}", headers=_hdr(admin_token), timeout=TIMEOUT
+    )
+
+
+def _set_membership(base, admin_token, user_id, group_id, group_role=None):
+    body = {"group_id": group_id}
+    if group_role is not None:
+        body["group_role"] = group_role
+    return requests.patch(
+        f"{base}/admin/users/{user_id}/membership",
+        headers=_hdr(admin_token),
+        json=body,
+        timeout=TIMEOUT,
+    )
+
+
+def _set_role(base, admin_token, user_id, role):
+    return requests.patch(
+        f"{base}/admin/users/{user_id}/role",
+        headers=_hdr(admin_token),
+        json={"role": role},
+        timeout=TIMEOUT,
+    )
+
+
+def _force_unassigned_community(base, admin_token, user_id):
+    """Reset a mutable user to (community, unassigned, member). Idempotent; keeps tests re-runnable."""
+    _set_membership(base, admin_token, user_id, None)
+    _set_role(base, admin_token, user_id, "community")
+
+
+# ----------------------------------------------------------------------------- group CRUD
+
+
+def test_groups_list_requires_admin(
+    auth_url, integration_env, admin_token, staff_token, community_token
+):
+    """GET /admin/groups: admin 200, staff/community 403, anonymous 401."""
+    if not integration_env or not admin_token or not staff_token or not community_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded users) to run")
+    base = _base(auth_url)
+
+    r = requests.get(f"{base}/admin/groups", headers=_hdr(admin_token), timeout=TIMEOUT)
+    assert r.status_code == 200, r.text
+    assert r.json().get("success") is True
+
+    r = requests.get(f"{base}/admin/groups", headers=_hdr(staff_token), timeout=TIMEOUT)
+    assert r.status_code == 403
+
+    r = requests.get(f"{base}/admin/groups", headers=_hdr(community_token), timeout=TIMEOUT)
+    assert r.status_code == 403
+
+    r = requests.get(f"{base}/admin/groups", timeout=TIMEOUT)
+    assert r.status_code == 401
+
+
+def test_group_crud_happy_path(auth_url, integration_env, admin_token):
+    """Create (201) -> appears in list with meta -> rename (200) -> delete (200)."""
+    if not integration_env or not admin_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded admin) to run")
+    base = _base(auth_url)
+    name = _uniq()
+    gid = None
+    try:
+        r = _create_group(base, admin_token, name)
+        assert r.status_code == 201, r.text
+        group = r.json()["group"]
+        gid = group["id"]
+        assert group["name"] == name
+        assert group["scope"] == "scoped"
+        assert group["system_key"] is None
+
+        listed = _find_group(base, admin_token, name=name)
+        assert listed is not None
+        assert listed["member_count"] == 0
+        assert listed["areas"] == []
+        assert "created_at" in listed
+
+        new_name = name + "_renamed"
+        r = requests.patch(
+            f"{base}/admin/groups/{gid}",
+            headers=_hdr(admin_token),
+            json={"name": new_name},
+            timeout=TIMEOUT,
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["group"]["name"] == new_name
+
+        r = _delete_group(base, admin_token, gid)
+        assert r.status_code == 200, r.text
+        assert r.json().get("success") is True
+        gid = None
+        assert _find_group(base, admin_token, name=new_name) is None
+    finally:
+        if gid is not None:
+            _delete_group(base, admin_token, gid)
+
+
+def test_group_duplicate_name_returns_400(auth_url, integration_env, admin_token):
+    """A second group with the same name (case-insensitive) is rejected with 400."""
+    if not integration_env or not admin_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded admin) to run")
+    base = _base(auth_url)
+    name = _uniq()
+    gid = None
+    try:
+        r = _create_group(base, admin_token, name)
+        assert r.status_code == 201, r.text
+        gid = r.json()["group"]["id"]
+
+        r = _create_group(base, admin_token, name)
+        assert r.status_code == 400
+
+        r = _create_group(base, admin_token, name.upper())
+        assert r.status_code == 400
+    finally:
+        if gid is not None:
+            _delete_group(base, admin_token, gid)
+
+
+def test_create_group_rejects_system_key_and_bad_scope(auth_url, integration_env, admin_token):
+    """POST rejects a supplied system_key and an invalid scope with 400."""
+    if not integration_env or not admin_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded admin) to run")
+    base = _base(auth_url)
+
+    r = requests.post(
+        f"{base}/admin/groups",
+        headers=_hdr(admin_token),
+        json={"name": _uniq(), "system_key": "operations"},
+        timeout=TIMEOUT,
+    )
+    assert r.status_code == 400
+
+    r = requests.post(
+        f"{base}/admin/groups",
+        headers=_hdr(admin_token),
+        json={"name": _uniq(), "scope": "planet"},
+        timeout=TIMEOUT,
+    )
+    assert r.status_code == 400
+
+    r = requests.post(
+        f"{base}/admin/groups",
+        headers=_hdr(admin_token),
+        json={"name": "   "},
+        timeout=TIMEOUT,
+    )
+    assert r.status_code == 400
+
+
+def test_system_group_delete_returns_400(auth_url, integration_env, admin_token):
+    """Deleting a system group (Operations) is rejected with 400 and leaves it intact."""
+    if not integration_env or not admin_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded admin) to run")
+    base = _base(auth_url)
+    ops = _find_group(base, admin_token, system_key="operations")
+    assert ops is not None, "Operations system group should exist after backfill"
+
+    r = _delete_group(base, admin_token, ops["id"])
+    assert r.status_code == 400
+    assert _find_group(base, admin_token, system_key="operations") is not None
+
+
+def test_put_areas_replace_and_validation(auth_url, integration_env, admin_token):
+    """PUT areas has replace-set semantics, dedupes case-insensitively, strips slashes, rejects bad input."""
+    if not integration_env or not admin_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded admin) to run")
+    base = _base(auth_url)
+    name = _uniq()
+    gid = None
+    try:
+        r = _create_group(base, admin_token, name)
+        assert r.status_code == 201, r.text
+        gid = r.json()["group"]["id"]
+        areas_url = f"{base}/admin/groups/{gid}/areas"
+
+        r = requests.put(
+            areas_url,
+            headers=_hdr(admin_token),
+            json={"areas": ["Kansas", "Kansas/Lawrence"]},
+            timeout=TIMEOUT,
+        )
+        assert r.status_code == 200, r.text
+        assert set(r.json()["areas"]) == {"Kansas", "Kansas/Lawrence"}
+
+        # replace-set: the new list fully replaces the old one
+        r = requests.put(
+            areas_url, headers=_hdr(admin_token), json={"areas": ["Nebraska"]}, timeout=TIMEOUT
+        )
+        assert r.status_code == 200, r.text
+        assert set(r.json()["areas"]) == {"Nebraska"}
+
+        # dedupe case-insensitively
+        r = requests.put(
+            areas_url,
+            headers=_hdr(admin_token),
+            json={"areas": ["Kansas/Topeka", "kansas/topeka"]},
+            timeout=TIMEOUT,
+        )
+        assert r.status_code == 200, r.text
+        assert len(r.json()["areas"]) == 1
+
+        # strip leading/trailing slashes
+        r = requests.put(
+            areas_url, headers=_hdr(admin_token), json={"areas": ["/Kansas/Topeka/"]}, timeout=TIMEOUT
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["areas"] == ["Kansas/Topeka"]
+
+        # rejects: not an array, '..' traversal, blank element, non-string element
+        for bad in ("Kansas", ["Kansas/../secret"], ["Kansas", "  "], ["Kansas", 5]):
+            r = requests.put(
+                areas_url, headers=_hdr(admin_token), json={"areas": bad}, timeout=TIMEOUT
+            )
+            assert r.status_code == 400, f"expected 400 for {bad!r}, got {r.status_code}"
+    finally:
+        if gid is not None:
+            _delete_group(base, admin_token, gid)
+
+
+def test_delete_group_with_members_returns_409(
+    auth_url, integration_env, admin_token, community_token
+):
+    """A group that still has members returns 409 with member_count."""
+    if not integration_env or not admin_token or not community_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded users) to run")
+    base = _base(auth_url)
+    comm_id = _user_id(base, admin_token, COMMUNITY_EMAIL)
+    name = _uniq()
+    gid = None
+    try:
+        r = _create_group(base, admin_token, name)
+        assert r.status_code == 201, r.text
+        gid = r.json()["group"]["id"]
+
+        assert _set_membership(base, admin_token, comm_id, gid).status_code == 200
+
+        r = _delete_group(base, admin_token, gid)
+        assert r.status_code == 409, r.text
+        assert r.json().get("member_count") == 1
+    finally:
+        _set_membership(base, admin_token, comm_id, None)
+        if gid is not None:
+            _delete_group(base, admin_token, gid)
+
+
+# ----------------------------------------------------------------------------- enriched /auth
+
+
+def test_validate_and_me_enriched_admin(auth_url, integration_env, admin_token):
+    """Admin resolves to the Operations global system group as a lead, with no areas."""
+    if not integration_env or not admin_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded admin) to run")
+    base = _base(auth_url)
+
+    r = _validate(base, admin_token)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("valid") is True
+    u = body["user"]
+    assert u["role"] == "admin"
+    assert u["group"]["system_key"] == "operations"
+    assert u["group"]["scope"] == "global"
+    assert u["group_role"] == "lead"
+    assert u["areas"] == []
+
+    r = _me(base, admin_token)
+    assert r.status_code == 200, r.text
+    u = r.json()["user"]
+    assert u["group"]["system_key"] == "operations"
+    assert u["group"]["scope"] == "global"
+    assert u["group_role"] == "lead"
+    assert u["areas"] == []
+
+
+def test_validate_enriched_primary_staff(auth_url, integration_env, staff_token):
+    """Seed staff resolves to the Primary global system group as a member, with no areas."""
+    if not integration_env or not staff_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded staff) to run")
+    base = _base(auth_url)
+
+    r = _validate(base, staff_token)
+    assert r.status_code == 200, r.text
+    u = r.json()["user"]
+    assert u["role"] == "staff"
+    assert u["group"]["system_key"] == "primary"
+    assert u["group"]["scope"] == "global"
+    assert u["group_role"] == "member"
+    assert u["areas"] == []
+
+
+def test_validate_enriched_team_lead(auth_url, integration_env, admin_token, teamlead_token):
+    """Team lead resolves to KansasTeam (scoped) as a lead, exposing that group's areas."""
+    if not integration_env or not admin_token or not teamlead_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded team lead) to run")
+    base = _base(auth_url)
+    kt = _find_group(base, admin_token, name="KansasTeam")
+    assert kt is not None, "seeded KansasTeam group should exist"
+
+    r = _validate(base, teamlead_token)
+    assert r.status_code == 200, r.text
+    u = r.json()["user"]
+    assert u["role"] == "staff"
+    assert u["group"]["name"] == "KansasTeam"
+    assert u["group"]["scope"] == "scoped"
+    assert u["group"]["system_key"] is None
+    assert u["group_role"] == "lead"
+    assert len(u["areas"]) >= 1
+    assert sorted(u["areas"]) == sorted(kt["areas"])
+
+
+def test_validate_enriched_scoped_staff(auth_url, integration_env, admin_token, scoped_staff_token):
+    """Scoped staff resolves to KansasTeam (scoped) as a member, exposing that group's areas."""
+    if not integration_env or not admin_token or not scoped_staff_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded scoped staff) to run")
+    base = _base(auth_url)
+    kt = _find_group(base, admin_token, name="KansasTeam")
+    assert kt is not None
+
+    r = _validate(base, scoped_staff_token)
+    assert r.status_code == 200, r.text
+    u = r.json()["user"]
+    assert u["group"]["name"] == "KansasTeam"
+    assert u["group"]["scope"] == "scoped"
+    assert u["group_role"] == "member"
+    assert sorted(u["areas"]) == sorted(kt["areas"])
+
+
+def test_validate_enriched_unassigned(auth_url, integration_env, unassigned_token):
+    """An unassigned community user resolves to group=None, member, no areas."""
+    if not integration_env or not unassigned_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded unassigned user) to run")
+    base = _base(auth_url)
+
+    r = _validate(base, unassigned_token)
+    assert r.status_code == 200, r.text
+    u = r.json()["user"]
+    assert u["group"] is None
+    assert u["group_role"] == "member"
+    assert u["areas"] == []
+
+
+def test_operations_locked_primary_flippable(auth_url, integration_env, admin_token):
+    """Operations cannot leave 'global'; Primary (the future lever) can flip and be restored."""
+    if not integration_env or not admin_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded admin) to run")
+    base = _base(auth_url)
+    ops = _find_group(base, admin_token, system_key="operations")
+    prim = _find_group(base, admin_token, system_key="primary")
+    assert ops is not None and prim is not None
+
+    r = requests.patch(
+        f"{base}/admin/groups/{ops['id']}",
+        headers=_hdr(admin_token),
+        json={"scope": "scoped"},
+        timeout=TIMEOUT,
+    )
+    assert r.status_code == 400
+
+    try:
+        r = requests.patch(
+            f"{base}/admin/groups/{prim['id']}",
+            headers=_hdr(admin_token),
+            json={"scope": "scoped"},
+            timeout=TIMEOUT,
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["group"]["scope"] == "scoped"
+    finally:
+        requests.patch(
+            f"{base}/admin/groups/{prim['id']}",
+            headers=_hdr(admin_token),
+            json={"scope": "global"},
+            timeout=TIMEOUT,
+        )
+
+
+# ----------------------------------------------------------------------------- admin membership
+
+
+def test_admin_membership_move_no_logout(
+    auth_url, integration_env, admin_token, community_token
+):
+    """A one-step lateral group->group move (member->member) does NOT bump the moved user's token."""
+    if not integration_env or not admin_token or not community_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded users) to run")
+    base = _base(auth_url)
+    comm_id = _user_id(base, admin_token, COMMUNITY_EMAIL)
+    gid_a = gid_b = None
+    try:
+        r = _create_group(base, admin_token, _uniq("MoveA"))
+        assert r.status_code == 201, r.text
+        gid_a = r.json()["group"]["id"]
+        r = _create_group(base, admin_token, _uniq("MoveB"))
+        assert r.status_code == 201, r.text
+        gid_b = r.json()["group"]["id"]
+
+        assert _set_membership(base, admin_token, comm_id, gid_a).status_code == 200
+        assert _validate(base, community_token).status_code == 200
+
+        # lateral move A -> B: no privilege reduction, so the session token must keep working
+        assert _set_membership(base, admin_token, comm_id, gid_b).status_code == 200
+        assert _validate(base, community_token).status_code == 200
+    finally:
+        _set_membership(base, admin_token, comm_id, None)
+        if gid_a is not None:
+            _delete_group(base, admin_token, gid_a)
+        if gid_b is not None:
+            _delete_group(base, admin_token, gid_b)
+
+
+def test_admin_membership_unknown_user_and_group(auth_url, integration_env, admin_token):
+    """Membership PATCH: unknown user -> 404, unknown group_id -> 400."""
+    if not integration_env or not admin_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded admin) to run")
+    base = _base(auth_url)
+
+    r = _set_membership(base, admin_token, 999999, None)
+    assert r.status_code == 404
+
+    comm_id = _user_id(base, admin_token, COMMUNITY_EMAIL)
+    r = _set_membership(base, admin_token, comm_id, 999999)
+    assert r.status_code == 400
+
+
+def test_admin_membership_lead_demotion_bumps(auth_url, integration_env, admin_token):
+    """Dropping a member from 'lead' to 'member' via the membership PATCH revokes their tokens."""
+    if not integration_env or not admin_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded admin) to run")
+    base = _base(auth_url)
+    rt_id = _user_id(base, admin_token, ROLE_TEST_EMAIL)
+    gid = None
+    try:
+        _force_unassigned_community(base, admin_token, rt_id)
+        r = _create_group(base, admin_token, _uniq("LeadBump"))
+        assert r.status_code == 201, r.text
+        gid = r.json()["group"]["id"]
+
+        assert _set_role(base, admin_token, rt_id, "staff").status_code == 200
+        assert _set_membership(base, admin_token, rt_id, gid, "lead").status_code == 200
+
+        tok = _login(base, ROLE_TEST_EMAIL, ROLE_TEST_PASSWORD)
+        if _validate(base, tok).status_code != 200:
+            pytest.skip(_REVOCATION_PRECONDITION_SKIP)
+
+        # lead -> member is a privilege reduction: revoke
+        assert _set_membership(base, admin_token, rt_id, gid, "member").status_code == 200
+        _assert_revoked_or_skip(base, tok)
+    finally:
+        _force_unassigned_community(base, admin_token, rt_id)
+        if gid is not None:
+            _delete_group(base, admin_token, gid)
+
+
+# ----------------------------------------------------------------------------- Team Lead API
+
+
+def test_lead_claim_matrix(auth_url, integration_env, admin_token, teamlead_token):
+    """Lead can claim an unassigned community user (200) but not an already-assigned staff user (400)."""
+    if not integration_env or not admin_token or not teamlead_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded team lead) to run")
+    base = _base(auth_url)
+    rt_id = _user_id(base, admin_token, ROLE_TEST_EMAIL)
+    kt = _find_group(base, admin_token, name="KansasTeam")
+    try:
+        _force_unassigned_community(base, admin_token, rt_id)
+
+        r = requests.post(
+            f"{base}/lead/members/claim",
+            headers=_hdr(teamlead_token),
+            json={"email": ROLE_TEST_EMAIL},
+            timeout=TIMEOUT,
+        )
+        assert r.status_code == 200, r.text
+        u = r.json()["user"]
+        assert u["group_id"] == kt["id"]
+        assert u["group_role"] == "member"
+        assert u["role"] == "community"
+
+        # scoped-staff is already staff + assigned -> cannot be claimed
+        r = requests.post(
+            f"{base}/lead/members/claim",
+            headers=_hdr(teamlead_token),
+            json={"email": SCOPED_STAFF_EMAIL},
+            timeout=TIMEOUT,
+        )
+        assert r.status_code == 400
+    finally:
+        _force_unassigned_community(base, admin_token, rt_id)
+
+
+def test_lead_promote_demote_matrix(auth_url, integration_env, admin_token, teamlead_token):
+    """community -> staff -> lead and back, with already-at-top / already-at-bottom 400s."""
+    if not integration_env or not admin_token or not teamlead_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded team lead) to run")
+    base = _base(auth_url)
+    rt_id = _user_id(base, admin_token, ROLE_TEST_EMAIL)
+    try:
+        _force_unassigned_community(base, admin_token, rt_id)
+        r = requests.post(
+            f"{base}/lead/members/claim",
+            headers=_hdr(teamlead_token),
+            json={"email": ROLE_TEST_EMAIL},
+            timeout=TIMEOUT,
+        )
+        assert r.status_code == 200, r.text
+        rank_url = f"{base}/lead/members/{rt_id}/rank"
+
+        # community -> staff (member)
+        r = requests.patch(rank_url, headers=_hdr(teamlead_token), json={"action": "promote"}, timeout=TIMEOUT)
+        assert r.status_code == 200, r.text
+        assert r.json()["user"]["role"] == "staff"
+        assert r.json()["user"]["group_role"] == "member"
+
+        # staff member -> lead
+        r = requests.patch(rank_url, headers=_hdr(teamlead_token), json={"action": "promote"}, timeout=TIMEOUT)
+        assert r.status_code == 200, r.text
+        assert r.json()["user"]["group_role"] == "lead"
+
+        # already at the top
+        r = requests.patch(rank_url, headers=_hdr(teamlead_token), json={"action": "promote"}, timeout=TIMEOUT)
+        assert r.status_code == 400
+
+        # lead -> member
+        r = requests.patch(rank_url, headers=_hdr(teamlead_token), json={"action": "demote"}, timeout=TIMEOUT)
+        assert r.status_code == 200, r.text
+        assert r.json()["user"]["role"] == "staff"
+        assert r.json()["user"]["group_role"] == "member"
+
+        # staff -> community
+        r = requests.patch(rank_url, headers=_hdr(teamlead_token), json={"action": "demote"}, timeout=TIMEOUT)
+        assert r.status_code == 200, r.text
+        assert r.json()["user"]["role"] == "community"
+
+        # already at the bottom
+        r = requests.patch(rank_url, headers=_hdr(teamlead_token), json={"action": "demote"}, timeout=TIMEOUT)
+        assert r.status_code == 400
+    finally:
+        _force_unassigned_community(base, admin_token, rt_id)
+
+
+def test_lead_self_rank_returns_400(auth_url, integration_env, admin_token, teamlead_token):
+    """A lead cannot change their own rank."""
+    if not integration_env or not admin_token or not teamlead_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded team lead) to run")
+    base = _base(auth_url)
+    tl_id = _user_id(base, admin_token, TEAMLEAD_EMAIL)
+    r = requests.patch(
+        f"{base}/lead/members/{tl_id}/rank",
+        headers=_hdr(teamlead_token),
+        json={"action": "demote"},
+        timeout=TIMEOUT,
+    )
+    assert r.status_code == 400
+
+
+def test_lead_out_of_group_target_returns_403(
+    auth_url, integration_env, admin_token, teamlead_token
+):
+    """A lead cannot rank a user who is not in their group."""
+    if not integration_env or not admin_token or not teamlead_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded team lead) to run")
+    base = _base(auth_url)
+    # seed staff lives in Primary, never in KansasTeam
+    staff_id = _user_id(base, admin_token, STAFF_EMAIL)
+    r = requests.patch(
+        f"{base}/lead/members/{staff_id}/rank",
+        headers=_hdr(teamlead_token),
+        json={"action": "demote"},
+        timeout=TIMEOUT,
+    )
+    assert r.status_code == 403
+
+
+def test_lead_admin_target_returns_403(auth_url, integration_env, admin_token, teamlead_token):
+    """Even for an in-group admin, a lead cannot rank or remove them (admin guard)."""
+    if not integration_env or not admin_token or not teamlead_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded team lead) to run")
+    base = _base(auth_url)
+    admin_id = _user_id(base, admin_token, ADMIN_EMAIL)
+    kt = _find_group(base, admin_token, name="KansasTeam")
+    ops = _find_group(base, admin_token, system_key="operations")
+    assert kt is not None and ops is not None
+    try:
+        # Move the admin into KansasTeam as a lead: lateral lead->lead move, so no revocation bump.
+        assert _set_membership(base, admin_token, admin_id, kt["id"], "lead").status_code == 200
+        # the move must not have invalidated the admin's own session token
+        assert _validate(base, admin_token).status_code == 200
+
+        r = requests.patch(
+            f"{base}/lead/members/{admin_id}/rank",
+            headers=_hdr(teamlead_token),
+            json={"action": "demote"},
+            timeout=TIMEOUT,
+        )
+        assert r.status_code == 403
+
+        r = requests.delete(
+            f"{base}/lead/members/{admin_id}", headers=_hdr(teamlead_token), timeout=TIMEOUT
+        )
+        assert r.status_code == 403
+    finally:
+        _set_membership(base, admin_token, admin_id, ops["id"], "lead")
+
+
+def test_lead_delete_member_releases_to_unassigned(
+    auth_url, integration_env, admin_token, teamlead_token
+):
+    """Releasing a staff member drops them to community and clears their group."""
+    if not integration_env or not admin_token or not teamlead_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded team lead) to run")
+    base = _base(auth_url)
+    rt_id = _user_id(base, admin_token, ROLE_TEST_EMAIL)
+    kt = _find_group(base, admin_token, name="KansasTeam")
+    try:
+        _force_unassigned_community(base, admin_token, rt_id)
+        assert _set_role(base, admin_token, rt_id, "staff").status_code == 200
+        assert _set_membership(base, admin_token, rt_id, kt["id"], "member").status_code == 200
+
+        r = requests.delete(
+            f"{base}/lead/members/{rt_id}", headers=_hdr(teamlead_token), timeout=TIMEOUT
+        )
+        assert r.status_code == 200, r.text
+
+        u = _find_user(base, admin_token, ROLE_TEST_EMAIL)
+        assert u["group_id"] is None
+        assert u["role"] == "community"
+    finally:
+        _force_unassigned_community(base, admin_token, rt_id)
+
+
+def test_lead_api_requires_team_lead(
+    auth_url, integration_env, admin_token, staff_token, scoped_staff_token
+):
+    """The lead API rejects a plain admin, a Primary staff, and a scoped non-lead staff with 403."""
+    if not integration_env or not admin_token or not staff_token or not scoped_staff_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded users) to run")
+    base = _base(auth_url)
+    for token in (admin_token, staff_token, scoped_staff_token):
+        r = requests.get(f"{base}/lead/group", headers=_hdr(token), timeout=TIMEOUT)
+        assert r.status_code == 403, r.text
+
+
+def test_lead_group_view(auth_url, integration_env, teamlead_token):
+    """GET /lead/group returns the lead's group, its areas, and its members."""
+    if not integration_env or not teamlead_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded team lead) to run")
+    base = _base(auth_url)
+    r = requests.get(f"{base}/lead/group", headers=_hdr(teamlead_token), timeout=TIMEOUT)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["group"]["name"] == "KansasTeam"
+    assert body["group"]["scope"] == "scoped"
+    assert len(body["areas"]) >= 1
+    emails = {str(m.get("email", "")).lower() for m in body["members"]}
+    assert TEAMLEAD_EMAIL.lower() in emails
+    assert SCOPED_STAFF_EMAIL.lower() in emails
+
+
+# ----------------------------------------------------------------------------- regressions
+
+
+def test_regression_last_admin_guard_intact(auth_url, integration_env, admin_token):
+    """The last admin cannot be demoted or deleted (guarded 400)."""
+    if not integration_env or not admin_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded admin) to run")
+    base = _base(auth_url)
+    admins = [u for u in _list_users(base, admin_token) if u.get("role") == "admin"]
+    if len(admins) != 1:
+        pytest.skip("last-admin guard test requires exactly one admin in the DB")
+    admin_id = admins[0]["id"]
+
+    r = _set_role(base, admin_token, admin_id, "community")
+    assert r.status_code == 400
+
+    r = requests.delete(f"{base}/admin/users/{admin_id}", headers=_hdr(admin_token), timeout=TIMEOUT)
+    assert r.status_code == 400
+
+
+def test_regression_role_demotion_bumps_revocation(auth_url, integration_env, admin_token):
+    """Demoting staff -> community via the role PATCH still revokes that user's existing tokens."""
+    if not integration_env or not admin_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded admin) to run")
+    base = _base(auth_url)
+    rt_id = _user_id(base, admin_token, ROLE_TEST_EMAIL)
+    try:
+        _force_unassigned_community(base, admin_token, rt_id)
+        assert _set_role(base, admin_token, rt_id, "staff").status_code == 200
+
+        tok = _login(base, ROLE_TEST_EMAIL, ROLE_TEST_PASSWORD)
+        if _validate(base, tok).status_code != 200:
+            pytest.skip(_REVOCATION_PRECONDITION_SKIP)
+
+        assert _set_role(base, admin_token, rt_id, "community").status_code == 200
+        _assert_revoked_or_skip(base, tok)
+    finally:
+        _force_unassigned_community(base, admin_token, rt_id)


### PR DESCRIPTION
## Summary

First stage of the staff-management overhaul (stacked series 1/4). Pure auth-backend groundwork — inert on its own: every existing user lands in a global-scope group, so nothing changes for anyone until stage 2 (Flask enforcement) merges and a scoped group is created.

- **Schema**: `groups` + `group_areas` tables and `users.group_id`/`users.group_role` columns via idempotent boot migrations. Roles stay `community|staff|admin` — a **Team Lead** is a staff user with `group_role='lead'`, not a new role value, so the `users.role` CHECK is untouched.
- **System groups**: **Operations** (head admins, locked global, undeletable) and **Primary** (current staff pool; global today, scope flippable later via one PATCH — the future lever). A **one-time** backfill routes existing admins → Operations (lead) and staff → Primary (member); it runs only on the boot that first adds the group columns, so an admin deliberately unassigning someone is never silently reverted by a restart (caught and fixed during pre-merge adversarial review).
- **Group management API** (`/api/admin/groups`, admin-only): CRUD + replace-set area assignment with validated opaque path prefixes (`Kansas`, `Kansas/Lawrence`).
- **Membership moves** (`PATCH /api/admin/users/:id/membership`): one-step stray-user correction between any groups; sessions are revoked only on privilege reductions — lateral moves and promotions never log anyone out.
- **Team Lead API** (`/api/lead`): view own group, claim Unassigned community users, promote/demote community ↔ staff ↔ lead strictly within the lead's own group, release to Unassigned. Cannot act on self, admins, or other groups; demotions/releases revoke tokens.
- **Enriched `POST /auth/validate` + `GET /auth/me`**: additive `group`/`group_role`/`areas` fields with `role` re-read fresh from the DB — stage 2's Flask backend will authorize off this response body (JWTs stay identity-only, so group/area edits take effect without re-login).
- **Seeds + tests**: seeded scoped `KansasTeam` (area `Kansas/Topeka`, real fixture-data folder) with team-lead / scoped-staff / unassigned personas; 26 new integration tests (CRUD, enriched payload shapes per persona, full Team Lead permission matrix, revocation + last-admin regressions).

Verified: TypeScript build clean; migration idempotency proven by double-seed; restart simulation confirms unassignments persist; integration suites (groups + existing admin/auth regressions) 38 passed / 1 skipped; backend unit suite unaffected (252 passing).

Closes #262