### PR TITLE
Flask scope enforcement for staff sub-areas (2/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Scoped-group enforcement in the backend (staff sub-areas)**: staff who belong to a **scoped** group now only see and act within their group's assigned areas (path prefixes like `Kansas` or `Kansas/North Topeka`), across the whole Flask API. Matching (photo upload, carapace quick check, and the review cross-check) is limited to the group's areas — an empty/`All Locations` scope is forced to those areas, requesting a broader sheet is narrowed to the owned sub-areas, and any candidate that falls outside scope is flagged (`in_scope` per candidate, `scope_expanded` on the response) rather than acted on silently. List endpoints (locations, sheet tabs, the turtle list, turtle names, the review queue, the release/flags page) return only the in-scope subset; a review packet with no location is visible to full-access users only. Every write (approve, classify, cross-check, add/remove review images, delete packet, clear release flag, create/update/mark-deceased/generate-ID in Sheets, and every turtle-record mutation including merge — which requires **both** turtles to be in scope) is refused with a 403 when its target falls outside the group's areas, failing closed when the target can't be resolved. **Operations (admins) and Primary (global staff) are completely unaffected** — every filter and gate is a no-op for a global member, so their behavior is byte-for-byte identical to before.
+- **Authorization now follows the live account, not the token**: staff/admin routes decide access from the auth service's fresh validate response (role + group areas) instead of the JWT's claims. A staff user who is promoted, moved between groups, or has their areas changed sees it take effect on their **next request — no logout/login required** — and a demotion still revokes immediately as before.
+
+### Changed
+
+- **General Location management is admin-only**: adding, deleting, or reconfiguring General Locations / fixed programs (and the "affected turtles" preview) now requires an admin. Staff keep read-only access to the General Location catalog (the turtle create/edit form still loads it). Creating a new Sheets tab defines a brand-new area, so it is restricted to **global** members (Operations admins and Primary staff keep it exactly as before); a scoped sub-area group can't create sheets outside its assigned locations. This is a capability change for scoped-group members only.
+
 ## [2.1.0] - 2026-07-20 — Staff groups foundation (auth-backend)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-07-20 — Scoped-group enforcement (backend)
+
 ### Added
 
 - **Scoped-group enforcement in the backend (staff sub-areas)**: staff who belong to a **scoped** group now only see and act within their group's assigned areas (path prefixes like `Kansas` or `Kansas/North Topeka`), across the whole Flask API. Matching (photo upload, carapace quick check, and the review cross-check) is limited to the group's areas — an empty/`All Locations` scope is forced to those areas, requesting a broader sheet is narrowed to the owned sub-areas, and any candidate that falls outside scope is flagged (`in_scope` per candidate, `scope_expanded` on the response) rather than acted on silently. List endpoints (locations, sheet tabs, the turtle list, turtle names, the review queue, the release/flags page) return only the in-scope subset; a review packet with no location is visible to full-access users only. Every write (approve, classify, cross-check, add/remove review images, delete packet, clear release flag, create/update/mark-deceased/generate-ID in Sheets, and every turtle-record mutation including merge — which requires **both** turtles to be in scope) is refused with a 403 when its target falls outside the group's areas, failing closed when the target can't be resolved. **Operations (admins) and Primary (global staff) are completely unaffected** — every filter and gate is a no-op for a global member, so their behavior is byte-for-byte identical to before.

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -95,17 +95,27 @@ def get_user_from_request():
     return True, payload, None
 
 
-def check_auth_revocation(auth_header):
-    """
-    Call auth service to enforce demotion revocation (tokens_valid_after).
-    Returns (allowed: bool, error_message: str or None).
-    Fails closed when AUTH_URL is unset so demoted staff/admin tokens are not accepted.
+# Print-once guard for the mixed-version-deploy warning (auth-backend older than
+# PR-1). Benign under threaded=True: a race just prints the warning twice — it is
+# a log flag, not load-bearing state — so it needs no lock.
+_MISSING_GROUP_WARNED = False
+
+
+def _post_validate(auth_header):
+    """POST to ``{AUTH_URL}/auth/validate`` and return ``(allowed, error, body)``.
+
+    Shared transport for the revocation check (``check_auth_revocation``) and the
+    scope-context builder (``validate_and_get_context``). ``allowed`` is True only
+    on HTTP 200; ``body`` is the parsed JSON of that 200 (or None). Fails closed
+    when AUTH_URL is unset. Retries once against 127.0.0.1 only when the primary
+    ``localhost`` host was unreachable (never after a definitive HTTP outcome such
+    as a 403 revocation), preserving the existing revocation semantics.
     """
     if not AUTH_URL:
-        return False, 'AUTH_URL must be set to verify staff/admin tokens (revocation check)'
+        return False, 'AUTH_URL must be set to verify staff/admin tokens (revocation check)', None
 
     def validate_against(auth_base_url):
-        """Returns (allowed, error, connectivity_failure).
+        """Returns (allowed, error, connectivity_failure, body).
 
         connectivity_failure is True only when the auth service could not be reached
         (no HTTP response). Used to decide whether a localhost → 127.0.0.1 fallback
@@ -118,8 +128,12 @@ def check_auth_revocation(auth_header):
             ctx = ssl.create_default_context()
             with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
                 if resp.status != 200:
-                    return False, f'Auth validation failed (HTTP {resp.status})', False
-                return True, None, False
+                    return False, f'Auth validation failed (HTTP {resp.status})', False, None
+                try:
+                    body = json.loads(resp.read().decode())
+                except (ValueError, AttributeError, OSError):
+                    body = None
+                return True, None, False, body
         except urllib.error.HTTPError as e:
             error_message = None
             try:
@@ -129,15 +143,15 @@ def check_auth_revocation(auth_header):
                 error_message = None
 
             if e.code == 403:
-                return False, error_message or 'Token has been revoked', False
-            return False, error_message or f'Auth validation failed (HTTP {e.code})', False
+                return False, error_message or 'Token has been revoked', False, None
+            return False, error_message or f'Auth validation failed (HTTP {e.code})', False, None
         except (urllib.error.URLError, OSError, TimeoutError):
             # Fail closed: if we can't reach auth service, deny access
-            return False, 'Unable to verify token; try again later', True
+            return False, 'Unable to verify token; try again later', True, None
 
-    allowed, revoke_error, primary_unreachable = validate_against(AUTH_URL)
+    allowed, revoke_error, primary_unreachable, body = validate_against(AUTH_URL)
     if allowed:
-        return True, None
+        return True, None, body
 
     # Windows/dev environments can resolve "localhost" to a different service than 127.0.0.1.
     # Retry once against 127.0.0.1 only when the primary host could not be reached — not after
@@ -147,12 +161,88 @@ def check_auth_revocation(auth_header):
         fallback_netloc = parsed.netloc.replace('localhost', '127.0.0.1', 1)
         fallback_url = urllib.parse.urlunparse(parsed._replace(netloc=fallback_netloc))
         if fallback_url != AUTH_URL:
-            retry_allowed, retry_error, _ = validate_against(fallback_url)
+            retry_allowed, retry_error, _, retry_body = validate_against(fallback_url)
             if retry_allowed:
-                return True, None
+                return True, None, retry_body
             revoke_error = retry_error or revoke_error
 
-    return False, revoke_error
+    return False, revoke_error, None
+
+
+def _build_scope_ctx(body):
+    """Parse a ``/auth/validate`` 200 body into the per-request scope context dict.
+
+    Authorization is done off this context (DB-fresh role + group areas), never
+    off the JWT claim. Tolerates missing fields:
+      - ``group`` present with a scope → ``is_global = role=='admin' or scope=='global'``.
+      - ``group`` present but null (unassigned) → ``areas=[]``, ``is_global = role=='admin'``.
+      - ``group`` KEY entirely absent → an auth-backend older than PR-1 (mixed-version
+        deploy). We can't scope without areas, so treat staff as global too and warn
+        ONCE per process, rather than locking every scoped route out during a rollout.
+    """
+    global _MISSING_GROUP_WARNED
+    user = (body or {}).get('user') or {}
+    role = user.get('role')
+    areas_raw = user.get('areas')
+    areas = [str(a).strip() for a in areas_raw if a and str(a).strip()] if isinstance(areas_raw, list) else []
+
+    group_present = isinstance(user, dict) and 'group' in user
+    group = user.get('group') if group_present else None
+    group = group if isinstance(group, dict) else {}
+    group_scope = group.get('scope')
+
+    if not group_present:
+        if not _MISSING_GROUP_WARNED:
+            _MISSING_GROUP_WARNED = True
+            try:
+                print(
+                    "⚠️  auth-backend /auth/validate returned no 'group' field — treating staff "
+                    "as global (mixed-version deploy). Upgrade auth-backend to enable scoped-group "
+                    "enforcement."
+                )
+            except UnicodeEncodeError:
+                print("[WARN] auth-backend /auth/validate returned no 'group' field — treating staff as global.")
+        is_global_flag = True
+    else:
+        is_global_flag = (role == 'admin') or (group_scope == 'global')
+
+    return {
+        'role': role,
+        'user_id': user.get('id'),
+        'email': user.get('email'),
+        'group_id': group.get('id'),
+        'group_name': group.get('name'),
+        'group_scope': group_scope,
+        'system_key': group.get('system_key'),
+        'group_role': user.get('group_role'),
+        'areas': areas,
+        'is_global': bool(is_global_flag),
+    }
+
+
+def validate_and_get_context(auth_header):
+    """Validate a token against the auth service and build its scope context.
+
+    Returns ``(allowed: bool, error: str|None, ctx: dict|None)``. The guards MUST
+    authorize off ``ctx`` (the validate-response body), never off JWT claims, so a
+    freshly promoted/moved user takes effect without re-login. Same POST /
+    fail-closed / localhost-retry transport as ``check_auth_revocation``.
+    """
+    allowed, error, body = _post_validate(auth_header)
+    if not allowed:
+        return False, error, None
+    return True, None, _build_scope_ctx(body)
+
+
+def check_auth_revocation(auth_header):
+    """Thin (allowed, error) wrapper over the shared validate transport.
+
+    Kept for callers that only need the yes/no revocation gate (e.g.
+    ``_authorize_archive_request`` in admin_backup.py); returns just the pair so
+    those call sites keep working unchanged. Fails closed when AUTH_URL is unset.
+    """
+    allowed, error, _ = _post_validate(auth_header)
+    return allowed, error
 
 
 def require_auth(f):
@@ -186,32 +276,44 @@ def optional_auth(f):
 
 
 def require_admin(f):
-    """Decorator to require staff or admin role (turtle records, release, sheets, review)."""
+    """Decorator to require staff or admin role (turtle records, release, sheets, review).
+
+    The JWT proves identity only (signature/expiry via get_user_from_request); the
+    role/scope decision is made off the auth service's DB-fresh validate body, NOT
+    the JWT's role claim — so a freshly promoted user's stale community JWT passes
+    once the body says staff. Sets request.scope_ctx for the scoped-enforcement layer.
+    """
     @wraps(f)
     def decorated_function(*args, **kwargs):
         if request.method == 'OPTIONS':
             return jsonify({}), 200
 
+        # Identity only: reject a missing/invalid/expired token. Do NOT pre-reject
+        # on the JWT's (possibly stale) role claim.
         success, user_data, error = get_user_from_request()
         if not success:
             return jsonify({'error': error or 'Authentication required'}), 401
 
-        if user_data.get('role') not in ('staff', 'admin'):
+        auth_header = request.headers.get('Authorization')
+        allowed, revoke_error, ctx = validate_and_get_context(auth_header)
+        if not allowed:
+            return jsonify({'error': revoke_error or 'Token has been revoked'}), 403
+        if (ctx or {}).get('role') not in ('staff', 'admin'):
             return jsonify({'error': 'Staff or admin access required'}), 403
 
-        auth_header = request.headers.get('Authorization')
-        if auth_header:
-            allowed, revoke_error = check_auth_revocation(auth_header)
-            if not allowed:
-                return jsonify({'error': revoke_error or 'Token has been revoked'}), 403
-
         request.user = user_data
+        request.scope_ctx = ctx
         return f(*args, **kwargs)
     return decorated_function
 
 
 def require_admin_only(f):
-    """Decorator: role must be admin (not staff) — e.g. full data backup download."""
+    """Decorator: role must be admin (not staff) — e.g. full data backup download.
+
+    Same validate-body authorization as require_admin (identity from the JWT, role
+    from the DB-fresh validate response). Sets request.scope_ctx (always global for
+    an admin) for consistency.
+    """
     @wraps(f)
     def decorated_function(*args, **kwargs):
         if request.method == 'OPTIONS':
@@ -221,15 +323,14 @@ def require_admin_only(f):
         if not success:
             return jsonify({'error': error or 'Authentication required'}), 401
 
-        if user_data.get('role') != 'admin':
+        auth_header = request.headers.get('Authorization')
+        allowed, revoke_error, ctx = validate_and_get_context(auth_header)
+        if not allowed:
+            return jsonify({'error': revoke_error or 'Token has been revoked'}), 403
+        if (ctx or {}).get('role') != 'admin':
             return jsonify({'error': 'Admin access required'}), 403
 
-        auth_header = request.headers.get('Authorization')
-        if auth_header:
-            allowed, revoke_error = check_auth_revocation(auth_header)
-            if not allowed:
-                return jsonify({'error': revoke_error or 'Token has been revoked'}), 403
-
         request.user = user_data
+        request.scope_ctx = ctx
         return f(*args, **kwargs)
     return decorated_function

--- a/backend/routes/general_locations.py
+++ b/backend/routes/general_locations.py
@@ -4,7 +4,7 @@ General location catalog endpoints.
 
 from flask import jsonify, request
 
-from auth import require_admin
+from auth import require_admin, require_admin_only
 from general_locations_catalog import (
     add_general_location,
     add_sheet_default,
@@ -87,13 +87,18 @@ def _get_affected_turtles_across_sheets(
 def register_general_location_routes(app):
     """Register general location catalog endpoints."""
 
-    @app.route('/api/general-locations', methods=['GET', 'POST'])
+    # GET is kept staff-visible (require_admin): the staff turtle create/edit form
+    # (useTurtleSheetsDataForm -> TurtleSheetsDataForm) reads this catalog for its
+    # General Location dropdown. All mutations below are admin-only.
+    @app.route('/api/general-locations', methods=['GET'])
     @require_admin
-    def general_locations():
-        if request.method == 'GET':
-            catalog = get_general_location_catalog()
-            return jsonify({'success': True, **_serialize_catalog(catalog)})
+    def general_locations_get():
+        catalog = get_general_location_catalog()
+        return jsonify({'success': True, **_serialize_catalog(catalog)})
 
+    @app.route('/api/general-locations', methods=['POST'])
+    @require_admin_only
+    def general_locations_post():
         data = request.get_json(silent=True) or {}
         state = (data.get('state') or '').strip()
         general_location = (data.get('general_location') or '').strip()
@@ -133,7 +138,7 @@ def register_general_location_routes(app):
         return jsonify(response)
 
     @app.route('/api/general-locations/affected-turtles', methods=['GET'])
-    @require_admin
+    @require_admin_only
     def general_locations_affected_turtles():
         general_location = (request.args.get('general_location') or '').strip()
         state = (request.args.get('state') or '').strip()
@@ -150,7 +155,7 @@ def register_general_location_routes(app):
         return jsonify({'success': True, 'total': total, 'sheets': sheets_summary})
 
     @app.route('/api/general-locations', methods=['DELETE'])
-    @require_admin
+    @require_admin_only
     def delete_general_location_endpoint():
         data = request.get_json(silent=True) or {}
         state = (data.get('state') or '').strip()
@@ -296,7 +301,7 @@ def register_general_location_routes(app):
         return jsonify(response)
 
     @app.route('/api/general-locations/sheet-defaults', methods=['POST'])
-    @require_admin
+    @require_admin_only
     def add_sheet_default_endpoint():
         """Create a fixed program (sheet default) or convert a selectable program to fixed."""
         data = request.get_json(silent=True) or {}
@@ -356,7 +361,7 @@ def register_general_location_routes(app):
         return jsonify(response)
 
     @app.route('/api/general-locations/sheet-defaults', methods=['DELETE'])
-    @require_admin
+    @require_admin_only
     def remove_sheet_default_endpoint():
         """Convert a fixed program to selectable by removing its sheet default."""
         data = request.get_json(silent=True) or {}

--- a/backend/routes/locations.py
+++ b/backend/routes/locations.py
@@ -5,6 +5,7 @@ Used for two-level path selection: sheet (state) + location.
 
 from flask import jsonify
 from auth import require_admin
+from scope import get_ctx, filter_locations
 from services import manager_service
 
 
@@ -25,6 +26,9 @@ def register_locations_routes(app):
             return jsonify({'error': 'TurtleManager failed to initialize'}), 500
         try:
             locations = manager_service.manager.get_all_locations()
+            # Scoped-group members see only their areas (plus the shared
+            # Community_Uploads); global admins/staff get the full list.
+            locations = filter_locations(get_ctx(), locations)
             return jsonify({'success': True, 'locations': locations})
         except Exception as e:
             return jsonify({'error': str(e)}), 500

--- a/backend/routes/review.py
+++ b/backend/routes/review.py
@@ -11,6 +11,16 @@ from typing import Optional, Tuple
 from flask import request, jsonify
 from werkzeug.utils import secure_filename
 from auth import require_admin
+from scope import (
+    get_ctx,
+    is_global,
+    effective_match_filter,
+    annotate_in_scope,
+    packet_scope_allows,
+    resolve_turtle_location,
+    scope_allows_location,
+    SCOPE_DENIED_ERROR,
+)
 from services import manager_service
 from services.manager_service import get_sheets_service, get_community_sheets_service
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
@@ -102,6 +112,46 @@ def normalize_new_turtle_location_for_disk(
     return (out, resolved_general_loc)
 
 
+def _read_packet_metadata(packet_dir):
+    """Load a review packet's metadata.json as a dict (empty on any error)."""
+    if not packet_dir:
+        return {}
+    meta_path = os.path.join(packet_dir, 'metadata.json')
+    if not os.path.isfile(meta_path):
+        return {}
+    try:
+        with open(meta_path, 'r') as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _packet_scope_denied(packet_dir):
+    """403 (json, code) when a scoped caller may not act on this (resolved) packet, else None."""
+    ctx = get_ctx()
+    if is_global(ctx):
+        return None
+    if not packet_scope_allows(ctx, _read_packet_metadata(packet_dir)):
+        return jsonify({'error': SCOPE_DENIED_ERROR}), 403
+    return None
+
+
+def _packet_scope_denied_by_id(request_id):
+    """403 (json, code) for a scoped caller acting on request_id, else None.
+
+    Resolves the packet dir first; a missing packet returns None so the handler's
+    own not-found path (404/400) still runs unchanged for everyone.
+    """
+    ctx = get_ctx()
+    if is_global(ctx):
+        return None
+    packet_dir = manager_service.manager._resolve_packet_dir(request_id)
+    if not packet_dir or not os.path.isdir(packet_dir):
+        return None
+    return _packet_scope_denied(packet_dir)
+
+
 def register_review_routes(app):
     """Register review queue routes"""
     
@@ -121,8 +171,16 @@ def register_review_routes(app):
         try:
             queue_items = manager_service.manager.get_review_queue()
             formatted_items = [format_review_packet_item(item['path'], item['request_id']) for item in queue_items]
+            # Scoped-group members only see packets in their areas; community
+            # packets with no declared location are visible to global users only.
+            ctx = get_ctx()
+            if not is_global(ctx):
+                formatted_items = [
+                    it for it in formatted_items
+                    if packet_scope_allows(ctx, it.get('metadata'))
+                ]
             return jsonify({'success': True, 'items': formatted_items})
-        
+
         except Exception as e:
             return jsonify({'error': f'Failed to load review queue: {str(e)}'}), 500
 
@@ -136,6 +194,9 @@ def register_review_routes(app):
             return jsonify({'error': 'TurtleManager is still initializing.'}), 503
         if manager_service.manager is None:
             return jsonify({'error': 'TurtleManager failed to initialize'}), 500
+        denied = _packet_scope_denied_by_id(request_id)
+        if denied:
+            return denied
         files_with_types = []
         try:
             files_with_types, rejections = collect_indexed_additional_uploads(
@@ -168,6 +229,9 @@ def register_review_routes(app):
         filename = (data.get('filename') or '').strip()
         if not filename:
             return jsonify({'error': 'filename required'}), 400
+        denied = _packet_scope_denied_by_id(request_id)
+        if denied:
+            return denied
         success, err = manager_service.manager.remove_additional_image_from_packet(request_id, filename)
         if not success:
             return jsonify({'error': err or 'Failed to remove image'}), 400
@@ -184,6 +248,10 @@ def register_review_routes(app):
         packet_dir = manager_service.manager._resolve_packet_dir(request_id)
         if not packet_dir or not os.path.isdir(packet_dir):
             return jsonify({'error': 'Request not found'}), 404
+        # A scoped member can only read a packet the queue would show them.
+        denied = _packet_scope_denied(packet_dir)
+        if denied:
+            return denied
         item = format_review_packet_item(packet_dir, request_id)
         return jsonify({'success': True, 'item': item})
 
@@ -212,6 +280,10 @@ def register_review_routes(app):
         if not packet_dir or not os.path.isdir(packet_dir):
             return jsonify({'error': 'Request not found'}), 404
 
+        denied = _packet_scope_denied(packet_dir)
+        if denied:
+            return denied
+
         # Use specified image_path if provided, otherwise fall back to packet's main image
         query_image = None
         specified_path = (data.get('image_path') or '').strip()
@@ -238,6 +310,11 @@ def register_review_routes(app):
                 location_filter = (packet_metadata.get('match_sheet') or '').strip() or None
             except (json.JSONDecodeError, OSError):
                 pass
+
+        # Scoped-group members: narrow the cross-check to their areas the same
+        # way the upload match does (global unchanged).
+        scope_ctx = get_ctx()
+        location_filter, scope_forced = effective_match_filter(scope_ctx, location_filter)
 
         try:
             # Cross-check disables the "expand to all locations when < 5 matches"
@@ -272,10 +349,13 @@ def register_review_routes(app):
                 'image_path': image_path,
             })
 
+        scope_expanded = annotate_in_scope(scope_ctx, formatted) or scope_forced
+
         return jsonify({
             'success': True,
             'photo_type': photo_type,
             'matches': formatted,
+            'scope_expanded': scope_expanded,
             'elapsed': round(elapsed, 2),
         })
 
@@ -300,6 +380,10 @@ def register_review_routes(app):
         packet_dir = manager_service.manager._resolve_packet_dir(request_id)
         if not packet_dir or not os.path.isdir(packet_dir):
             return jsonify({'error': 'Request not found'}), 404
+
+        denied = _packet_scope_denied(packet_dir)
+        if denied:
+            return denied
 
         # Update metadata with photo_type
         metadata_path = os.path.join(packet_dir, 'metadata.json')
@@ -363,6 +447,10 @@ def register_review_routes(app):
             return jsonify({'error': 'TurtleManager failed to initialize'}), 500
         try:
             items = manager_service.manager.get_turtles_with_flags()
+            # Scoped-group members only see flagged turtles in their areas.
+            ctx = get_ctx()
+            if not is_global(ctx):
+                items = [it for it in items if scope_allows_location(ctx, it.get('location'))]
             return jsonify({'success': True, 'items': items})
         except Exception as e:
             return jsonify({'error': str(e)}), 500
@@ -380,6 +468,12 @@ def register_review_routes(app):
         location = (data.get('location') or '').strip() or None
         if not turtle_id:
             return jsonify({'error': 'turtle_id required'}), 400
+        # Scope gate on the flagged turtle's on-disk location (fail closed).
+        ctx = get_ctx()
+        if not is_global(ctx):
+            resolved = resolve_turtle_location(manager_service.manager, turtle_id, location)
+            if not scope_allows_location(ctx, resolved):
+                return jsonify({'error': SCOPE_DENIED_ERROR}), 403
         success, err = manager_service.manager.clear_release_flag(turtle_id, location)
         if not success:
             return jsonify({'error': err or 'Failed to clear release flag'}), 400
@@ -396,6 +490,9 @@ def register_review_routes(app):
             return jsonify({'error': 'TurtleManager is still initializing. Please try again in a moment.'}), 503
         if manager_service.manager is None:
             return jsonify({'error': 'TurtleManager failed to initialize'}), 500
+        denied = _packet_scope_denied_by_id(request_id)
+        if denied:
+            return denied
         try:
             success, message = manager_service.manager.reject_review_packet(request_id)
             if success:
@@ -464,6 +561,33 @@ def register_review_routes(app):
                 return jsonify({'error': str(exc)}), 400
             if isinstance(sheets_data, dict) and resolved_for_sheet is not None:
                 sheets_data['general_location'] = resolved_for_sheet
+
+        # Scope gate: a scoped-group member may only approve into their areas.
+        # Gate on the write TARGET — the matched turtle's on-disk folder, a
+        # community->admin destination, or the new turtle's location — and fail
+        # closed when the target can't be resolved. Placed before the new-turtle
+        # ID generation below so an out-of-scope approve never triggers any Sheets
+        # work. Global members skip the whole check.
+        #
+        # The target precedence MUST mirror _approve_review_packet_locked: it runs
+        # "Scenario A" (write onto the matched turtle's folder, resolved unscoped)
+        # whenever match_turtle_id is truthy, ignoring new_location/new_admin_location.
+        # Checking new_location first would let an attacker pass an in-scope
+        # new_location as a decoy while the manager writes onto an out-of-scope
+        # matched turtle. So match_turtle_id is gated first, exactly as the manager acts.
+        ctx = get_ctx()
+        if not is_global(ctx):
+            if match_turtle_id:
+                hint = sheets_data.get('sheet_name') if isinstance(sheets_data, dict) else None
+                target_loc = resolve_turtle_location(manager_service.manager, match_turtle_id, hint)
+            elif new_admin_location:
+                target_loc = new_admin_location
+            elif new_location:
+                target_loc = new_location
+            else:
+                target_loc = None
+            if not scope_allows_location(ctx, target_loc):
+                return jsonify({'error': SCOPE_DENIED_ERROR}), 403
 
         # For new turtle creation, defer packet deletion until Sheets sync succeeds.
         # This ensures the packet survives as a retry point if Sheets fails.

--- a/backend/routes/sheets.py
+++ b/backend/routes/sheets.py
@@ -9,7 +9,14 @@ import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from flask import request, jsonify
-from auth import require_admin
+from auth import require_admin, require_admin_only
+from scope import (
+    get_ctx,
+    is_global,
+    scope_allows_location,
+    scope_allows_sheet,
+    SCOPE_DENIED_ERROR,
+)
 from services.manager_service import get_sheets_service, get_community_sheets_service, is_transient_sheets_error
 from general_locations_catalog import resolve_general_location_from_sheet_and_value
 from sheets import sheet_management
@@ -22,6 +29,20 @@ SHEETS_TURTLE_DATA_TIMEOUT_SEC = 25
 # Lock for list_turtle_names so concurrent requests don't trigger SSL errors (WRONG_VERSION_NUMBER)
 # when making many Google API calls in parallel.
 _turtle_names_lock = threading.Lock()
+
+
+def _scoped_sheet_location(sheet_name, general_location=None):
+    """Target location string for a sheets write, e.g. ``Kansas/North Topeka``.
+
+    Matches the VRAM/area path model (top-level tab == state folder). Falls back
+    to just the tab when no general location is known. Returns None for a blank
+    sheet_name so the write gate fails closed.
+    """
+    sn = (sheet_name or '').strip()
+    if not sn:
+        return None
+    gl = (general_location or '').strip()
+    return f"{sn}/{gl}" if gl else sn
 
 
 def _refresh_general_location_validation_for_sheet(service, sheet_name: str) -> None:
@@ -215,7 +236,14 @@ def register_sheets_routes(app):
             data = request.json or {}
             state = data.get('state', '')
             location = data.get('location', '')
-            
+
+            # Scoped-group members may only mint IDs within their sheet (the
+            # subsequent turtle write is gated too). No target sheet given =>
+            # a bare globally-unique id that writes nothing, so it is allowed.
+            ctx = get_ctx()
+            if not is_global(ctx) and (state or '').strip() and not scope_allows_sheet(ctx, state):
+                return jsonify({'error': SCOPE_DENIED_ERROR}), 403
+
             # State is no longer required - Primary IDs are globally unique
             service = get_sheets_service()
             if not service:
@@ -262,6 +290,12 @@ def register_sheets_routes(app):
 
             if not sheet_name:
                 return jsonify({'error': 'sheet_name is required for ID generation'}), 400
+
+            # Scoped-group members may only mint biology IDs for a sheet they own
+            # (this can create the tab, so fail closed for out-of-scope sheets).
+            ctx = get_ctx()
+            if not is_global(ctx) and not scope_allows_sheet(ctx, sheet_name):
+                return jsonify({'error': SCOPE_DENIED_ERROR}), 403
 
             if target_spreadsheet == 'community':
                 service = get_community_sheets_service()
@@ -337,6 +371,13 @@ def register_sheets_routes(app):
                     )
                 except ValueError as exc:
                     return jsonify({'error': str(exc)}), 400
+
+            # Scope gate: a scoped-group member may only create within its areas.
+            ctx = get_ctx()
+            if not is_global(ctx):
+                target_loc = _scoped_sheet_location(sheet_name, turtle_data.get('general_location'))
+                if not scope_allows_location(ctx, target_loc):
+                    return jsonify({'error': SCOPE_DENIED_ERROR}), 403
 
             # If sheet (tab) does not exist, create it with required headers
             existing_sheets = service.list_sheets()
@@ -423,6 +464,14 @@ def register_sheets_routes(app):
                     )
                 except ValueError as exc:
                     return jsonify({'error': str(exc)}), 400
+
+            # Scope gate: a scoped-group member may only write within its areas
+            # (gated on the destination sheet/general-location it is writing to).
+            ctx = get_ctx()
+            if not is_global(ctx):
+                target_loc = _scoped_sheet_location(sheet_name, turtle_data.get('general_location'))
+                if not scope_allows_location(ctx, target_loc):
+                    return jsonify({'error': SCOPE_DENIED_ERROR}), 403
 
             # If sheet (tab) does not exist, create it with required headers (e.g. when using backend locations like "Kansas")
             existing_sheets = service.list_sheets()
@@ -616,6 +665,12 @@ def register_sheets_routes(app):
             if not sheet_name:
                 return jsonify({'error': 'sheet_name is required'}), 400
 
+            # Coarse scope gate: reject sheets the scoped member has no claim on
+            # before any lookup. The exact row's location is re-checked below.
+            ctx = get_ctx()
+            if not is_global(ctx) and not scope_allows_sheet(ctx, sheet_name):
+                return jsonify({'error': SCOPE_DENIED_ERROR}), 403
+
             filled = sum(1 for x in (primary_id, biology_id, name) if x)
             if filled != 1:
                 return jsonify({
@@ -649,6 +704,14 @@ def register_sheets_routes(app):
                 }), 409
 
             row = matches[0]
+            # Fine scope gate: the matched row's general location must be inside
+            # the member's areas before we write (fail closed on an out-of-scope
+            # sub-location the coarse sheet gate let through).
+            if not is_global(ctx):
+                row_loc = _scoped_sheet_location(sheet_name, row.get('general_location'))
+                if not scope_allows_location(ctx, row_loc):
+                    return jsonify({'error': SCOPE_DENIED_ERROR}), 403
+
             resolved_primary = (row.get('primary_id') or '').strip()
             if not resolved_primary:
                 return jsonify({
@@ -691,73 +754,99 @@ def register_sheets_routes(app):
         out = re.sub(r'[/\\:*?"<>|]', '_', name.strip())
         return out or '_'
 
-    @app.route('/api/sheets/sheets', methods=['GET', 'POST'])
+    @app.route('/api/sheets/sheets', methods=['POST'])
+    @require_admin
+    def create_sheet():
+        """
+        Create a new sheet (tab) with headers.
+
+        Staff-or-admin, but restricted to GLOBAL-scope members: creating a new
+        top-level sheet defines a brand-new area, which is meaningless (and out of
+        bounds) for a scoped sub-area group confined to its assigned locations.
+        Global staff/admin (Operations, Primary) keep the pre-scoping capability.
+        Body may include target_spreadsheet: 'research' | 'community'.
+        """
+        ctx = get_ctx()
+        if not is_global(ctx):
+            return jsonify({'error': SCOPE_DENIED_ERROR}), 403
+        try:
+            data = request.json or {}
+            sheet_name = data.get('sheet_name', '').strip()
+            target = (data.get('target_spreadsheet') or 'research').strip().lower()
+            if target not in ('research', 'community'):
+                target = 'research'
+
+            if not sheet_name:
+                return jsonify({
+                    'success': False,
+                    'error': 'sheet_name is required'
+                }), 400
+
+            if target == 'community':
+                service = get_community_sheets_service()
+                if not service:
+                    return jsonify({
+                        'success': False,
+                        'error': 'Community Google Sheets not configured',
+                        'sheets': []
+                    }), 503
+            else:
+                service = get_sheets_service()
+                if not service:
+                    return jsonify({
+                        'success': False,
+                        'error': 'Google Sheets service not configured',
+                        'sheets': []
+                    }), 503
+
+            existing_sheets = service.list_sheets()
+            if sheet_name in existing_sheets:
+                return jsonify({
+                    'success': True,
+                    'message': f'Sheet "{sheet_name}" already exists',
+                    'sheets': service.list_sheets()
+                })
+
+            if service.create_sheet_with_headers(sheet_name):
+                if target == 'community':
+                    try:
+                        backend_base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+                        data_dir = os.path.join(backend_base, 'data')
+                        community_dir = os.path.join(data_dir, 'Community_Uploads')
+                        safe_name = _safe_folder_name(sheet_name)
+                        os.makedirs(os.path.join(community_dir, safe_name), exist_ok=True)
+                    except Exception as folder_err:
+                        print(f"Warning: could not create Community_Uploads folder for new sheet: {folder_err}")
+                return jsonify({
+                    'success': True,
+                    'message': f'Sheet "{sheet_name}" created successfully',
+                    'sheets': service.list_sheets()
+                })
+            return jsonify({
+                'success': False,
+                'error': f'Failed to create sheet "{sheet_name}"'
+            }), 500
+        except Exception as e:
+            error_trace = traceback.format_exc()
+            try:
+                print(f"❌ Error creating sheet: {str(e)}")
+            except UnicodeEncodeError:
+                print(f"[ERROR] Error creating sheet: {str(e)}")
+            print(f"Traceback:\n{error_trace}")
+            return jsonify({
+                'success': False,
+                'error': f'Failed to process request: {str(e)}',
+                'sheets': []
+            }), 500
+
+    @app.route('/api/sheets/sheets', methods=['GET'])
     @require_admin
     def list_sheets():
         """
-        List all available sheets (tabs) in the Google Spreadsheet (Admin only)
-        POST: Create a new sheet with headers. Body may include target_spreadsheet: 'research' | 'community'.
-        GET: List all sheets
+        List all available sheets (tabs) in the Google Spreadsheet (staff/admin).
+        Scoped-group members see only the tabs their areas belong to.
         """
         try:
-            if request.method == 'POST':
-                data = request.json or {}
-                sheet_name = data.get('sheet_name', '').strip()
-                target = (data.get('target_spreadsheet') or 'research').strip().lower()
-                if target not in ('research', 'community'):
-                    target = 'research'
-
-                if not sheet_name:
-                    return jsonify({
-                        'success': False,
-                        'error': 'sheet_name is required'
-                    }), 400
-
-                if target == 'community':
-                    service = get_community_sheets_service()
-                    if not service:
-                        return jsonify({
-                            'success': False,
-                            'error': 'Community Google Sheets not configured',
-                            'sheets': []
-                        }), 503
-                else:
-                    service = get_sheets_service()
-                    if not service:
-                        return jsonify({
-                            'success': False,
-                            'error': 'Google Sheets service not configured',
-                            'sheets': []
-                        }), 503
-
-                existing_sheets = service.list_sheets()
-                if sheet_name in existing_sheets:
-                    return jsonify({
-                        'success': True,
-                        'message': f'Sheet "{sheet_name}" already exists',
-                        'sheets': service.list_sheets()
-                    })
-
-                if service.create_sheet_with_headers(sheet_name):
-                    if target == 'community':
-                        try:
-                            backend_base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-                            data_dir = os.path.join(backend_base, 'data')
-                            community_dir = os.path.join(data_dir, 'Community_Uploads')
-                            safe_name = _safe_folder_name(sheet_name)
-                            os.makedirs(os.path.join(community_dir, safe_name), exist_ok=True)
-                        except Exception as folder_err:
-                            print(f"Warning: could not create Community_Uploads folder for new sheet: {folder_err}")
-                    return jsonify({
-                        'success': True,
-                        'message': f'Sheet "{sheet_name}" created successfully',
-                        'sheets': service.list_sheets()
-                    })
-                return jsonify({
-                    'success': False,
-                    'error': f'Failed to create sheet "{sheet_name}"'
-                }), 500
-
             service = get_sheets_service()
             if not service:
                 return jsonify({
@@ -766,7 +855,6 @@ def register_sheets_routes(app):
                     'sheets': []
                 }), 503
 
-            # GET: List sheets
             try:
                 sheets = service.list_sheets()
                 if not isinstance(sheets, list):
@@ -780,12 +868,17 @@ def register_sheets_routes(app):
                     'error': f'Failed to list sheets: {str(list_error)}',
                     'sheets': []
                 }), 500
-            
+
+            # Scoped-group members only see tabs their areas belong to.
+            ctx = get_ctx()
+            if not is_global(ctx):
+                sheets = [s for s in sheets if scope_allows_sheet(ctx, s)]
+
             return jsonify({
                 'success': True,
                 'sheets': sheets
             })
-        
+
         except Exception as e:
             error_trace = traceback.format_exc()
             try:
@@ -938,7 +1031,23 @@ def register_sheets_routes(app):
                 except Exception as e:
                     print(f"Error reading sheet {sheet}: {e}")
                     continue
-            
+
+            # Scoped-group members: drop rows whose sheet is out of scope; where a
+            # row exposes a general location, refine to that sub-location (keep
+            # sheet-level rows when no general location resolves).
+            ctx = get_ctx()
+            if not is_global(ctx):
+                scoped = []
+                for t in all_turtles:
+                    sn = (t.get('sheet_name') or '').strip()
+                    if not scope_allows_sheet(ctx, sn):
+                        continue
+                    gl = (t.get('general_location') or '').strip()
+                    if gl and not scope_allows_location(ctx, f"{sn}/{gl}"):
+                        continue
+                    scoped.append(t)
+                all_turtles = scoped
+
             return jsonify({
                 'success': True,
                 'turtles': all_turtles,
@@ -983,6 +1092,11 @@ def register_sheets_routes(app):
             sheets_to_search = service.list_sheets()
             backup_sheet_names = ['Backup (Initial State)', 'Backup (Inital State)', 'Backup']
             sheets_to_search = [s for s in sheets_to_search if s not in backup_sheet_names]
+
+            # Scoped-group members only scan (and expose names from) their tabs.
+            ctx = get_ctx()
+            if not is_global(ctx):
+                sheets_to_search = [s for s in sheets_to_search if scope_allows_sheet(ctx, s)]
 
             all_names = []
             with _turtle_names_lock:
@@ -1058,7 +1172,7 @@ def register_sheets_routes(app):
             return jsonify({'error': f'Failed to list turtle names: {str(e)}'}), 500
 
     @app.route('/api/sheets/migrate-ids', methods=['POST'])
-    @require_admin
+    @require_admin_only
     def migrate_ids_to_primary_ids():
         """
         Migrate all turtles from "ID" column to "Primary ID" column.

--- a/backend/routes/turtles.py
+++ b/backend/routes/turtles.py
@@ -7,6 +7,13 @@ import time
 from flask import request, jsonify
 from werkzeug.utils import secure_filename
 from auth import require_admin
+from scope import (
+    get_ctx,
+    is_global,
+    resolve_turtle_location,
+    scope_allows_location,
+    SCOPE_DENIED_ERROR,
+)
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
 from image_utils import UploadImageError
 from upload_rate_limit import upload_rate_limit_ok, upload_rate_limit_response
@@ -78,6 +85,24 @@ def _ensure_primary_for_new_sheet_turtle(turtle_id, bio_id, sheet_name):
         return new_pid
 
     return manager_service.call_sheets_with_retry(_work)
+
+
+def _scope_denied_for_turtle(manager, turtle_id, sheet_name=None, primary_id=None):
+    """403 (json, code) when a scoped caller may not write to this turtle, else None.
+
+    Global ctx → None (no-op). Otherwise resolves the turtle's on-disk location
+    and fails closed (403) when it is unresolvable or outside the caller's areas.
+    New-turtle creation via these endpoints therefore fails closed for scoped
+    members (no folder yet → unresolvable); they create new turtles through the
+    review-approve flow, which gates on the chosen destination instead.
+    """
+    ctx = get_ctx()
+    if is_global(ctx):
+        return None
+    location = resolve_turtle_location(manager, turtle_id, sheet_name, primary_id)
+    if not scope_allows_location(ctx, location):
+        return jsonify({'error': SCOPE_DENIED_ERROR}), 403
+    return None
 
 
 def register_turtle_routes(app):
@@ -184,6 +209,9 @@ def register_turtle_routes(app):
             return jsonify({'error': 'filename required'}), 400
         if labels is not None and not isinstance(labels, list):
             return jsonify({'error': 'labels must be an array of strings'}), 400
+        denied = _scope_denied_for_turtle(manager_service.manager, turtle_id, sheet_name)
+        if denied:
+            return denied
         lbs = normalize_label_list(labels if isinstance(labels, list) else [])
         ok, err = manager_service.manager.update_turtle_additional_image_labels(
             turtle_id, filename, sheet_name, lbs
@@ -227,6 +255,9 @@ def register_turtle_routes(app):
         # Same primary-first lookup order as the image endpoints — biology IDs
         # collide across US state sheets, primaries don't.
         manager = manager_service.manager
+        denied = _scope_denied_for_turtle(manager, turtle_id, sheet_name, primary_id_fallback)
+        if denied:
+            return denied
         ok = False
         err = None
         if primary_id_fallback:
@@ -343,6 +374,9 @@ def register_turtle_routes(app):
             return jsonify({'error': 'turtle_id required'}), 400
         if not path:
             return jsonify({'error': 'path required'}), 400
+        denied = _scope_denied_for_turtle(manager_service.manager, turtle_id, sheet_name)
+        if denied:
+            return denied
         success, info = manager_service.manager.soft_delete_turtle_image(
             turtle_id, path, sheet_name
         )
@@ -377,6 +411,9 @@ def register_turtle_routes(app):
             return jsonify({'error': 'turtle_id required'}), 400
         if not path:
             return jsonify({'error': 'path required'}), 400
+        denied = _scope_denied_for_turtle(manager_service.manager, turtle_id, sheet_name)
+        if denied:
+            return denied
         success, info = manager_service.manager.restore_turtle_image(
             turtle_id, path, sheet_name
         )
@@ -403,6 +440,9 @@ def register_turtle_routes(app):
             return jsonify({'error': 'turtle_id required'}), 400
         if not filename:
             return jsonify({'error': 'filename required'}), 400
+        denied = _scope_denied_for_turtle(manager_service.manager, turtle_id, sheet_name)
+        if denied:
+            return denied
         success, err = manager_service.manager.remove_additional_image_from_turtle(
             turtle_id, filename, sheet_name
         )
@@ -435,6 +475,11 @@ def register_turtle_routes(app):
         bio_id = (request.form.get('bio_id') or request.args.get('bio_id') or '').strip() or None
         if not turtle_id:
             return jsonify({'error': 'turtle_id required'}), 400
+        denied = _scope_denied_for_turtle(
+            manager_service.manager, turtle_id, sheet_name, primary_id
+        )
+        if denied:
+            return denied
         files_with_types = []
         try:
             files_with_types, rejections = collect_indexed_additional_uploads(
@@ -486,6 +531,11 @@ def register_turtle_routes(app):
             return jsonify({'error': 'turtle_id required'}), 400
         if photo_type not in ('plastron', 'carapace'):
             return jsonify({'error': "photo_type must be 'plastron' or 'carapace'"}), 400
+        denied = _scope_denied_for_turtle(
+            manager_service.manager, turtle_id, sheet_name, primary_id
+        )
+        if denied:
+            return denied
         f = request.files.get('file')
         if not f or not f.filename or not allowed_file(f.filename):
             return jsonify({
@@ -586,6 +636,12 @@ def register_turtle_routes(app):
                     'code': 'primary_id_required',
                 }), 400
 
+        denied = _scope_denied_for_turtle(
+            manager_service.manager, turtle_id, sheet_name, primary_id
+        )
+        if denied:
+            return denied
+
         if 'file' not in request.files:
             return jsonify({'error': 'No file provided'}), 400
         f = request.files['file']
@@ -677,6 +733,13 @@ def register_turtle_routes(app):
             return jsonify({'error': 'keep_secondary_additional must be an array'}), 400
 
         manager = manager_service.manager
+        # Merge touches BOTH turtles' folders, so a scoped member must own both
+        # the primary (kept) and secondary (deleted) — fail closed on either.
+        for _pid, _sheet in ((primary_id, primary_sheet), (secondary_id, secondary_sheet)):
+            denied = _scope_denied_for_turtle(manager, _pid, _sheet, _pid)
+            if denied:
+                return denied
+
         ok, msg = manager.merge_turtles(
             primary_id, secondary_id,
             primary_sheet=primary_sheet,

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -14,7 +14,8 @@ import uuid
 from flask import request, jsonify
 from werkzeug.utils import secure_filename
 from config import UPLOAD_FOLDER, MAX_FILE_SIZE, allowed_file
-from auth import optional_auth, check_auth_revocation, require_admin
+from auth import optional_auth, validate_and_get_context, require_admin
+from scope import get_ctx, effective_match_filter, annotate_in_scope, is_global
 from image_utils import UploadImageError
 from upload_rate_limit import upload_rate_limit_ok, upload_rate_limit_response
 from upload_validation import ingest_saved_upload, log_upload_rejection, upload_error_response
@@ -224,7 +225,10 @@ def register_upload_routes(app):
                 return jsonify({'error': 'Failed to save file'}), 500
 
             if user_role in ('staff', 'admin'):
-                # Enforce revocation before privileged path (demotion must revoke immediately)
+                # Enforce revocation before privileged path (demotion must revoke
+                # immediately) and resolve the caller's scope context off the
+                # validate body (never the JWT claim). request.scope_ctx drives the
+                # scoped match filter below.
                 auth_header = request.headers.get('Authorization')
                 if not auth_header:
                     if os.path.exists(temp_path):
@@ -233,7 +237,7 @@ def register_upload_routes(app):
                         except OSError:
                             pass
                     return jsonify({'error': 'Staff or admin access requires a valid token'}), 403
-                allowed, revoke_error = check_auth_revocation(auth_header)
+                allowed, revoke_error, scope_ctx = validate_and_get_context(auth_header)
                 if not allowed:
                     if os.path.exists(temp_path):
                         try:
@@ -241,6 +245,7 @@ def register_upload_routes(app):
                         except OSError:
                             pass
                     return jsonify({'error': revoke_error or 'Token has been revoked'}), 403
+                request.scope_ctx = scope_ctx
                 # Admin/Staff: create a packet (so we can add additional images on match page) then run search
                 request_id = f"admin_{int(time.time())}_{filename}"
                 packet_dir = os.path.join(manager_service.manager.review_queue_dir, request_id)
@@ -272,10 +277,15 @@ def register_upload_routes(app):
                 match_sheet = (request.form.get('match_sheet') or '').strip() or None
                 candidates_dir = os.path.join(packet_dir, 'candidate_matches')
 
+                # Scoped-group members search only their areas; global users are
+                # unchanged. scope_forced marks that the requested scope was
+                # narrowed/overridden to the group's areas.
+                location_filter, scope_forced = effective_match_filter(scope_ctx, match_sheet)
+
                 try:
                     # Admin uploads are always plastron — photo_type is fixed
                     results = manager_service.manager.search_for_matches(
-                        query_save_path, location_filter=match_sheet, photo_type='plastron'
+                        query_save_path, location_filter=location_filter, photo_type='plastron'
                     )
 
                     # Safely unpack the tuple (matches, elapsed_time)
@@ -311,6 +321,12 @@ def register_upload_routes(app):
                             'filename': os.path.basename(image_path) if image_path else ''
                         })
 
+                    # Flag each candidate in/out of the caller's scope, and whether
+                    # the result set was expanded beyond scope (out-of-scope hits or
+                    # the requested scope was forced to the group's areas). Global
+                    # ctx => every candidate in_scope, scope_expanded False.
+                    scope_expanded = annotate_in_scope(scope_ctx, formatted_matches) or scope_forced
+
                     message = (
                         f'Photo processed successfully. {len(formatted_matches)} matches found.'
                         if len(formatted_matches) > 0
@@ -323,6 +339,16 @@ def register_upload_routes(app):
                     packet_metadata = {'photo_type': 'plastron'}
                     if match_sheet:
                         packet_metadata['match_sheet'] = match_sheet
+                    # Persist the scope outcome so a later cross-check / review of
+                    # this packet reuses the same scope, and so the review queue can
+                    # decide visibility for scoped members. scope_filter is the
+                    # effective (possibly narrowed) area list for a scoped uploader.
+                    packet_metadata['scope_expanded'] = scope_expanded
+                    if not is_global(scope_ctx):
+                        packet_metadata['scope_filter'] = (
+                            list(location_filter) if isinstance(location_filter, (list, tuple))
+                            else ([location_filter] if location_filter else [])
+                        )
                     # Persist the same flag / find-metadata fields the community
                     # path saves so admin uploads can carry them through approval
                     # the same way. The form extracts these above into local
@@ -353,6 +379,7 @@ def register_upload_routes(app):
                         'matches': formatted_matches,
                         'uploaded_image_path': query_save_path,
                         'photo_type': 'plastron',
+                        'scope_expanded': scope_expanded,
                         'message': message
                     })
                 except Exception as search_exc:
@@ -528,9 +555,13 @@ def register_upload_routes(app):
             except UploadImageError as img_err:
                 return upload_error_response(img_err)
 
+            # Scope the carapace search to the caller's areas (global unchanged).
+            scope_ctx = get_ctx()
+            location_filter, scope_forced = effective_match_filter(scope_ctx, match_sheet)
+
             results, elapsed = manager_service.manager.search_for_matches(
                 temp_path,
-                location_filter=match_sheet,
+                location_filter=location_filter,
                 photo_type='carapace',
                 expand_to_all_when_short=True,
             )
@@ -548,10 +579,14 @@ def register_upload_routes(app):
                     'image_path': find_image_for_pt(pt_path),
                 })
 
+            # Flag in/out of scope; persists nothing (quick check is read-only).
+            scope_expanded = annotate_in_scope(scope_ctx, formatted) or scope_forced
+
             return jsonify({
                 'success': True,
                 'photo_type': 'carapace',
                 'matches': formatted,
+                'scope_expanded': scope_expanded,
                 'elapsed': round(elapsed, 2),
             })
         except Exception as e:

--- a/backend/scope.py
+++ b/backend/scope.py
@@ -1,0 +1,258 @@
+"""
+Group-scope enforcement primitives (PR-2).
+
+Pure functions that turn a per-request scope *context* (produced by
+``auth.validate_and_get_context`` from the auth service's ``/auth/validate``
+body) into filter/gate decisions. Authorization is always done off this
+context — never off JWT claims — so a promotion/move applies without re-login.
+
+A context (``ctx``) is a dict::
+
+    {'role', 'user_id', 'email', 'group_id', 'group_name', 'group_scope',
+     'system_key', 'group_role', 'areas': [...], 'is_global': bool}
+
+``areas`` are opaque path prefixes matching the VRAM index ``location`` strings
+(``"Kansas"``, ``"Kansas/Lawrence"``, ``"NebraskaCPBS"`` — the ``"/".join`` of
+the path above ``<TurtleID>/<reffolder>``). A global context (admin, or a group
+whose ``scope == 'global'``) bypasses every filter and write gate, so behavior
+is byte-identical to pre-PR-2 for Operations/Primary members. Only scoped-group
+members are restricted; community/anon paths never set a context.
+
+This module imports Flask only for the tiny ``get_ctx`` request accessor; every
+other function is a pure transform (ctx + data → decision), fully unit-testable
+without Flask, and the turtle/packet resolvers take the manager/metadata as
+arguments so they stay testable too.
+"""
+
+import os
+
+from flask import request
+
+# Standard 403 body for an out-of-scope write attempt.
+SCOPE_DENIED_ERROR = "Target is outside your group's assigned areas"
+
+
+def get_ctx():
+    """Return the current request's scope context (set by the auth guards), or None.
+
+    None means a non-guarded/legacy path (community/anon upload, or a caller that
+    never set ``request.scope_ctx``) — treated as global by ``is_global``.
+    """
+    return getattr(request, 'scope_ctx', None)
+
+
+def is_global(ctx):
+    """True when the context is unrestricted.
+
+    - ``ctx is None`` (non-guarded/legacy path) → global (no filtering applied).
+    - ``ctx['is_global']`` → global (admin, or a group with ``scope == 'global'``).
+    """
+    if ctx is None:
+        return True
+    return bool(ctx.get('is_global'))
+
+
+def _clean(value):
+    return value.strip() if isinstance(value, str) else ''
+
+
+def top_level_of(location):
+    """First path segment of a location string (the sheet/tab), e.g.
+    ``"Kansas/Lawrence"`` → ``"Kansas"``. Empty for a falsy/blank value."""
+    loc = _clean(location)
+    if not loc:
+        return ''
+    return loc.split('/', 1)[0]
+
+
+def area_covers(area, location):
+    """True when ``location`` is at or below ``area`` in the path tree.
+
+    ``location == area`` or ``location`` is a descendant (``location.startswith(area + '/')``).
+    This is the simple prefix primitive both gates build on. Blank inputs → False.
+    """
+    a = _clean(area)
+    loc = _clean(location)
+    if not a or not loc:
+        return False
+    return loc == a or loc.startswith(a + '/')
+
+
+def scope_allows_location(ctx, location):
+    """WRITE gate: may this context write to ``location``?
+
+    - Global → True.
+    - Falsy/unresolvable ``location`` → **False (fail closed)** — an unresolved
+      target is never writable for a scoped user.
+    - Else True when any owned area covers the location.
+    """
+    if is_global(ctx):
+        return True
+    loc = _clean(location)
+    if not loc:
+        return False
+    return any(area_covers(a, loc) for a in (ctx.get('areas') or []))
+
+
+def scope_allows_sheet(ctx, sheet):
+    """LIST gate: may this context SEE ``sheet`` (a top-level tab) in a list?
+
+    Broader than the write gate: a group owning only ``Kansas/Lawrence`` can
+    still see the ``Kansas`` sheet/tab (an owned area lives under it). Global →
+    True; blank sheet → False.
+    """
+    if is_global(ctx):
+        return True
+    s = _clean(sheet)
+    if not s:
+        return False
+    return any(a == s or a.startswith(s + '/') for a in (ctx.get('areas') or []))
+
+
+def filter_locations(ctx, locations):
+    """Filter a ``get_all_locations()``-style list to what a scoped ctx may see.
+
+    Global → unchanged. Otherwise: ``Community_Uploads`` is always kept (shared
+    pool); a top-level entry is kept when its sheet passes ``scope_allows_sheet``;
+    a nested ``State/SubLoc`` entry is kept only when it is within an owned area
+    OR an owned area is within it (so ``Kansas/Lawrence`` is hidden from a
+    ``Kansas/Topeka`` owner, but a whole-``Kansas`` owner keeps every sub-site).
+    """
+    if is_global(ctx):
+        return list(locations)
+    areas = ctx.get('areas') or []
+    out = []
+    for loc in locations:
+        if loc == 'Community_Uploads':
+            out.append(loc)
+            continue
+        if not scope_allows_sheet(ctx, top_level_of(loc)):
+            continue
+        if '/' not in str(loc):
+            # Top-level entry (the sheet itself) — already passed the sheet gate.
+            out.append(loc)
+            continue
+        # Nested entry: keep when the entry is within an owned area or vice-versa.
+        if any(area_covers(a, loc) or area_covers(loc, a) for a in areas):
+            out.append(loc)
+    return out
+
+
+def effective_match_filter(ctx, requested):
+    """Resolve the location filter to pass to ``search_for_matches``.
+
+    Returns ``(location_filter, scope_forced)`` where ``scope_forced`` is True
+    when the requested scope was narrowed/overridden to the group's areas.
+
+    - Global → ``(requested, False)`` unchanged.
+    - Scoped:
+      * empty / ``'All Locations'`` / ``'__all__'`` → ``(list(areas), True)``.
+      * ``'Community_Uploads'`` → ``('Community_Uploads', False)`` (shared pool).
+      * within scope (an owned area covers it, or it is a prefix of an owned
+        area) → narrow to the owned areas touching it, ``(that_list, False)``.
+      * fully out of scope → ``(list(areas), True)``.
+    """
+    if is_global(ctx):
+        return requested, False
+    areas = list(ctx.get('areas') or [])
+    req = requested.strip() if isinstance(requested, str) else requested
+    if not req or req in ('All Locations', '__all__'):
+        return list(areas), True
+    if req == 'Community_Uploads':
+        return 'Community_Uploads', False
+    narrowed = [a for a in areas if area_covers(req, a) or area_covers(a, req)]
+    if narrowed:
+        return narrowed, False
+    return list(areas), True
+
+
+def annotate_in_scope(ctx, matches):
+    """Set ``match['in_scope']`` on each match dict; return ``scope_expanded``.
+
+    ``in_scope`` = whether the match's ``location`` is writable by this ctx
+    (global → all True). ``scope_expanded`` is True when any match fell outside
+    scope (e.g. the ``<5 ⇒ expand to all`` fallback pulled in distant turtles).
+    """
+    scope_expanded = False
+    for m in matches:
+        in_scope = scope_allows_location(ctx, m.get('location'))
+        m['in_scope'] = in_scope
+        if not in_scope:
+            scope_expanded = True
+    return scope_expanded
+
+
+def resolve_turtle_location(manager, turtle_id, sheet_hint=None, primary_id=None):
+    """Resolve a turtle's on-disk location relative to ``data/`` (e.g. ``Kansas/Topeka``).
+
+    Returns the location string, or ``None`` when the folder can't be resolved
+    (caller then fails closed for a scoped user). Primary-first (globally unique)
+    then bio_id (sheet-scoped) — reuses ``_get_turtle_folder`` unchanged, so the
+    existing scoped / fail-closed lookup semantics are preserved (bio IDs stay
+    sheet-scoped; only a globally-unique primary may resolve unscoped).
+    """
+    if manager is None:
+        return None
+    turtle_dir = None
+    pid = _clean(primary_id)
+    tid = _clean(turtle_id)
+    if pid and pid != tid:
+        turtle_dir = manager._get_turtle_folder(pid, sheet_hint)
+    if (not turtle_dir or not os.path.isdir(turtle_dir)) and tid:
+        turtle_dir = manager._get_turtle_folder(tid, sheet_hint)
+    if not turtle_dir or not os.path.isdir(turtle_dir):
+        return None
+    try:
+        rel = os.path.relpath(os.path.dirname(turtle_dir), manager.base_dir)
+    except (ValueError, OSError):
+        return None
+    if not rel or rel == '.' or rel.startswith('..'):
+        return None
+    return rel.replace(os.sep, '/')
+
+
+def packet_scope_locations(meta):
+    """Location string(s) that describe a review packet's scope, from its metadata.
+
+    Order of precedence:
+      1. ``match_sheet`` (staff/admin upload's chosen scope).
+      2. ``scope_filter`` (the persisted effective filter for a scoped uploader).
+      3. community ``state``/``location`` the uploader declared.
+    Returns ``[]`` when the packet carries no location info (→ global-only).
+    """
+    if not isinstance(meta, dict):
+        return []
+    ms = _clean(meta.get('match_sheet'))
+    if ms:
+        return [ms]
+    sf = meta.get('scope_filter')
+    if isinstance(sf, (list, tuple)):
+        locs = [_clean(x) for x in sf if _clean(x)]
+        if locs:
+            return locs
+    state = _clean(meta.get('state'))
+    location = _clean(meta.get('location'))
+    if state and location:
+        return [f"{state}/{location}"]
+    if state:
+        return [state]
+    return []
+
+
+def packet_scope_allows(ctx, meta):
+    """True when a scoped ctx may see/act on a review packet (by its metadata).
+
+    Global → True. A packet with no location info is visible only to global (a
+    scoped user can't prove it is theirs → fail closed). Otherwise the packet is
+    in scope when any of its scope-locations passes the write gate OR the (looser)
+    sheet gate — mirroring the review-queue visibility rule so "see == act".
+    """
+    if is_global(ctx):
+        return True
+    locs = packet_scope_locations(meta)
+    if not locs:
+        return False
+    for loc in locs:
+        if scope_allows_location(ctx, loc) or scope_allows_sheet(ctx, top_level_of(loc)):
+            return True
+    return False

--- a/backend/tests/integration/test_scoped_enforcement.py
+++ b/backend/tests/integration/test_scoped_enforcement.py
@@ -1,0 +1,91 @@
+"""
+Integration tests: Flask scope enforcement against the seeded personas (PR-2).
+
+Requires the Docker integration stack (backend + auth) and seeded users:
+
+  BACKEND_URL=http://localhost:5000 AUTH_URL=http://localhost:3001/api \
+    pytest tests/integration/test_scoped_enforcement.py -v
+
+Personas (from the e2e seed): scoped-staff@test.com is a KansasTeam member whose
+only area is ``Kansas/Topeka`` (top-level tab ``Kansas``); staff@test.com is a
+global Primary member; admin@test.com is a global Operations lead. These tests
+only READ (list endpoints) and attempt one deliberately out-of-scope write that
+is rejected before any Sheets mutation, so they never change data.
+"""
+
+import os
+
+import pytest
+import requests
+
+TIMEOUT = 20
+
+
+def _backend(backend_url):
+    return backend_url.rstrip("/")
+
+
+def _hdr(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _get(backend_url, path, token):
+    return requests.get(f"{_backend(backend_url)}{path}", headers=_hdr(token), timeout=TIMEOUT)
+
+
+def test_scoped_staff_sheets_are_a_subset(
+    backend_url, integration_env, admin_token, staff_token, scoped_staff_token
+):
+    """Scoped staff (KansasTeam) see only their tab(s); global staff match admin."""
+    if not integration_env or not admin_token or not staff_token or not scoped_staff_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded users) to run")
+
+    admin_sheets = set(_get(backend_url, "/api/sheets/sheets", admin_token).json().get("sheets", []))
+    global_sheets = set(_get(backend_url, "/api/sheets/sheets", staff_token).json().get("sheets", []))
+    scoped_sheets = set(_get(backend_url, "/api/sheets/sheets", scoped_staff_token).json().get("sheets", []))
+
+    # A global staff (Primary) is unchanged — identical to what admin sees.
+    assert global_sheets == admin_sheets
+    # KansasTeam's only area is Kansas/Topeka, so the only visible tab is "Kansas".
+    assert scoped_sheets <= {"Kansas"}
+    assert scoped_sheets <= admin_sheets
+
+
+def test_scoped_staff_locations_are_scoped(backend_url, integration_env, scoped_staff_token):
+    """/api/locations for scoped staff keeps Community_Uploads + only Kansas entries."""
+    if not integration_env or not scoped_staff_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded scoped staff) to run")
+    r = _get(backend_url, "/api/locations", scoped_staff_token)
+    assert r.status_code == 200, r.text
+    locs = r.json().get("locations", [])
+    assert all(loc == "Community_Uploads" or loc.split("/")[0] == "Kansas" for loc in locs), locs
+
+
+def test_scoped_staff_turtles_list_is_scoped(backend_url, integration_env, scoped_staff_token):
+    """Every turtle row a scoped member sees belongs to its Kansas tab."""
+    if not integration_env or not scoped_staff_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded scoped staff) to run")
+    r = _get(backend_url, "/api/sheets/turtles", scoped_staff_token)
+    assert r.status_code == 200, r.text
+    turtles = r.json().get("turtles", [])
+    assert all((t.get("sheet_name") or "") == "Kansas" for t in turtles), [t.get("sheet_name") for t in turtles]
+
+
+def test_scoped_staff_out_of_scope_write_is_forbidden(
+    backend_url, integration_env, scoped_staff_token
+):
+    """A scoped member is 403 on a write to a sheet outside its areas.
+
+    Uses generate-id for NebraskaCPBS (KansasTeam owns only Kansas/Topeka): the
+    scope guard rejects it before any Sheets call, so nothing is mutated. The
+    "global staff unchanged" half of this requirement is covered by
+    test_scoped_staff_sheets_are_a_subset (global == admin)."""
+    if not integration_env or not scoped_staff_token:
+        pytest.skip("Set BACKEND_URL and AUTH_URL (and seeded scoped staff) to run")
+    url = f"{_backend(backend_url)}/api/sheets/generate-id"
+    r = requests.post(
+        url, headers=_hdr(scoped_staff_token),
+        json={"sex": "F", "sheet_name": "NebraskaCPBS"}, timeout=TIMEOUT,
+    )
+    assert r.status_code == 403, r.text
+    assert "outside your group" in (r.json() or {}).get("error", "")

--- a/backend/tests/scope_test_utils.py
+++ b/backend/tests/scope_test_utils.py
@@ -1,0 +1,142 @@
+"""
+Shared helpers for scope-enforcement tests (PR-2).
+
+The route guards now authorize off ``auth.validate_and_get_context`` (the auth
+service's ``/auth/validate`` body), not off ``auth.check_auth_revocation``. These
+factories build the per-request scope context dicts and patch the guard so unit
+tests can exercise global vs scoped behavior without a live auth service.
+"""
+
+import jwt
+
+import config
+
+
+def global_admin_ctx():
+    """Admin — Operations (global). Bypasses every filter/gate."""
+    return {
+        'role': 'admin',
+        'user_id': 1,
+        'email': 'admin@test.com',
+        'group_id': 1,
+        'group_name': 'Operations',
+        'group_scope': 'global',
+        'system_key': 'operations',
+        'group_role': 'lead',
+        'areas': [],
+        'is_global': True,
+    }
+
+
+def global_staff_ctx():
+    """Staff — Primary (global). Bypasses every filter/gate."""
+    return {
+        'role': 'staff',
+        'user_id': 2,
+        'email': 'staff@test.com',
+        'group_id': 2,
+        'group_name': 'Primary',
+        'group_scope': 'global',
+        'system_key': 'primary',
+        'group_role': 'member',
+        'areas': [],
+        'is_global': True,
+    }
+
+
+def scoped_ctx(areas=None, role='staff', group_role='member'):
+    """A scoped-group member (default staff) restricted to ``areas``.
+
+    A community role or an empty area list is scoped with zero reach (the
+    "waiting to be assigned" state); admin is always global regardless of group.
+    """
+    areas = list(areas or [])
+    return {
+        'role': role,
+        'user_id': 3,
+        'email': f'{role}-scoped@test.com',
+        'group_id': 3,
+        'group_name': 'KansasTeam',
+        'group_scope': 'scoped',
+        'system_key': None,
+        'group_role': group_role,
+        'areas': areas,
+        'is_global': role == 'admin',
+    }
+
+
+def community_ctx():
+    """A community (non-staff) user — no group, no areas, not global."""
+    return {
+        'role': 'community',
+        'user_id': 4,
+        'email': 'community@test.com',
+        'group_id': None,
+        'group_name': None,
+        'group_scope': None,
+        'system_key': None,
+        'group_role': 'member',
+        'areas': [],
+        'is_global': False,
+    }
+
+
+def ctx_for_role(role):
+    """Map a bare JWT role claim to a global context (admin/staff) or community."""
+    if role == 'admin':
+        return global_admin_ctx()
+    if role == 'staff':
+        return global_staff_ctx()
+    return community_ctx()
+
+
+def _role_from_auth_header(auth_header):
+    """Decode the test JWT and read its role claim (defaults to community)."""
+    if not auth_header:
+        return 'community'
+    tok = auth_header[7:] if auth_header.startswith('Bearer ') else auth_header
+    try:
+        payload = jwt.decode(tok, config.JWT_SECRET, algorithms=['HS256'])
+        return payload.get('role', 'community')
+    except Exception:
+        return 'community'
+
+
+def role_aware_validate(auth_header):
+    """A ``validate_and_get_context`` stand-in that mirrors the token's role.
+
+    Returns ``(True, None, ctx)`` where ctx is the global context matching the
+    JWT's role claim — so ``_auth("community")`` still 403s on staff routes and
+    ``_auth("admin")`` passes, exactly as the real auth service would (role is
+    DB-fresh, approximated here by the JWT claim).
+    """
+    return True, None, ctx_for_role(_role_from_auth_header(auth_header))
+
+
+def patch_validate(monkeypatch, ctx):
+    """Patch the auth guards to always resolve to ``ctx`` (allowed).
+
+    Patches both ``auth.validate_and_get_context`` (require_admin/only + the
+    /api/upload staff branch) and ``auth.check_auth_revocation`` (admin_backup)
+    so every guarded path sees the same context.
+    """
+    import auth
+
+    monkeypatch.setattr(auth, 'validate_and_get_context', lambda auth_header: (True, None, ctx))
+    monkeypatch.setattr(auth, 'check_auth_revocation', lambda auth_header: (True, None))
+    return ctx
+
+
+def bearer(role='admin', secret=None):
+    """Mint a test JWT carrying ``role`` (identity only; scope comes from ctx)."""
+    token = jwt.encode(
+        {'role': role, 'sub': f'pytest-{role}'},
+        secret or config.JWT_SECRET,
+        algorithm='HS256',
+    )
+    return token if isinstance(token, str) else token.decode('ascii')
+
+
+def auth_header(role='admin'):
+    """Authorization header dict for a test JWT of the given role."""
+    return {'Authorization': f'Bearer {bearer(role)}'}

--- a/backend/tests/test_general_locations_admin_only.py
+++ b/backend/tests/test_general_locations_admin_only.py
@@ -1,0 +1,108 @@
+"""
+Unit tests for §7: general-locations mutations are admin-only, while the
+read-only GET catalog stays staff-visible (the staff turtle form reads it).
+
+Staff (global) get 403 on POST/DELETE/affected-turtles/sheet-defaults but 200 on
+GET; admin gets 200 on a mutation. The auth guards are patched with role-specific
+contexts; the admin mutation patches the catalog writer so the real catalog file
+is never touched.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tests.scope_test_utils import global_admin_ctx, global_staff_ctx, auth_header
+
+
+@pytest.fixture
+def app_client():
+    from app import app
+
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _as_staff():
+    return patch("auth.validate_and_get_context", return_value=(True, None, global_staff_ctx()))
+
+
+def _as_admin():
+    return patch("auth.validate_and_get_context", return_value=(True, None, global_admin_ctx()))
+
+
+# ------------------------------------------------------ GET stays staff-visible
+
+def test_get_catalog_staff_200(app_client):
+    with _as_staff():
+        r = app_client.get("/api/general-locations", headers=auth_header("staff"))
+    assert r.status_code == 200
+    assert r.get_json()["success"] is True
+    assert "catalog" in r.get_json()
+
+
+# --------------------------------------------------- mutations are admin-only
+
+def test_post_add_location_staff_403(app_client):
+    with _as_staff():
+        r = app_client.post(
+            "/api/general-locations",
+            json={"state": "Kansas", "general_location": "New Site"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+    assert "Admin access required" in r.get_json()["error"]
+
+
+def test_delete_location_staff_403(app_client):
+    with _as_staff():
+        r = app_client.delete(
+            "/api/general-locations",
+            json={"state": "Kansas", "general_location": "North Topeka"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+
+
+def test_affected_turtles_staff_403(app_client):
+    with _as_staff():
+        r = app_client.get(
+            "/api/general-locations/affected-turtles?general_location=North+Topeka&state=Kansas",
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+
+
+def test_add_sheet_default_staff_403(app_client):
+    with _as_staff():
+        r = app_client.post(
+            "/api/general-locations/sheet-defaults",
+            json={"sheet_name": "NebraskaCPBS", "general_location": "CPBS"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+
+
+def test_remove_sheet_default_staff_403(app_client):
+    with _as_staff():
+        r = app_client.delete(
+            "/api/general-locations/sheet-defaults",
+            json={"sheet_name": "NebraskaCPBS"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+
+
+def test_post_add_location_admin_200(app_client):
+    """Admin passes the guard; the catalog writer is stubbed so nothing is mutated on disk."""
+    fake_catalog = {"states": {"Kansas": ["New Site"]}, "sheet_defaults": {}}
+    with _as_admin(), \
+            patch("routes.general_locations.add_general_location", return_value=fake_catalog), \
+            patch("routes.general_locations.get_sheets_service", return_value=None):
+        r = app_client.post(
+            "/api/general-locations",
+            json={"state": "Kansas", "general_location": "New Site"},
+            headers=auth_header("admin"),
+        )
+    assert r.status_code == 200, r.get_json()
+    assert r.get_json()["success"] is True

--- a/backend/tests/test_quick_check_route.py
+++ b/backend/tests/test_quick_check_route.py
@@ -14,6 +14,7 @@ import pytest
 
 import config
 from image_utils import UploadImageError
+from tests.scope_test_utils import role_aware_validate
 
 
 def _bearer(role):
@@ -56,7 +57,10 @@ def quick_check_env(tmp_path):
     mock_manager.review_queue_dir = str(review_dir)
     mock_manager.search_for_matches.return_value = ([], 0.42)
 
-    with patch("auth.check_auth_revocation", return_value=(True, None)), \
+    # require_admin now authorizes off validate_and_get_context (not
+    # check_auth_revocation); role_aware_validate mirrors the token's role so a
+    # community token still 403s and admin/staff pass.
+    with patch("auth.validate_and_get_context", side_effect=role_aware_validate), \
             patch("routes.upload.UPLOAD_FOLDER", str(upload_dir)), \
             patch("routes.upload.ingest_saved_upload", side_effect=lambda p, **kw: p), \
             patch("routes.upload.manager_service.manager", mock_manager), \

--- a/backend/tests/test_review_approve_no_community_sync_on_research_match.py
+++ b/backend/tests/test_review_approve_no_community_sync_on_research_match.py
@@ -9,6 +9,7 @@ import jwt
 import pytest
 
 import config
+from tests.scope_test_utils import global_admin_ctx
 
 
 def _admin_bearer():
@@ -34,7 +35,7 @@ def test_approve_research_match_does_not_call_community_sheets_service(app_clien
     mock_manager = MagicMock()
     mock_manager.approve_review_packet.return_value = (True, "approved")
 
-    with patch("auth.check_auth_revocation", return_value=(True, None)):
+    with patch("auth.validate_and_get_context", return_value=(True, None, global_admin_ctx())):
         with patch("routes.review.get_community_sheets_service") as get_comm:
             with patch("routes.review.manager_service.manager", mock_manager):
                 with patch("routes.review.manager_service.manager_ready") as ready:
@@ -59,7 +60,7 @@ def test_approve_community_to_admin_still_deletes_community_row(app_client):
     mock_manager = MagicMock()
     mock_manager.approve_review_packet.return_value = (True, "moved")
 
-    with patch("auth.check_auth_revocation", return_value=(True, None)):
+    with patch("auth.validate_and_get_context", return_value=(True, None, global_admin_ctx())):
         with patch(
             "routes.review.resolve_general_location_from_sheet_and_value",
             return_value="NT",

--- a/backend/tests/test_scope_helpers.py
+++ b/backend/tests/test_scope_helpers.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for the pure scope primitives in ``scope.py`` (PR-2).
+
+No Flask app / auth service needed — every function is a pure transform of a
+context dict plus data. Covers ``area_covers`` edge cases, the write vs list
+gates, ``filter_locations``, every ``effective_match_filter`` branch, fail-closed
+behavior on None/empty locations, and the packet-scope resolver.
+"""
+
+import pytest
+
+import scope
+from tests.scope_test_utils import (
+    global_admin_ctx,
+    global_staff_ctx,
+    scoped_ctx,
+    community_ctx,
+)
+
+
+# ------------------------------------------------------------------- is_global
+
+def test_is_global_none_is_global():
+    assert scope.is_global(None) is True
+
+
+def test_is_global_admin_and_global_group():
+    assert scope.is_global(global_admin_ctx()) is True
+    assert scope.is_global(global_staff_ctx()) is True
+
+
+def test_is_global_scoped_is_not_global():
+    assert scope.is_global(scoped_ctx(areas=['Kansas'])) is False
+    assert scope.is_global(scoped_ctx(areas=[])) is False
+
+
+# ------------------------------------------------------------------ area_covers
+
+@pytest.mark.parametrize("area,loc,expected", [
+    ("Kansas", "Kansas", True),
+    ("Kansas", "Kansas/Topeka", True),
+    ("Kansas", "Kansas/Topeka/East Geo", True),
+    ("Kansas", "KansasCPBS", False),           # prefix-not-at-boundary must NOT match
+    ("Kansas/Topeka", "Kansas", False),         # parent is not covered by child
+    ("Kansas/Topeka", "Kansas/Topeka", True),
+    ("Kansas/Topeka", "Kansas/TopekaWest", False),
+    ("", "Kansas", False),
+    ("Kansas", "", False),
+])
+def test_area_covers(area, loc, expected):
+    assert scope.area_covers(area, loc) is expected
+
+
+def test_top_level_of():
+    assert scope.top_level_of("Kansas/Topeka/East") == "Kansas"
+    assert scope.top_level_of("NebraskaCPBS") == "NebraskaCPBS"
+    assert scope.top_level_of("") == ""
+    assert scope.top_level_of(None) == ""
+
+
+# --------------------------------------------------------- scope_allows_location
+
+def test_scope_allows_location_global_always_true():
+    assert scope.scope_allows_location(global_admin_ctx(), None) is True
+    assert scope.scope_allows_location(None, "") is True
+
+
+def test_scope_allows_location_fail_closed_on_empty():
+    ctx = scoped_ctx(areas=['Kansas'])
+    assert scope.scope_allows_location(ctx, None) is False
+    assert scope.scope_allows_location(ctx, "") is False
+    assert scope.scope_allows_location(ctx, "   ") is False
+
+
+def test_scope_allows_location_matches_area():
+    ctx = scoped_ctx(areas=['Kansas/Topeka'])
+    assert scope.scope_allows_location(ctx, "Kansas/Topeka") is True
+    assert scope.scope_allows_location(ctx, "Kansas/Topeka/East Geo") is True
+    assert scope.scope_allows_location(ctx, "Kansas") is False        # parent sheet, not writable
+    assert scope.scope_allows_location(ctx, "Kansas/Lawrence") is False
+
+
+def test_scope_allows_location_zero_areas_writes_nothing():
+    ctx = scoped_ctx(areas=[])
+    assert scope.scope_allows_location(ctx, "Kansas/Topeka") is False
+
+
+# ------------------------------------------------------------ scope_allows_sheet
+
+def test_scope_allows_sheet_owning_subarea_sees_sheet():
+    ctx = scoped_ctx(areas=['Kansas/Lawrence'])
+    assert scope.scope_allows_sheet(ctx, "Kansas") is True          # can SEE the tab
+    assert scope.scope_allows_sheet(ctx, "Nebraska") is False
+    assert scope.scope_allows_sheet(ctx, "") is False
+
+
+def test_scope_allows_sheet_owning_whole_sheet():
+    ctx = scoped_ctx(areas=['Kansas'])
+    assert scope.scope_allows_sheet(ctx, "Kansas") is True
+    assert scope.scope_allows_sheet(ctx, "KansasCPBS") is False
+
+
+# ------------------------------------------------------------- filter_locations
+
+def test_filter_locations_global_unchanged():
+    locs = ["Community_Uploads", "Kansas", "Kansas/Lawrence", "Nebraska"]
+    assert scope.filter_locations(global_admin_ctx(), locs) == locs
+
+
+def test_filter_locations_scoped_subarea():
+    locs = ["Community_Uploads", "Kansas", "Kansas/Lawrence", "Kansas/Topeka", "Nebraska"]
+    ctx = scoped_ctx(areas=['Kansas/Topeka'])
+    out = scope.filter_locations(ctx, locs)
+    assert "Community_Uploads" in out         # shared pool always kept
+    assert "Kansas" in out                     # sheet visible (owns Topeka under it)
+    assert "Kansas/Topeka" in out              # owned area
+    assert "Kansas/Lawrence" not in out        # sibling sub-site hidden
+    assert "Nebraska" not in out
+
+
+def test_filter_locations_scoped_whole_state_keeps_all_subsites():
+    locs = ["Community_Uploads", "Kansas", "Kansas/Lawrence", "Kansas/Topeka"]
+    ctx = scoped_ctx(areas=['Kansas'])
+    out = scope.filter_locations(ctx, locs)
+    assert set(out) == {"Community_Uploads", "Kansas", "Kansas/Lawrence", "Kansas/Topeka"}
+
+
+def test_filter_locations_zero_areas_keeps_only_community():
+    locs = ["Community_Uploads", "Kansas", "Kansas/Topeka"]
+    assert scope.filter_locations(scoped_ctx(areas=[]), locs) == ["Community_Uploads"]
+
+
+# -------------------------------------------------------- effective_match_filter
+
+def test_effective_match_filter_global_passthrough():
+    ctx = global_admin_ctx()
+    assert scope.effective_match_filter(ctx, "Kansas") == ("Kansas", False)
+    assert scope.effective_match_filter(ctx, None) == (None, False)
+    assert scope.effective_match_filter(ctx, "__all__") == ("__all__", False)
+
+
+@pytest.mark.parametrize("requested", [None, "", "All Locations", "__all__"])
+def test_effective_match_filter_scoped_all_forces_areas(requested):
+    ctx = scoped_ctx(areas=['Kansas/Topeka', 'Kansas/Lawrence'])
+    flt, forced = scope.effective_match_filter(ctx, requested)
+    assert forced is True
+    assert set(flt) == {'Kansas/Topeka', 'Kansas/Lawrence'}
+
+
+def test_effective_match_filter_scoped_community_uploads():
+    ctx = scoped_ctx(areas=['Kansas/Topeka'])
+    assert scope.effective_match_filter(ctx, "Community_Uploads") == ("Community_Uploads", False)
+
+
+def test_effective_match_filter_scoped_sheet_narrows_to_owned_subareas():
+    ctx = scoped_ctx(areas=['Kansas/Topeka'])
+    flt, forced = scope.effective_match_filter(ctx, "Kansas")
+    assert forced is False
+    assert flt == ['Kansas/Topeka']
+
+
+def test_effective_match_filter_scoped_exact_area():
+    ctx = scoped_ctx(areas=['Kansas/Topeka'])
+    flt, forced = scope.effective_match_filter(ctx, "Kansas/Topeka")
+    assert forced is False
+    assert flt == ['Kansas/Topeka']
+
+
+def test_effective_match_filter_scoped_out_of_scope_forces_areas():
+    ctx = scoped_ctx(areas=['Kansas/Topeka'])
+    flt, forced = scope.effective_match_filter(ctx, "Nebraska")
+    assert forced is True
+    assert flt == ['Kansas/Topeka']
+
+
+# ------------------------------------------------------------- annotate_in_scope
+
+def test_annotate_in_scope_global_all_true():
+    matches = [{'location': 'Kansas/Topeka'}, {'location': 'Nebraska'}]
+    expanded = scope.annotate_in_scope(global_admin_ctx(), matches)
+    assert expanded is False
+    assert all(m['in_scope'] for m in matches)
+
+
+def test_annotate_in_scope_scoped_flags_out_of_area():
+    matches = [{'location': 'Kansas/Topeka'}, {'location': 'Nebraska'}, {'location': None}]
+    ctx = scoped_ctx(areas=['Kansas/Topeka'])
+    expanded = scope.annotate_in_scope(ctx, matches)
+    assert expanded is True
+    assert matches[0]['in_scope'] is True
+    assert matches[1]['in_scope'] is False
+    assert matches[2]['in_scope'] is False   # unresolved location fails closed
+
+
+# ------------------------------------------------------------- packet_scope
+
+def test_packet_scope_locations_precedence():
+    assert scope.packet_scope_locations({'match_sheet': 'Kansas'}) == ['Kansas']
+    assert scope.packet_scope_locations({'scope_filter': ['Kansas/Topeka', '']}) == ['Kansas/Topeka']
+    assert scope.packet_scope_locations({'state': 'Kansas', 'location': 'Topeka'}) == ['Kansas/Topeka']
+    assert scope.packet_scope_locations({'state': 'Kansas'}) == ['Kansas']
+    assert scope.packet_scope_locations({}) == []
+    assert scope.packet_scope_locations({'photo_type': 'plastron'}) == []
+
+
+def test_packet_scope_allows_global_and_no_location():
+    assert scope.packet_scope_allows(global_admin_ctx(), {}) is True
+    # no location info => a scoped user cannot see/act (fail closed)
+    assert scope.packet_scope_allows(scoped_ctx(areas=['Kansas/Topeka']), {}) is False
+
+
+def test_packet_scope_allows_scoped_matches_sheet_or_location():
+    ctx = scoped_ctx(areas=['Kansas/Topeka'])
+    # admin packet whose match_sheet is the whole Kansas tab: visible (owns a sub-area)
+    assert scope.packet_scope_allows(ctx, {'match_sheet': 'Kansas'}) is True
+    # community packet in another state: hidden
+    assert scope.packet_scope_allows(ctx, {'state': 'Nebraska', 'location': 'CPBS'}) is False
+    # persisted scoped-upload filter that overlaps: visible
+    assert scope.packet_scope_allows(ctx, {'scope_filter': ['Kansas/Topeka']}) is True
+
+
+# ---------------------------------------------------- resolve_turtle_location
+
+class _FakeManager:
+    def __init__(self, base_dir, mapping):
+        self.base_dir = base_dir
+        self._mapping = mapping  # (turtle_id, hint) -> dir | id -> dir
+
+    def _get_turtle_folder(self, turtle_id, location_hint=None):
+        return self._mapping.get(turtle_id)
+
+
+def test_resolve_turtle_location_from_folder(tmp_path):
+    tdir = tmp_path / "Kansas" / "Topeka" / "F102_T1770000001"
+    tdir.mkdir(parents=True)
+    mgr = _FakeManager(str(tmp_path), {"T1770000001": str(tdir), "F102": str(tdir)})
+    assert scope.resolve_turtle_location(mgr, "F102", "Kansas") == "Kansas/Topeka"
+    # primary-first still resolves the same folder
+    assert scope.resolve_turtle_location(mgr, "F102", "Kansas", primary_id="T1770000001") == "Kansas/Topeka"
+
+
+def test_resolve_turtle_location_unresolvable_returns_none(tmp_path):
+    mgr = _FakeManager(str(tmp_path), {})
+    assert scope.resolve_turtle_location(mgr, "F999", "Kansas") is None
+    assert scope.resolve_turtle_location(None, "F999", "Kansas") is None
+
+
+def test_resolve_turtle_location_combo_sheet(tmp_path):
+    tdir = tmp_path / "NebraskaCPBS" / "F050_T1770000009"
+    tdir.mkdir(parents=True)
+    mgr = _FakeManager(str(tmp_path), {"F050": str(tdir)})
+    assert scope.resolve_turtle_location(mgr, "F050", "NebraskaCPBS") == "NebraskaCPBS"
+
+
+# -------------------------------------------- auth._build_scope_ctx (is_global)
+
+def _body(role, group=Ellipsis, areas=None):
+    user = {'id': 1, 'email': 'u@test.com', 'role': role, 'group_role': 'member'}
+    if group is not Ellipsis:          # Ellipsis => omit the group key entirely
+        user['group'] = group
+    if areas is not None:
+        user['areas'] = areas
+    return {'valid': True, 'user': user}
+
+
+def test_build_ctx_global_group_is_global():
+    import auth
+    ctx = auth._build_scope_ctx(_body('staff', group={'id': 2, 'name': 'Primary',
+                                                       'scope': 'global', 'system_key': 'primary'}))
+    assert ctx['is_global'] is True
+    assert ctx['areas'] == []
+
+
+def test_build_ctx_scoped_group_staff_not_global():
+    import auth
+    ctx = auth._build_scope_ctx(_body('staff', group={'id': 3, 'name': 'KansasTeam',
+                                                       'scope': 'scoped', 'system_key': None},
+                                       areas=['Kansas/Topeka', '', '  Kansas ']))
+    assert ctx['is_global'] is False
+    assert ctx['areas'] == ['Kansas/Topeka', 'Kansas']   # cleaned/trimmed, blanks dropped
+
+
+def test_build_ctx_admin_always_global_even_in_scoped_group():
+    import auth
+    ctx = auth._build_scope_ctx(_body('admin', group={'id': 3, 'name': 'KansasTeam',
+                                                       'scope': 'scoped', 'system_key': None},
+                                       areas=['Kansas/Topeka']))
+    assert ctx['is_global'] is True
+
+
+def test_build_ctx_null_group_unassigned_staff_scoped():
+    import auth
+    ctx = auth._build_scope_ctx(_body('staff', group=None))
+    assert ctx['is_global'] is False      # unassigned staff: zero reach
+    assert ctx['areas'] == []
+
+
+def test_build_ctx_missing_group_key_is_global_mixed_version():
+    import auth
+    # group key entirely absent (old auth-backend) => treat staff as global too
+    ctx = auth._build_scope_ctx(_body('staff'))
+    assert ctx['is_global'] is True

--- a/backend/tests/test_scoped_list_filters.py
+++ b/backend/tests/test_scoped_list_filters.py
@@ -1,0 +1,151 @@
+"""
+Unit tests: list endpoints return an areas-limited subset for scoped-group members
+and the full set for global users — locations, sheets tabs, the turtles list, and
+the review queue (including a no-location community packet hidden from a scoped
+member but shown to global).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.scope_test_utils import global_admin_ctx, scoped_ctx, auth_header
+
+KS = ["Kansas/North Topeka"]
+
+
+@pytest.fixture
+def app_client():
+    from app import app
+
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+@pytest.fixture
+def mgr():
+    m = MagicMock()
+    with patch("services.manager_service.manager", m), \
+            patch("services.manager_service.manager_ready") as ready:
+        ready.wait.return_value = True
+        yield m
+
+
+def _scoped(areas=KS):
+    return patch("auth.validate_and_get_context", return_value=(True, None, scoped_ctx(areas=areas)))
+
+
+def _global():
+    return patch("auth.validate_and_get_context", return_value=(True, None, global_admin_ctx()))
+
+
+# ----------------------------------------------------------------- locations
+
+def test_locations_scoped_subset(app_client, mgr):
+    mgr.get_all_locations.return_value = [
+        "Community_Uploads", "Kansas", "Kansas/North Topeka", "Kansas/Lawrence", "Nebraska",
+    ]
+    with _scoped():
+        r = app_client.get("/api/locations", headers=auth_header("staff"))
+    assert r.status_code == 200
+    locs = r.get_json()["locations"]
+    assert set(locs) == {"Community_Uploads", "Kansas", "Kansas/North Topeka"}
+
+
+def test_locations_global_full(app_client, mgr):
+    full = ["Community_Uploads", "Kansas", "Kansas/Lawrence", "Nebraska"]
+    mgr.get_all_locations.return_value = full
+    with _global():
+        r = app_client.get("/api/locations", headers=auth_header("admin"))
+    assert r.get_json()["locations"] == full
+
+
+# -------------------------------------------------------------------- sheets
+
+def test_sheets_list_scoped_subset(app_client, mgr):
+    svc = MagicMock()
+    svc.list_sheets.return_value = ["Kansas", "Nebraska", "IowaHawkeye"]
+    with _scoped(), patch("routes.sheets.get_sheets_service", return_value=svc):
+        r = app_client.get("/api/sheets/sheets", headers=auth_header("staff"))
+    assert r.status_code == 200
+    assert r.get_json()["sheets"] == ["Kansas"]
+
+
+def test_sheets_list_global_full(app_client, mgr):
+    svc = MagicMock()
+    svc.list_sheets.return_value = ["Kansas", "Nebraska", "IowaHawkeye"]
+    with _global(), patch("routes.sheets.get_sheets_service", return_value=svc):
+        r = app_client.get("/api/sheets/sheets", headers=auth_header("admin"))
+    assert r.get_json()["sheets"] == ["Kansas", "Nebraska", "IowaHawkeye"]
+
+
+# ------------------------------------------------------------- list_all_turtles
+
+def _turtles_service():
+    svc = MagicMock()
+    svc.list_sheets.return_value = ["Kansas", "Nebraska"]
+    svc.COLUMN_MAPPING = {
+        "Primary ID": "primary_id",
+        "General Location": "general_location",
+        "Name": "name",
+    }
+    svc._ensure_primary_id_column.return_value = None
+    svc.spreadsheet_id = "sid"
+    values = {"values": [
+        ["Primary ID", "General Location", "Name"],
+        ["T1", "North Topeka", "Sheldon"],
+    ]}
+    svc.service.spreadsheets.return_value.values.return_value.get.return_value.execute.return_value = values
+    return svc
+
+
+def test_list_all_turtles_scoped_drops_out_of_scope_sheet(app_client, mgr):
+    with _scoped(), patch("routes.sheets.get_sheets_service", return_value=_turtles_service()):
+        r = app_client.get("/api/sheets/turtles", headers=auth_header("staff"))
+    assert r.status_code == 200
+    turtles = r.get_json()["turtles"]
+    # Only the Kansas/North Topeka row survives; the Nebraska sheet is dropped.
+    assert len(turtles) == 1
+    assert turtles[0]["sheet_name"] == "Kansas"
+
+
+def test_list_all_turtles_global_full(app_client, mgr):
+    with _global(), patch("routes.sheets.get_sheets_service", return_value=_turtles_service()):
+        r = app_client.get("/api/sheets/turtles", headers=auth_header("admin"))
+    assert r.get_json()["count"] == 2
+
+
+# --------------------------------------------------------------- review queue
+
+def _queue_items():
+    return [
+        {"path": "/p1", "request_id": "admin_1"},
+        {"path": "/p2", "request_id": "Req_2"},
+        {"path": "/p3", "request_id": "Req_3"},
+    ]
+
+
+def _formatted(packet_dir, request_id):
+    meta = {
+        "admin_1": {"match_sheet": "Kansas"},                       # in a scoped Kansas tab
+        "Req_2": {"state": "Nebraska", "location": "CPBS"},          # other state
+        "Req_3": {"photo_type": "unclassified"},                    # community, no location
+    }[request_id]
+    return {"request_id": request_id, "metadata": meta}
+
+
+def test_review_queue_scoped_subset(app_client, mgr):
+    mgr.get_review_queue.return_value = _queue_items()
+    with _scoped(), patch("routes.review.format_review_packet_item", side_effect=_formatted):
+        r = app_client.get("/api/review-queue", headers=auth_header("staff"))
+    assert r.status_code == 200
+    ids = [it["request_id"] for it in r.get_json()["items"]]
+    assert ids == ["admin_1"]           # Nebraska + no-location community hidden
+
+
+def test_review_queue_global_full(app_client, mgr):
+    mgr.get_review_queue.return_value = _queue_items()
+    with _global(), patch("routes.review.format_review_packet_item", side_effect=_formatted):
+        r = app_client.get("/api/review-queue", headers=auth_header("admin"))
+    ids = sorted(it["request_id"] for it in r.get_json()["items"])
+    assert ids == ["Req_2", "Req_3", "admin_1"]

--- a/backend/tests/test_scoped_matching.py
+++ b/backend/tests/test_scoped_matching.py
@@ -1,0 +1,190 @@
+"""
+Unit tests: scoped-group members get an areas-limited match filter and in/out-of
+-scope flags on the staff/admin match endpoints (/api/upload staff branch and
+/api/match/quick-check), while global users are unchanged and the community
+upload path is untouched. The manager + ingest are mocked (no AI runs).
+"""
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.scope_test_utils import (
+    global_admin_ctx,
+    scoped_ctx,
+    community_ctx,
+    auth_header,
+)
+
+
+@pytest.fixture
+def app_client():
+    from app import app
+
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+@pytest.fixture
+def env(tmp_path):
+    """Patched upload folder, identity ingest, ready mock manager."""
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+    review_dir = tmp_path / "review_queue"
+    review_dir.mkdir()
+
+    mock_manager = MagicMock()
+    mock_manager.review_queue_dir = str(review_dir)
+    mock_manager.search_for_matches.return_value = ([], 0.1)
+
+    with patch("routes.upload.UPLOAD_FOLDER", str(upload_dir)), \
+            patch("routes.upload.ingest_saved_upload", side_effect=lambda p, **kw: p), \
+            patch("routes.upload.manager_service.manager", mock_manager), \
+            patch("routes.upload.manager_service.manager_ready") as ready:
+        ready.wait.return_value = True
+        yield {"manager": mock_manager, "upload_dir": upload_dir, "review_dir": review_dir}
+
+
+def _file(extra=None):
+    payload = {"file": (io.BytesIO(b"\xff\xd8\xff\xe0 fake jpeg"), "q.jpg")}
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+# ------------------------------------------------------------- /api/upload staff
+
+def test_upload_scoped_blank_sheet_forces_areas_and_flags(app_client, env):
+    """A scoped staff with a blank match_sheet searches its areas (scope_forced),
+    and out-of-area candidates are flagged in_scope=False / scope_expanded=True."""
+    env["manager"].search_for_matches.return_value = (
+        [
+            {"site_id": "F1", "location": "Kansas/Topeka", "confidence": 0.9, "file_path": "/x/a.pt"},
+            {"site_id": "F2", "location": "Nebraska/CPBS", "confidence": 0.5, "file_path": "/x/b.pt"},
+        ],
+        0.2,
+    )
+    with patch("routes.upload.validate_and_get_context",
+               return_value=(True, None, scoped_ctx(areas=["Kansas/Topeka"]))):
+        r = app_client.post(
+            "/api/upload",
+            data=_file(),
+            content_type="multipart/form-data",
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 200, r.get_json()
+    body = r.get_json()
+    # Blank sheet => forced to the group's areas.
+    kwargs = env["manager"].search_for_matches.call_args.kwargs
+    assert kwargs["location_filter"] == ["Kansas/Topeka"]
+    assert body["scope_expanded"] is True
+    by_id = {m["turtle_id"]: m for m in body["matches"]}
+    assert by_id["F1"]["in_scope"] is True
+    assert by_id["F2"]["in_scope"] is False
+
+
+def test_upload_scoped_persists_scope_metadata(app_client, env):
+    """The packet metadata records scope_expanded and the effective scope_filter."""
+    import json
+    import os
+
+    env["manager"].search_for_matches.return_value = (
+        [{"site_id": "F1", "location": "Nebraska", "confidence": 0.9, "file_path": "/x/a.pt"}],
+        0.2,
+    )
+    with patch("routes.upload.validate_and_get_context",
+               return_value=(True, None, scoped_ctx(areas=["Kansas/Topeka"]))):
+        r = app_client.post(
+            "/api/upload",
+            data=_file(),
+            content_type="multipart/form-data",
+            headers=auth_header("staff"),
+        )
+    request_id = r.get_json()["request_id"]
+    meta_path = os.path.join(env["review_dir"], request_id, "metadata.json")
+    with open(meta_path) as f:
+        meta = json.load(f)
+    assert meta["scope_expanded"] is True
+    assert meta["scope_filter"] == ["Kansas/Topeka"]
+
+
+def test_upload_global_unchanged(app_client, env):
+    """A global admin passes the requested sheet straight through, no expansion."""
+    env["manager"].search_for_matches.return_value = (
+        [{"site_id": "F1", "location": "Nebraska", "confidence": 0.9, "file_path": "/x/a.pt"}],
+        0.2,
+    )
+    with patch("routes.upload.validate_and_get_context",
+               return_value=(True, None, global_admin_ctx())):
+        r = app_client.post(
+            "/api/upload",
+            data=_file(extra={"match_sheet": "Kansas"}),
+            content_type="multipart/form-data",
+            headers=auth_header("admin"),
+        )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert env["manager"].search_for_matches.call_args.kwargs["location_filter"] == "Kansas"
+    assert body["scope_expanded"] is False
+    assert body["matches"][0]["in_scope"] is True   # global => every candidate in scope
+
+
+def test_community_upload_untouched(app_client, env):
+    """A community upload never enters the scoped staff branch (background packet)."""
+    with patch("auth.validate_and_get_context",
+               return_value=(True, None, community_ctx())):
+        r = app_client.post(
+            "/api/upload",
+            data=_file(extra={"state": "Kansas", "location": "Topeka"}),
+            content_type="multipart/form-data",
+            headers=auth_header("community"),
+        )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "Waiting for admin review" in body["message"]
+    assert "scope_expanded" not in body           # community response shape unchanged
+    env["manager"].search_for_matches.assert_not_called()
+
+
+# ------------------------------------------------------- /api/match/quick-check
+
+def test_quick_check_scoped_narrows_and_flags(app_client, env):
+    """Quick check narrows a requested sheet to the owned sub-areas and flags results."""
+    env["manager"].search_for_matches.return_value = (
+        [
+            {"site_id": "C1", "location": "Kansas/Topeka", "confidence": 0.9, "score": 400, "file_path": "/x/a.pt"},
+            {"site_id": "C2", "location": "Kansas/Lawrence", "confidence": 0.4, "score": 100, "file_path": "/x/b.pt"},
+        ],
+        0.3,
+    )
+    with patch("auth.validate_and_get_context",
+               return_value=(True, None, scoped_ctx(areas=["Kansas/Topeka"]))):
+        r = app_client.post(
+            "/api/match/quick-check",
+            data=_file(extra={"match_sheet": "Kansas"}),
+            content_type="multipart/form-data",
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 200, r.get_json()
+    body = r.get_json()
+    # Requesting the whole Kansas tab while owning only Topeka narrows the filter.
+    assert env["manager"].search_for_matches.call_args.kwargs["location_filter"] == ["Kansas/Topeka"]
+    assert body["scope_expanded"] is True         # Lawrence hit is out of scope
+    by_id = {m["turtle_id"]: m for m in body["matches"]}
+    assert by_id["C1"]["in_scope"] is True
+    assert by_id["C2"]["in_scope"] is False
+
+
+def test_quick_check_global_passthrough(app_client, env):
+    with patch("auth.validate_and_get_context",
+               return_value=(True, None, global_admin_ctx())):
+        r = app_client.post(
+            "/api/match/quick-check",
+            data=_file(extra={"match_sheet": "Kansas"}),
+            content_type="multipart/form-data",
+            headers=auth_header("admin"),
+        )
+    assert r.status_code == 200
+    assert env["manager"].search_for_matches.call_args.kwargs["location_filter"] == "Kansas"
+    assert r.get_json()["scope_expanded"] is False

--- a/backend/tests/test_scoped_write_guards.py
+++ b/backend/tests/test_scoped_write_guards.py
@@ -1,0 +1,304 @@
+"""
+Unit tests: the scoped write guards return 403 when a scoped-group member targets
+a turtle/sheet outside its areas (and when the target is unresolvable), and 200
+when in-scope; global users are never gated. Covers approve_review, the sheets
+create/update writes, a turtles.py mutation, and merge (both ends must pass).
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.scope_test_utils import global_admin_ctx, global_staff_ctx, scoped_ctx, auth_header
+
+# Scoped member owns Kansas/North Topeka only.
+KS = ["Kansas/North Topeka"]
+
+
+@pytest.fixture
+def app_client():
+    from app import app
+
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+@pytest.fixture
+def mgr(tmp_path):
+    """Mock manager with real in-/out-of-scope turtle folders on disk."""
+    in_dir = tmp_path / "Kansas" / "North Topeka" / "F_IN_T1770000001"
+    in_dir.mkdir(parents=True)
+    out_dir = tmp_path / "Nebraska" / "CPBS" / "F_OUT_T1770000002"
+    out_dir.mkdir(parents=True)
+    folders = {
+        "F_IN": str(in_dir), "T1770000001": str(in_dir),
+        "F_OUT": str(out_dir), "T1770000002": str(out_dir),
+    }
+
+    m = MagicMock()
+    m.base_dir = str(tmp_path)
+    m._get_turtle_folder.side_effect = lambda tid, hint=None: folders.get(tid)
+    m.approve_review_packet.return_value = (True, "approved")
+    m.soft_delete_turtle_image.return_value = (True, {"was_reference": False})
+    m.merge_turtles.return_value = (True, "merged")
+
+    with patch("services.manager_service.manager", m), \
+            patch("services.manager_service.manager_ready") as ready:
+        ready.wait.return_value = True
+        yield m
+
+
+def _scoped(areas=KS):
+    return patch("auth.validate_and_get_context", return_value=(True, None, scoped_ctx(areas=areas)))
+
+
+def _global():
+    return patch("auth.validate_and_get_context", return_value=(True, None, global_admin_ctx()))
+
+
+# --------------------------------------------------------------- approve_review
+
+def test_approve_match_in_scope_200(app_client, mgr):
+    with _scoped():
+        r = app_client.post(
+            "/api/review/admin_x/approve",
+            json={"match_turtle_id": "F_IN"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 200, r.get_json()
+    mgr.approve_review_packet.assert_called_once()
+
+
+def test_approve_match_out_of_scope_403(app_client, mgr):
+    with _scoped():
+        r = app_client.post(
+            "/api/review/admin_x/approve",
+            json={"match_turtle_id": "F_OUT"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+    assert "outside your group" in r.get_json()["error"]
+    mgr.approve_review_packet.assert_not_called()
+
+
+def test_approve_match_out_of_scope_with_inscope_decoy_403(app_client, mgr):
+    """Regression: an in-scope new_location decoy must not unlock an out-of-scope match.
+
+    _approve_review_packet_locked writes onto the matched turtle's folder whenever
+    match_turtle_id is present (Scenario A), ignoring new_location. So the scope gate
+    must authorize match_turtle_id FIRST — otherwise a scoped member could pass an
+    in-scope new_location as a decoy while the manager writes onto an out-of-scope
+    turtle. The gate must resolve F_OUT (Nebraska) and deny despite new_location=Kansas.
+    """
+    with _scoped(), patch(
+        "routes.review.normalize_new_turtle_location_for_disk",
+        side_effect=lambda loc, sd, **kw: (loc, "North Topeka"),
+    ):
+        r = app_client.post(
+            "/api/review/admin_x/approve",
+            json={"match_turtle_id": "F_OUT", "new_location": "Kansas/North Topeka",
+                  "new_turtle_id": "T1770000004"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403, r.get_json()
+    assert "outside your group" in r.get_json()["error"]
+    mgr.approve_review_packet.assert_not_called()
+
+
+def test_approve_match_unresolvable_403(app_client, mgr):
+    """A scoped member fails closed when the target turtle can't be resolved."""
+    with _scoped():
+        r = app_client.post(
+            "/api/review/admin_x/approve",
+            json={"match_turtle_id": "GHOST"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+    mgr.approve_review_packet.assert_not_called()
+
+
+def test_approve_new_turtle_out_of_scope_403(app_client, mgr):
+    """A scoped member cannot create a new turtle at an out-of-scope destination.
+
+    Location normalization is patched to identity so the *scope guard* (not the
+    catalog validation) is what's exercised.
+    """
+    with _scoped(), patch(
+        "routes.review.normalize_new_turtle_location_for_disk",
+        side_effect=lambda loc, sd, **kw: (loc, "CPBS"),
+    ):
+        r = app_client.post(
+            "/api/review/admin_x/approve",
+            json={"new_location": "Nebraska/CPBS", "new_turtle_id": "T1770000004"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+    assert "outside your group" in r.get_json()["error"]
+    mgr.approve_review_packet.assert_not_called()
+
+
+def test_approve_global_unrestricted(app_client, mgr):
+    with _global():
+        r = app_client.post(
+            "/api/review/admin_x/approve",
+            json={"match_turtle_id": "F_OUT"},
+            headers=auth_header("admin"),
+        )
+    assert r.status_code == 200
+    mgr.approve_review_packet.assert_called_once()
+
+
+# ------------------------------------------------------------------- sheets
+
+def _identity_gl():
+    return patch(
+        "routes.sheets.resolve_general_location_from_sheet_and_value",
+        side_effect=lambda sheet, gl, **kw: gl or "",
+    )
+
+
+def _sheets_service():
+    svc = MagicMock()
+    svc.list_sheets.return_value = ["Kansas"]
+    svc.generate_biology_id.return_value = "F001"
+    svc.create_turtle_data.return_value = "T1770000009"
+    svc.update_turtle_data.return_value = True
+    svc.find_turtle_sheet.return_value = "Kansas"
+    svc.get_turtle_data.return_value = {"general_location": "North Topeka", "id": "F001"}
+    return svc
+
+
+def test_sheets_create_in_scope_200(app_client, mgr):
+    with _scoped(), _identity_gl(), \
+            patch("routes.sheets.get_sheets_service", return_value=_sheets_service()):
+        r = app_client.post(
+            "/api/sheets/turtle",
+            json={"sheet_name": "Kansas",
+                  "turtle_data": {"primary_id": "T1770000009", "general_location": "North Topeka", "sex": "F"}},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 200, r.get_json()
+
+
+def test_sheets_create_out_of_scope_403(app_client, mgr):
+    svc = _sheets_service()
+    with _scoped(), _identity_gl(), patch("routes.sheets.get_sheets_service", return_value=svc):
+        r = app_client.post(
+            "/api/sheets/turtle",
+            json={"sheet_name": "Nebraska",
+                  "turtle_data": {"primary_id": "T1770000009", "general_location": "CPBS", "sex": "F"}},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+    svc.create_turtle_data.assert_not_called()   # gate fired before any write
+
+
+def test_sheets_update_out_of_scope_403(app_client, mgr):
+    svc = _sheets_service()
+    with _scoped(), _identity_gl(), patch("routes.sheets.get_sheets_service", return_value=svc):
+        r = app_client.put(
+            "/api/sheets/turtle/T1770000009",
+            json={"sheet_name": "Nebraska",
+                  "turtle_data": {"general_location": "CPBS", "sex": "F"}},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+    svc.update_turtle_data.assert_not_called()
+    svc.create_turtle_data.assert_not_called()
+
+
+def test_sheets_generate_id_out_of_scope_403(app_client, mgr):
+    svc = _sheets_service()
+    with _scoped(), patch("routes.sheets.get_sheets_service", return_value=svc):
+        r = app_client.post(
+            "/api/sheets/generate-id",
+            json={"sex": "F", "sheet_name": "Nebraska"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+    svc.generate_biology_id.assert_not_called()
+
+
+def test_create_sheet_scoped_member_403(app_client, mgr):
+    """Creating a top-level sheet defines a new area — forbidden for a scoped group."""
+    svc = _sheets_service()
+    svc.create_sheet_with_headers.return_value = True
+    with _scoped(), patch("routes.sheets.get_sheets_service", return_value=svc):
+        r = app_client.post(
+            "/api/sheets/sheets",
+            json={"sheet_name": "BrandNewArea"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+    svc.create_sheet_with_headers.assert_not_called()
+
+
+def test_create_sheet_global_staff_200(app_client, mgr):
+    """Global (Primary) staff keep the pre-scoping sheet-creation capability."""
+    svc = _sheets_service()
+    svc.list_sheets.return_value = ["Kansas"]
+    svc.create_sheet_with_headers.return_value = True
+    global_staff = patch(
+        "auth.validate_and_get_context", return_value=(True, None, global_staff_ctx())
+    )
+    with global_staff, patch("routes.sheets.get_sheets_service", return_value=svc):
+        r = app_client.post(
+            "/api/sheets/sheets",
+            json={"sheet_name": "BrandNewArea"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 200, r.get_json()
+    svc.create_sheet_with_headers.assert_called_once()
+
+
+# ----------------------------------------------------------------- turtles.py
+
+def test_soft_delete_in_scope_200(app_client, mgr):
+    with _scoped():
+        r = app_client.delete(
+            "/api/turtles/image",
+            json={"turtle_id": "F_IN", "path": "/x/y.jpg", "sheet_name": "Kansas"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 200, r.get_json()
+    mgr.soft_delete_turtle_image.assert_called_once()
+
+
+def test_soft_delete_out_of_scope_403(app_client, mgr):
+    with _scoped():
+        r = app_client.delete(
+            "/api/turtles/image",
+            json={"turtle_id": "F_OUT", "path": "/x/y.jpg", "sheet_name": "Nebraska"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+    mgr.soft_delete_turtle_image.assert_not_called()
+
+
+# -------------------------------------------------------------------- merge
+
+def test_merge_mixed_scope_403(app_client, mgr):
+    """Merge must reject when only one of the two turtles is in scope."""
+    with _scoped():
+        r = app_client.post(
+            "/api/turtles/merge",
+            json={"primary_id": "T1770000001", "secondary_id": "T1770000002",
+                  "primary_sheet": "Kansas", "secondary_sheet": "Nebraska"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 403
+    mgr.merge_turtles.assert_not_called()
+
+
+def test_merge_both_in_scope_200(app_client, mgr):
+    """Both ends in scope → allowed (owns the whole Kansas + Nebraska here)."""
+    with _scoped(areas=["Kansas", "Nebraska"]):
+        r = app_client.post(
+            "/api/turtles/merge",
+            json={"primary_id": "T1770000001", "secondary_id": "T1770000002",
+                  "primary_sheet": "Kansas", "secondary_sheet": "Nebraska"},
+            headers=auth_header("staff"),
+        )
+    assert r.status_code == 200, r.get_json()
+    mgr.merge_turtles.assert_called_once()

--- a/backend/tests/test_search_for_matches_list_filter.py
+++ b/backend/tests/test_search_for_matches_list_filter.py
@@ -1,0 +1,71 @@
+"""
+Unit tests: ``TurtleManager.search_for_matches`` accepts a list location filter
+(scoped-group areas) without crashing, appends the shared pools, dedupes, and
+keeps the single-string behavior byte-identical. ``brain`` is mocked so no
+SuperPoint/LightGlue runs.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import turtle_manager as tm
+
+
+@pytest.fixture
+def mgr(tmp_path, monkeypatch):
+    # Mock the heavy brain calls; capture the location filter passed to the cache.
+    monkeypatch.setattr(tm.brain, "extract_query_features", lambda p: {"q": 1})
+    if hasattr(tm.brain, "load_database_to_vram"):
+        monkeypatch.setattr(tm.brain, "load_database_to_vram", MagicMock())
+    match_mock = MagicMock(return_value=[])
+    monkeypatch.setattr(tm.brain, "match_against_cache", match_mock)
+    manager = tm.TurtleManager(base_data_dir=str(tmp_path))
+    manager._match_mock = match_mock
+    return manager
+
+
+def _first_filter(mgr):
+    """The loc_filter passed to the first match_against_cache call."""
+    args, kwargs = mgr._match_mock.call_args_list[0]
+    return args[1] if len(args) > 1 else kwargs.get("location_filter")
+
+
+def test_list_filter_appends_pools_and_dedupes(mgr):
+    mgr.search_for_matches("q.jpg", location_filter=["Kansas/Topeka", "Kansas/Lawrence"])
+    assert _first_filter(mgr) == [
+        "Kansas/Topeka", "Kansas/Lawrence", "Community_Uploads", "Incidental Places",
+    ]
+
+
+def test_list_filter_dedupes_when_pool_already_present(mgr):
+    mgr.search_for_matches("q.jpg", location_filter=["Community_Uploads", "Kansas/Topeka"])
+    assert _first_filter(mgr) == ["Community_Uploads", "Kansas/Topeka", "Incidental Places"]
+
+
+def test_empty_list_filter_treated_as_all(mgr):
+    mgr.search_for_matches("q.jpg", location_filter=[])
+    assert _first_filter(mgr) is None
+
+
+def test_list_filter_drops_blank_entries(mgr):
+    mgr.search_for_matches("q.jpg", location_filter=["", "  ", "Kansas/Topeka"])
+    assert _first_filter(mgr) == ["Kansas/Topeka", "Community_Uploads", "Incidental Places"]
+
+
+def test_string_filter_behavior_unchanged(mgr):
+    mgr.search_for_matches("q.jpg", location_filter="Kansas")
+    assert _first_filter(mgr) == ["Kansas", "Community_Uploads", "Incidental Places"]
+
+
+def test_string_community_uploads_unchanged(mgr):
+    mgr.search_for_matches("q.jpg", location_filter="Community_Uploads")
+    assert _first_filter(mgr) == ["Community_Uploads"]
+
+
+def test_none_and_all_locations_unchanged(mgr):
+    mgr.search_for_matches("q.jpg", location_filter=None)
+    assert _first_filter(mgr) is None
+    mgr._match_mock.reset_mock()
+    mgr.search_for_matches("q.jpg", location_filter="All Locations")
+    assert _first_filter(mgr) is None

--- a/backend/turtle_manager/manager.py
+++ b/backend/turtle_manager/manager.py
@@ -387,15 +387,27 @@ class TurtleManager(TurtleReferenceMixin, TurtleDeletionMixin, TurtleReviewMixin
         t_start = time.time()
         filename = os.path.basename(query_image_path)
 
-        # Build location filter: selected location always includes Community_Uploads + Incidental Places
-        raw_loc = (location_filter or '').strip() or None
-        if raw_loc and raw_loc != 'All Locations':
-            if raw_loc == 'Community_Uploads':
-                loc_filter = ['Community_Uploads']
+        # Build location filter: selected location always includes Community_Uploads + Incidental Places.
+        # A list/tuple (scoped-group areas, from effective_match_filter) is supported alongside the
+        # legacy single-string form; the string branch is byte-identical to before.
+        if isinstance(location_filter, (list, tuple)):
+            filters = [str(x).strip() for x in location_filter if x and str(x).strip()]
+            if not filters:
+                loc_filter = None
             else:
-                loc_filter = [raw_loc, 'Community_Uploads', 'Incidental Places']
+                loc_filter = []
+                for item in [*filters, 'Community_Uploads', 'Incidental Places']:
+                    if item not in loc_filter:  # dedupe, preserve order
+                        loc_filter.append(item)
         else:
-            loc_filter = None
+            raw_loc = (location_filter or '').strip() or None
+            if raw_loc and raw_loc != 'All Locations':
+                if raw_loc == 'Community_Uploads':
+                    loc_filter = ['Community_Uploads']
+                else:
+                    loc_filter = [raw_loc, 'Community_Uploads', 'Incidental Places']
+            else:
+                loc_filter = None
 
         scope = f" (Location: {loc_filter})" if loc_filter else " (all locations)"
         print(f"🔍 Searching {filename} (VRAM Cached Mode, {photo_type}){scope}...")


### PR DESCRIPTION
## Summary

Second stage of the staff-management overhaul (stacked series 2/4 — **based on `feat/staff-groups-auth` (#263)**, retargets to `main` once #263 merges). Inert for existing users: Operations and Primary are global-scope, so every filter and gate is a no-op for them and their behavior is byte-for-byte identical to before. Enforcement only bites once an admin creates a scoped group.

- **Fresh-account authorization**: staff/admin routes now decide access from the auth service's live `/auth/validate` response (role + group areas) instead of the JWT's claims. Promotions, group moves, and area edits take effect on the user's **next request — no re-login** — while demotions still revoke immediately.
- **`backend/scope.py`**: pure prefix-based helpers — `scope_allows_location` (write gate), `scope_allows_sheet` (list gate), `effective_match_filter`, `annotate_in_scope`, `resolve_turtle_location`.
- **Scoped matching**: a scoped group's areas pass as a list filter (`search_for_matches` extended to accept lists); empty/`All Locations`/out-of-scope requests are forced to the owned areas; the existing <5-results expand-to-all fallback is kept but every out-of-scope candidate comes back flagged (`in_scope` per candidate, `scope_expanded` on the response) for stage 4's read-only match page. No writes are possible on flagged candidates.
- **Write guards (fail closed)**: approve/classify/cross-check/review-image ops/delete/clear-flag, sheets create/update/mark-deceased/generate-ID, and every turtle mutation (merge requires **both** turtles in scope) return 403 when the resolved target falls outside the group's areas.
- **List filters**: locations, sheet tabs, turtle list, turtle names, review queue (a no-location community packet is visible to global members only), and the flags page return the in-scope subset.
- **Tightening**: General-Location catalog *mutations* are admin-only (staff keep read-only catalog access for the turtle form); creating a new Sheets tab is restricted to global members (Primary staff keep it; scoped groups can't).

### Review

A pre-merge adversarial review caught and fixed a **critical scope-bypass**: the `approve_review` gate originally authorized `new_location` first, but the manager writes onto `match_turtle_id`'s folder first — so an in-scope `new_location` decoy could unlock an out-of-scope matched-turtle write. The gate now mirrors the manager's precedence (match first), with a regression test. It also corrected an over-tightening that would have removed inline sheet-creation from global Primary staff.

Verified: full backend unit suite **341 passing** (252 baseline + 89 new/scope), Flask app imports clean, auth-backend build untouched.

Closes #264