### PR TITLE
Admin group management + Team Lead UI (3/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.2] - 2026-07-21 — Staff group management UI
+
 ### Added
 
 - **Group management UI (admin)**: a new **Groups** admin page (`/admin/groups`) lists every group with its scope (global/scoped), live member count, and a tag for the seeded Operations/Primary system groups. Admins can create Sub-Area groups, rename them, flip a group's scope (Primary and Sub-Areas can change; Operations stays global), assign each scoped group one or more areas (a `State` folder or a `State/Location` prefix) from the backend location list, and delete an empty Sub-Area group — deletion is blocked with a "reassign first" message while the group still has members, and system groups can never be deleted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Group management UI (admin)**: a new **Groups** admin page (`/admin/groups`) lists every group with its scope (global/scoped), live member count, and a tag for the seeded Operations/Primary system groups. Admins can create Sub-Area groups, rename them, flip a group's scope (Primary and Sub-Areas can change; Operations stays global), assign each scoped group one or more areas (a `State` folder or a `State/Location` prefix) from the backend location list, and delete an empty Sub-Area group — deletion is blocked with a "reassign first" message while the group still has members, and system groups can never be deleted.
+- **Group membership on the User Management page**: every user row now shows its group (or "Unassigned") plus a **Lead** chip for Team Leads, and a one-step **Move to group** control (with a Member/Lead rank picker where applicable) reassigns a user between any two groups in a single action. A dedicated **Unassigned users** section makes stray accounts easy to spot.
+- **My Team page for Team Leads (`/admin/my-team`)**: a staff Team Lead can view their own group (name, scope, assigned areas) and its members, claim an unassigned community user by email, walk a member up or down the ladder (community ↔ staff ↔ lead), and release a member back to Unassigned — all scoped to their own group. Admins who are not leads of a specific group get an explanatory pointer to the Groups / User Management pages instead. A distinct **Team Lead** badge appears in the header next to the role badge, and "Groups" (admins) / "My Team" (leads + admins) are added to the navigation.
+
+### Changed
+
+- **The "+ Create New Sheet" option is hidden for scoped-group members**: creating a new Google Sheets tab defines a brand-new area, which the backend already refuses to scoped Sub-Area staff, so the affordance no longer appears for them in the turtle data form. Global staff and admins keep it exactly as before.
+
 ## [2.1.1] - 2026-07-20 — Scoped-group enforcement (backend)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -242,6 +242,29 @@ You need to run **all three services** simultaneously:
    - The modal polls the backend's health endpoint every 5 seconds and dismisses itself the moment the server is back up *and* the expected duration has elapsed. After 10 minutes of stalled maintenance it surfaces a contact-admin hint.
    - Schedule and duration are configurable via the backend env vars `BACKUP_SCHEDULE_HOUR`, `BACKUP_SCHEDULE_MINUTE`, and `BACKUP_DURATION_SECONDS`. Window times come from the new `GET /api/backup/window` endpoint, so the server is the source of truth — client clock drift cannot skew the countdown.
 
+### Staff Groups & Team Leads
+
+Staff are organized into **groups**. Two system groups are seeded — **Operations** (holds admins) and **Primary** (global staff) — both *global*, so their members see and act everywhere. Admins can also create **Sub-Area** groups that are *scoped* to one or more areas (a `State` folder or a `State/Location` path); a scoped group's members only see and act within those areas (enforced by the backend). A **Team Lead** is a staff member who leads one group.
+
+1. **Group Management** (`/admin/groups`, admin only):
+
+   - Lists every group with its scope (global/scoped), live member count, and a tag for the seeded system groups.
+   - Create, rename, and delete admin-made Sub-Area groups; deletion is blocked with a "reassign first" prompt while a group still has members, and system groups can never be deleted.
+   - Flip a group's scope (Primary and Sub-Areas can change; Operations always stays global) and assign each scoped group its areas from the backend location list.
+
+2. **Group membership on User Management** (`/admin/users`, admin only):
+
+   - Every user row shows its group (or "Unassigned") and a **Lead** chip for Team Leads.
+   - A one-step **Move to group** control reassigns a user between any two groups (with a Member/Lead rank picker where applicable); a dedicated **Unassigned users** section surfaces stray accounts.
+
+3. **My Team** (`/admin/my-team`, Team Leads and admins):
+
+   - A Team Lead manages only their own group: claim an unassigned community user by email, promote/demote a member one rung along the ladder (community ↔ staff ↔ lead), and release a member back to Unassigned.
+   - Admins who are not leads of a specific group get a pointer to the Groups / User Management pages instead.
+   - A distinct **Team Lead** badge shows in the header, and "Groups" / "My Team" appear in the navigation for the appropriate roles.
+
+Scoped Sub-Area staff cannot create new Google Sheets tabs (a new tab defines a new area), so the "+ Create New Sheet" option is hidden for them; global staff and admins keep it.
+
 ### Community Users
 
 1. **Photo Upload**:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,9 @@ import AdminTurtleRecordsPage from './pages/AdminTurtleRecordsPage';
 import AdminTurtleMatchPage from './pages/AdminTurtleMatchPage';
 import AdminReleasePage from './pages/AdminReleasePage';
 import AdminUserManagementPage from './pages/AdminUserManagementPage';
+import AdminGroupManagementPage from './pages/AdminGroupManagementPage';
 import AdminLocationManagementPage from './pages/AdminLocationManagementPage';
+import TeamLeadManagementPage from './pages/TeamLeadManagementPage';
 import VerifyEmailPage from './pages/VerifyEmailPage';
 import EmailVerificationGuard from './components/EmailVerificationGuard';
 import { store } from './store';
@@ -62,6 +64,8 @@ function App(): React.JSX.Element {
                 />
                 <Route path='/admin/release' element={<AdminReleasePage />} />
                 <Route path='/admin/users' element={<AdminUserManagementPage />} />
+                <Route path='/admin/groups' element={<AdminGroupManagementPage />} />
+                <Route path='/admin/my-team' element={<TeamLeadManagementPage />} />
                 <Route path='/admin/locations' element={<AdminLocationManagementPage />} />
               </Routes>
               </EmailVerificationGuard>

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -25,13 +25,15 @@ import {
   IconShield,
   IconPhoto,
   IconUsers,
+  IconUsersGroup,
   IconFlag,
   IconCompass,
   IconMapPin,
+  IconCrown,
 } from '@tabler/icons-react';
 import { useUser } from '../hooks/useUser';
 import { logout as apiLogout } from '../services/api';
-import { isStaffRole } from '../services/api/auth';
+import { isStaffRole, isTeamLead } from '../services/api/auth';
 import { notifications } from '@mantine/notifications';
 
 interface NavigationProps {
@@ -59,6 +61,9 @@ export default function Navigation({ children }: NavigationProps) {
 
   const isStaff = isStaffRole(role);
   const isAdmin = role === 'admin';
+  const isTeamLeadUser = isTeamLead(user);
+  // "My Team" is for staff Team Leads (their own group) and admins (empty-state → admin pages).
+  const showMyTeam = isTeamLeadUser || isAdmin;
   // Theme/UI color per role: community=blue, staff=orange, admin=red
   const roleColor = role === 'admin' ? 'red' : role === 'staff' ? 'orange' : 'blue';
   const roleColorHex =
@@ -90,11 +95,23 @@ export default function Navigation({ children }: NavigationProps) {
           icon: IconUsers,
         });
         items.splice(5, 0, {
+          label: 'Groups',
+          path: '/admin/groups',
+          icon: IconUsersGroup,
+        });
+        items.splice(6, 0, {
           label: 'Locations',
           path: '/admin/locations',
           icon: IconMapPin,
         });
       }
+    }
+    if (showMyTeam) {
+      items.push({
+        label: 'My Team',
+        path: '/admin/my-team',
+        icon: IconUsersGroup,
+      });
     }
     return items;
   };
@@ -105,8 +122,10 @@ export default function Navigation({ children }: NavigationProps) {
   const dynamicBreakpoint = useMemo(() => {
     const baseBreakpoint = 1000; // Base breakpoint for customer view with normal name
 
-    // Home + Observer HQ (+ staff/admin ops); About/Contact are in the footer
-    const itemCount = isAdmin ? 6 : isStaff ? 4 : 2;
+    // Home + Observer HQ (+ staff/admin ops + My Team); About/Contact are in the footer.
+    // admin: Home, Observer, Turtle Records, Release, User Management, Groups, Locations, My Team = 8
+    // staff lead: Home, Observer, Turtle Records, Release, My Team = 5; staff: 4; community: 2
+    const itemCount = isAdmin ? 8 : isStaff ? (isTeamLeadUser ? 5 : 4) : 2;
 
     // Admin has 2 extra items, increase breakpoint by ~167px per extra item
     // This makes drawer appear earlier when there are more nav items
@@ -122,7 +141,7 @@ export default function Navigation({ children }: NavigationProps) {
 
     // Calculate final breakpoint (higher = drawer appears at larger screen width)
     return baseBreakpoint + itemAdjustment + userNameAdjustment;
-  }, [isStaff, isAdmin, user?.name, user?.email]);
+  }, [isStaff, isAdmin, isTeamLeadUser, user?.name, user?.email]);
 
   // Use dynamic breakpoint; on mobile (< 768px) always show drawer for best touch UX
   const isMobile = useMediaQuery('(max-width: 767px)');
@@ -225,6 +244,17 @@ export default function Navigation({ children }: NavigationProps) {
             >
               {role === 'admin' ? 'Admin' : role === 'staff' ? 'Staff' : 'Community'}
             </Badge>
+            {isTeamLeadUser && (
+              <Badge
+                data-testid='team-lead-badge'
+                color='grape'
+                leftSection={<IconCrown size={12} />}
+                size='sm'
+                style={{ flexShrink: 0 }}
+              >
+                Team Lead
+              </Badge>
+            )}
           </Group>
 
           {/* Center - Desktop Navigation */}

--- a/frontend/src/components/TurtleSheetsDataForm.tsx
+++ b/frontend/src/components/TurtleSheetsDataForm.tsx
@@ -15,6 +15,8 @@ import {
 } from '@mantine/core';
 import { useImperativeHandle, forwardRef } from 'react';
 import { IconInfoCircle, IconSkull } from '@tabler/icons-react';
+import { useUser } from '../hooks/useUser';
+import { isGlobalScope } from '../services/api/auth';
 import { useTurtleSheetsDataForm } from '../hooks/useTurtleSheetsDataForm';
 import type { UseTurtleSheetsDataFormReturn } from './TurtleSheetsDataForm.types';
 import {
@@ -58,6 +60,11 @@ export const TurtleSheetsDataForm = forwardRef<
   },
   ref,
 ) {
+  // Only global staff/admins may create brand-new sheets (a new sheet defines a new area).
+  // PR-2's POST /api/sheets/sheets 403s scoped-group members, so hide the affordance for them.
+  const { user } = useUser();
+  const canCreateNewSheet = isGlobalScope(user);
+
   const hook: UseTurtleSheetsDataFormReturn = useTurtleSheetsDataForm({
     initialData,
     sheetName: initialSheetName,
@@ -157,7 +164,7 @@ export const TurtleSheetsDataForm = forwardRef<
                 setSelectedSheetName={hook.setSelectedSheetName}
                 availableSheets={hook.availableSheets}
                 setShowCreateSheetModal={hook.setShowCreateSheetModal}
-                allowCreateNewSheet
+                allowCreateNewSheet={canCreateNewSheet}
               />
               {requireNewSheetForCommunityMatch && (
                 <Text size="xs" c="dimmed" mt={4}>

--- a/frontend/src/pages/AdminGroupManagementPage.tsx
+++ b/frontend/src/pages/AdminGroupManagementPage.tsx
@@ -1,0 +1,466 @@
+import {
+  Container,
+  Title,
+  Text,
+  Stack,
+  Paper,
+  TextInput,
+  Button,
+  Loader,
+  Center,
+  Select,
+  MultiSelect,
+  Table,
+  Badge,
+  Group,
+  Tooltip,
+  Modal,
+  ActionIcon,
+} from '@mantine/core';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import {
+  IconUsersGroup,
+  IconAlertCircle,
+  IconCheck,
+  IconPlus,
+  IconTrash,
+  IconLock,
+  IconPencil,
+  IconMapPin,
+  IconDeviceFloppy,
+} from '@tabler/icons-react';
+import { useUser } from '../hooks/useUser';
+import { useNavigate } from 'react-router-dom';
+import { notifications } from '@mantine/notifications';
+import { getGroups, createGroup, updateGroup, deleteGroup, setGroupAreas } from '../services/api';
+import { getLocations } from '../services/api/sheets';
+import type { Group as GroupType } from '../services/api';
+import type { GroupScope } from '../types/User';
+
+const SCOPE_OPTIONS: { value: GroupScope; label: string }[] = [
+  { value: 'global', label: 'Global' },
+  { value: 'scoped', label: 'Scoped' },
+];
+
+/** Friendly label for a system group; Sub-Areas (system_key null) have no system tag. */
+function systemLabel(systemKey: string | null): string | null {
+  if (systemKey === 'operations') return 'Operations';
+  if (systemKey === 'primary') return 'Primary';
+  return null;
+}
+
+const notifyError = (message: string) =>
+  notifications.show({ title: 'Error', message, color: 'red', icon: <IconAlertCircle size={18} /> });
+
+const notifySuccess = (title: string, message: string) =>
+  notifications.show({ title, message, color: 'green', icon: <IconCheck size={18} /> });
+
+export default function AdminGroupManagementPage() {
+  const { role, authChecked } = useUser();
+  const navigate = useNavigate();
+
+  const [groups, setGroups] = useState<GroupType[]>([]);
+  const [groupsLoading, setGroupsLoading] = useState(true);
+  const [locations, setLocations] = useState<string[]>([]);
+
+  const [newGroupName, setNewGroupName] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const [scopeUpdatingId, setScopeUpdatingId] = useState<number | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  // Rename modal
+  const [renameTarget, setRenameTarget] = useState<GroupType | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [renaming, setRenaming] = useState(false);
+
+  // Per-group staged area edits + save state
+  const [areaEdits, setAreaEdits] = useState<Record<number, string[]>>({});
+  const [savingAreasId, setSavingAreasId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!authChecked) return;
+    if (role !== 'admin') navigate('/');
+  }, [authChecked, role, navigate]);
+
+  const loadGroups = useCallback(() => {
+    setGroupsLoading(true);
+    getGroups()
+      .then((res) => {
+        if (res.success && res.groups) {
+          setGroups(res.groups);
+          setAreaEdits({});
+        }
+      })
+      .catch((err: Error) => notifyError(err.message))
+      .finally(() => setGroupsLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (role !== 'admin') return;
+    loadGroups();
+    getLocations()
+      .then((res) => {
+        if (res.success && res.locations) setLocations(res.locations);
+      })
+      .catch(() => setLocations([]));
+  }, [role, loadGroups]);
+
+  // Options for the area MultiSelect: the full backend location list plus any already-assigned
+  // area (so an existing value set via the API always renders as a removable pill).
+  const locationOptions = useMemo(() => {
+    const set = new Set<string>(locations);
+    groups.forEach((g) => g.areas.forEach((a) => set.add(a)));
+    return Array.from(set)
+      .sort((a, b) => a.localeCompare(b))
+      .map((v) => ({ value: v, label: v }));
+  }, [locations, groups]);
+
+  if (!authChecked) {
+    return (
+      <Center py='xl'>
+        <Loader size='lg' />
+      </Center>
+    );
+  }
+  if (role !== 'admin') return null;
+
+  const handleCreate = async () => {
+    const name = newGroupName.trim();
+    if (!name) return;
+    setCreating(true);
+    try {
+      await createGroup(name, 'scoped');
+      notifySuccess('Group created', `Sub-Area group "${name}" created.`);
+      setNewGroupName('');
+      loadGroups();
+    } catch (err) {
+      notifyError(err instanceof Error ? err.message : 'Failed to create group');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleScopeChange = async (g: GroupType, scope: GroupScope) => {
+    if (scope === g.scope) return;
+    setScopeUpdatingId(g.id);
+    try {
+      await updateGroup(g.id, { scope });
+      notifySuccess('Scope updated', `"${g.name}" is now ${scope}.`);
+      loadGroups();
+    } catch (err) {
+      notifyError(err instanceof Error ? err.message : 'Failed to update scope');
+    } finally {
+      setScopeUpdatingId(null);
+    }
+  };
+
+  const handleRename = async () => {
+    if (!renameTarget) return;
+    const name = renameValue.trim();
+    if (!name || name === renameTarget.name) {
+      setRenameTarget(null);
+      return;
+    }
+    setRenaming(true);
+    try {
+      await updateGroup(renameTarget.id, { name });
+      notifySuccess('Group renamed', `Renamed to "${name}".`);
+      setRenameTarget(null);
+      loadGroups();
+    } catch (err) {
+      notifyError(err instanceof Error ? err.message : 'Failed to rename group');
+    } finally {
+      setRenaming(false);
+    }
+  };
+
+  const handleDelete = async (g: GroupType) => {
+    if (!window.confirm(`Delete group "${g.name}"? This cannot be undone.`)) return;
+    setDeletingId(g.id);
+    try {
+      await deleteGroup(g.id);
+      notifySuccess('Group deleted', `"${g.name}" was removed.`);
+      loadGroups();
+    } catch (err) {
+      // ApiError for a non-empty group carries "N members — reassign first".
+      notifyError(err instanceof Error ? err.message : 'Failed to delete group');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleSaveAreas = async (g: GroupType) => {
+    const next = areaEdits[g.id] ?? g.areas;
+    setSavingAreasId(g.id);
+    try {
+      const res = await setGroupAreas(g.id, next);
+      setGroups((prev) => prev.map((row) => (row.id === g.id ? { ...row, areas: res.areas } : row)));
+      setAreaEdits((prev) => {
+        const copy = { ...prev };
+        delete copy[g.id];
+        return copy;
+      });
+      notifySuccess('Areas saved', `"${g.name}" now covers ${res.areas.length} area(s).`);
+    } catch (err) {
+      notifyError(err instanceof Error ? err.message : 'Failed to save areas');
+    } finally {
+      setSavingAreasId(null);
+    }
+  };
+
+  const scopedGroups = groups.filter((g) => g.scope === 'scoped');
+
+  return (
+    <Container size='lg' py={{ base: 'md', sm: 'xl' }} px={{ base: 'xs', sm: 'md' }}>
+      <Stack gap='lg'>
+        <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
+          <Stack gap='lg'>
+            <div>
+              <Group gap='xs'>
+                <IconUsersGroup size={26} />
+                <Title order={1}>Group Management</Title>
+              </Group>
+              <Text size='sm' c='dimmed' mt='xs'>
+                Groups organize staff. <strong>Operations</strong> (admins) and <strong>Primary</strong>{' '}
+                (global staff) are global — they see everything. Admin-created <strong>Sub-Area</strong>{' '}
+                groups are scoped: their members only see and act within the areas assigned below.
+              </Text>
+            </div>
+
+            <Group align='flex-end' gap='sm' wrap='nowrap'>
+              <TextInput
+                label='Create a Sub-Area group'
+                placeholder='e.g. Kansas Field Team'
+                value={newGroupName}
+                onChange={(e) => setNewGroupName(e.currentTarget.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreate();
+                }}
+                style={{ flex: 1 }}
+                disabled={creating}
+              />
+              <Button
+                leftSection={<IconPlus size={16} />}
+                onClick={handleCreate}
+                loading={creating}
+                disabled={!newGroupName.trim()}
+              >
+                Create
+              </Button>
+            </Group>
+          </Stack>
+        </Paper>
+
+        <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
+          <Title order={2} size='h3'>
+            <Group gap='xs'>
+              <IconUsersGroup size={20} />
+              All groups
+            </Group>
+          </Title>
+          {groupsLoading ? (
+            <Center py='xl'>
+              <Loader size='lg' />
+            </Center>
+          ) : (
+            <Table.ScrollContainer minWidth={640} mt='md'>
+              <Table striped highlightOnHover verticalSpacing='sm'>
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>Name</Table.Th>
+                    <Table.Th style={{ width: 170 }}>Scope</Table.Th>
+                    <Table.Th style={{ width: 100 }}>Members</Table.Th>
+                    <Table.Th style={{ width: 170 }}> </Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {groups.map((g) => {
+                    const sysLabel = systemLabel(g.system_key);
+                    const isOperations = g.system_key === 'operations';
+                    const isSystem = g.system_key !== null;
+                    return (
+                      <Table.Tr key={g.id}>
+                        <Table.Td>
+                          <Group gap='xs' wrap='nowrap'>
+                            <Text fw={500}>{g.name}</Text>
+                            {sysLabel && (
+                              <Badge size='xs' variant='light' color='grape'>
+                                {sysLabel}
+                              </Badge>
+                            )}
+                          </Group>
+                        </Table.Td>
+                        <Table.Td>
+                          {isOperations ? (
+                            <Tooltip label='Operations must stay global' withArrow>
+                              <Badge
+                                color='teal'
+                                variant='light'
+                                leftSection={<IconLock size={11} />}
+                              >
+                                Global
+                              </Badge>
+                            </Tooltip>
+                          ) : (
+                            <Select
+                              size='xs'
+                              w={130}
+                              data={SCOPE_OPTIONS}
+                              value={g.scope}
+                              allowDeselect={false}
+                              disabled={scopeUpdatingId === g.id}
+                              onChange={(v) => v && handleScopeChange(g, v as GroupScope)}
+                            />
+                          )}
+                        </Table.Td>
+                        <Table.Td>
+                          <Badge variant='light' color='blue' data-testid={`group-members-${g.name}`}>
+                            {g.member_count}
+                          </Badge>
+                        </Table.Td>
+                        <Table.Td>
+                          <Group gap={4} wrap='nowrap' justify='flex-end'>
+                            <Tooltip label='Rename' withArrow>
+                              <ActionIcon
+                                variant='subtle'
+                                color='gray'
+                                aria-label={`Rename ${g.name}`}
+                                onClick={() => {
+                                  setRenameTarget(g);
+                                  setRenameValue(g.name);
+                                }}
+                              >
+                                <IconPencil size={16} />
+                              </ActionIcon>
+                            </Tooltip>
+                            {isSystem ? (
+                              <Tooltip label='System groups cannot be deleted' withArrow>
+                                <span style={{ display: 'inline-flex' }}>
+                                  <ActionIcon variant='subtle' color='red' disabled aria-label='Delete (disabled)'>
+                                    <IconTrash size={16} />
+                                  </ActionIcon>
+                                </span>
+                              </Tooltip>
+                            ) : (
+                              <Tooltip label='Delete group' withArrow>
+                                <ActionIcon
+                                  variant='subtle'
+                                  color='red'
+                                  aria-label={`Delete ${g.name}`}
+                                  loading={deletingId === g.id}
+                                  onClick={() => handleDelete(g)}
+                                >
+                                  <IconTrash size={16} />
+                                </ActionIcon>
+                              </Tooltip>
+                            )}
+                          </Group>
+                        </Table.Td>
+                      </Table.Tr>
+                    );
+                  })}
+                </Table.Tbody>
+              </Table>
+            </Table.ScrollContainer>
+          )}
+        </Paper>
+
+        <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
+          <Title order={2} size='h3'>
+            <Group gap='xs'>
+              <IconMapPin size={20} />
+              Area assignments
+            </Group>
+          </Title>
+          <Text size='sm' c='dimmed' mt='xs' mb='md'>
+            Assign one or more areas (a State folder or a State/Location path) to each Sub-Area group.
+            Members are limited to these areas. Operations and Primary are global, so areas do not
+            apply to them.
+          </Text>
+          {groupsLoading ? (
+            <Center py='md'>
+              <Loader />
+            </Center>
+          ) : scopedGroups.length === 0 ? (
+            <Text size='sm' c='dimmed'>
+              No scoped groups yet. Create a Sub-Area group above (or flip Primary to scoped) to assign
+              areas.
+            </Text>
+          ) : (
+            <Stack gap='md'>
+              {scopedGroups.map((g) => {
+                const current = areaEdits[g.id] ?? g.areas;
+                const dirty = g.id in areaEdits;
+                return (
+                  <Paper key={g.id} withBorder radius='md' p='md' data-testid={`area-card-${g.name}`}>
+                    <Stack gap='sm'>
+                      <Group justify='space-between' gap='sm'>
+                        <Text fw={600} size='sm'>
+                          {g.name}
+                        </Text>
+                        <Button
+                          size='xs'
+                          leftSection={<IconDeviceFloppy size={14} />}
+                          loading={savingAreasId === g.id}
+                          disabled={!dirty}
+                          onClick={() => handleSaveAreas(g)}
+                        >
+                          Save areas
+                        </Button>
+                      </Group>
+                      <MultiSelect
+                        data={locationOptions}
+                        value={current}
+                        onChange={(vals) =>
+                          setAreaEdits((prev) => ({ ...prev, [g.id]: vals }))
+                        }
+                        placeholder={current.length === 0 ? 'No areas — select State/Location paths' : undefined}
+                        searchable
+                        clearable
+                        nothingFoundMessage='No matching locations'
+                        comboboxProps={{ withinPortal: true }}
+                      />
+                    </Stack>
+                  </Paper>
+                );
+              })}
+            </Stack>
+          )}
+        </Paper>
+      </Stack>
+
+      <Modal
+        opened={renameTarget !== null}
+        onClose={() => !renaming && setRenameTarget(null)}
+        title='Rename group'
+        centered
+        size='sm'
+      >
+        <Stack gap='md'>
+          <TextInput
+            label='Group name'
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleRename();
+            }}
+            autoFocus
+          />
+          <Group justify='flex-end' gap='sm'>
+            <Button variant='subtle' color='gray' onClick={() => setRenameTarget(null)} disabled={renaming}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleRename}
+              loading={renaming}
+              disabled={!renameValue.trim() || renameValue.trim() === renameTarget?.name}
+            >
+              Save
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Container>
+  );
+}

--- a/frontend/src/pages/AdminUserManagementPage.tsx
+++ b/frontend/src/pages/AdminUserManagementPage.tsx
@@ -14,7 +14,7 @@ import {
   Badge,
   Group,
 } from '@mantine/core';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   IconMail,
   IconShield,
@@ -22,11 +22,20 @@ import {
   IconCheck,
   IconUsers,
   IconTrash,
+  IconUserQuestion,
 } from '@tabler/icons-react';
 import { useUser } from '../hooks/useUser';
 import { useNavigate } from 'react-router-dom';
-import { promoteToAdmin, getUsers, setUserRole, deleteUser } from '../services/api';
-import type { UserRole } from '../services/api';
+import {
+  promoteToAdmin,
+  getUsers,
+  setUserRole,
+  deleteUser,
+  getGroups,
+  setUserMembership,
+} from '../services/api';
+import type { UserRole, AdminUserRow, Group as GroupType } from '../services/api';
+import type { GroupRole } from '../types/User';
 import { notifications } from '@mantine/notifications';
 
 const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
@@ -34,6 +43,13 @@ const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
   { value: 'staff', label: 'Staff' },
   { value: 'admin', label: 'Admin' },
 ];
+
+const RANK_OPTIONS: { value: GroupRole; label: string }[] = [
+  { value: 'member', label: 'Member' },
+  { value: 'lead', label: 'Lead' },
+];
+
+const UNASSIGNED_VALUE = 'none';
 
 /** Display order: admin first, then staff, then community */
 const ROLE_ORDER: UserRole[] = ['admin', 'staff', 'community'];
@@ -50,7 +66,71 @@ const ROLE_BADGE_COLOR: Record<UserRole, string> = {
   community: 'blue',
 };
 
-type UserRow = { id: number; email: string; name: string | null; role: UserRole; created_at: string };
+const notifyError = (message: string) =>
+  notifications.show({ title: 'Error', message, color: 'red', icon: <IconAlertCircle size={18} /> });
+
+const notifySuccess = (title: string, message: string) =>
+  notifications.show({ title, message, color: 'green', icon: <IconCheck size={18} /> });
+
+/**
+ * Group + rank controls for one user row. The Group select is the one-step "move to any group"
+ * path; the Rank select appears only when the user is in a group and can hold a lead (staff/admin).
+ */
+function MembershipControls({
+  user,
+  groups,
+  busy,
+  isSelf,
+  onMove,
+  onRank,
+}: {
+  user: AdminUserRow;
+  groups: GroupType[];
+  busy: boolean;
+  isSelf: boolean;
+  onMove: (u: AdminUserRow, groupId: number | null) => void;
+  onRank: (u: AdminUserRow, rank: GroupRole) => void;
+}) {
+  const inGroup = user.group_id != null;
+  const canLead = user.role === 'staff' || user.role === 'admin';
+  const groupOptions = [
+    { value: UNASSIGNED_VALUE, label: 'Unassigned' },
+    ...groups.map((g) => ({ value: String(g.id), label: g.name })),
+  ];
+  // Editing your own membership can revoke your own token (demoting yourself out
+  // of lead, or releasing yourself to Unassigned bumps tokens_valid_after), which
+  // would 403 every subsequent request and wedge the session. Another admin must
+  // make the change — mirrors the self-guard on the Delete button.
+  const selfTitle = isSelf ? 'Ask another admin to change your own group or rank' : undefined;
+  return (
+    <Stack gap={6}>
+      <Select
+        size='xs'
+        w={150}
+        data={groupOptions}
+        value={user.group_id == null ? UNASSIGNED_VALUE : String(user.group_id)}
+        allowDeselect={false}
+        disabled={busy || isSelf}
+        title={selfTitle}
+        onChange={(v) => v && onMove(user, v === UNASSIGNED_VALUE ? null : Number(v))}
+        aria-label={`Move ${user.email} to a group`}
+      />
+      {inGroup && canLead && (
+        <Select
+          size='xs'
+          w={150}
+          data={RANK_OPTIONS}
+          value={user.group_role === 'lead' ? 'lead' : 'member'}
+          allowDeselect={false}
+          disabled={busy || isSelf}
+          title={selfTitle}
+          onChange={(v) => v && onRank(user, v as GroupRole)}
+          aria-label={`Set ${user.email} rank`}
+        />
+      )}
+    </Stack>
+  );
+}
 
 export default function AdminUserManagementPage() {
   const { role, authChecked, user: currentUser } = useUser();
@@ -58,9 +138,11 @@ export default function AdminUserManagementPage() {
   const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [users, setUsers] = useState<UserRow[]>([]);
+  const [users, setUsers] = useState<AdminUserRow[]>([]);
   const [usersLoading, setUsersLoading] = useState(true);
+  const [groups, setGroups] = useState<GroupType[]>([]);
   const [updatingRoleId, setUpdatingRoleId] = useState<number | null>(null);
+  const [membershipBusyId, setMembershipBusyId] = useState<number | null>(null);
   const [deletingUserId, setDeletingUserId] = useState<number | null>(null);
 
   useEffect(() => {
@@ -70,19 +152,31 @@ export default function AdminUserManagementPage() {
     }
   }, [authChecked, role, navigate]);
 
-  useEffect(() => {
-    if (role !== 'admin') return;
-    setUsersLoading(true);
-    getUsers()
+  const refetchUsers = useCallback(() => {
+    // On a refetch error (e.g. this admin's token was just revoked by a concurrent
+    // change), keep the last-known list rather than blanking every table — a wiped
+    // page with a success toast reads as data loss. AuthProvider handles a genuinely
+    // invalid token on the next mount; a real load failure surfaces via notifyError.
+    return getUsers()
       .then((res) => {
         if (res.success && res.users) setUsers(res.users);
       })
-      .catch(() => setUsers([]))
-      .finally(() => setUsersLoading(false));
-  }, [role]);
+      .catch((err) => {
+        notifyError(err instanceof Error ? err.message : 'Could not refresh the user list');
+      });
+  }, []);
+
+  useEffect(() => {
+    if (role !== 'admin') return;
+    setUsersLoading(true);
+    refetchUsers().finally(() => setUsersLoading(false));
+    getGroups()
+      .then((res) => res.success && res.groups && setGroups(res.groups))
+      .catch(() => setGroups([]));
+  }, [role, refetchUsers]);
 
   const usersByRole = useMemo(() => {
-    const map: Record<UserRole, UserRow[]> = {
+    const map: Record<UserRole, AdminUserRow[]> = {
       admin: [],
       staff: [],
       community: [],
@@ -90,6 +184,8 @@ export default function AdminUserManagementPage() {
     users.forEach((u) => map[u.role].push(u));
     return ROLE_ORDER.map((r) => ({ role: r, list: map[r] }));
   }, [users]);
+
+  const unassignedUsers = useMemo(() => users.filter((u) => u.group_id == null), [users]);
 
   if (!authChecked) {
     return (
@@ -109,24 +205,14 @@ export default function AdminUserManagementPage() {
 
     try {
       const result = await promoteToAdmin(email);
-      notifications.show({
-        title: 'Success!',
-        message: result.message,
-        color: 'green',
-        icon: <IconCheck size={18} />,
-      });
+      notifySuccess('Success!', result.message);
       setEmail('');
-      getUsers().then((res) => res.success && res.users && setUsers(res.users));
+      refetchUsers();
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to promote user to admin';
       setError(errorMessage);
-      notifications.show({
-        title: 'Error',
-        message: errorMessage,
-        color: 'red',
-        icon: <IconAlertCircle size={18} />,
-      });
+      notifyError(errorMessage);
     } finally {
       setLoading(false);
     }
@@ -136,28 +222,46 @@ export default function AdminUserManagementPage() {
     setUpdatingRoleId(userId);
     try {
       await setUserRole(userId, newRole);
-      setUsers((prev) =>
-        prev.map((u) => (u.id === userId ? { ...u, role: newRole } : u)),
-      );
-      notifications.show({
-        title: 'Role updated',
-        message: `User role set to ${newRole}`,
-        color: 'green',
-        icon: <IconCheck size={18} />,
-      });
+      // Role changes can affect membership eligibility (e.g. lead requires staff), so refetch.
+      await refetchUsers();
+      notifySuccess('Role updated', `User role set to ${newRole}`);
     } catch (err) {
-      notifications.show({
-        title: 'Error',
-        message: err instanceof Error ? err.message : 'Failed to update role',
-        color: 'red',
-        icon: <IconAlertCircle size={18} />,
-      });
+      notifyError(err instanceof Error ? err.message : 'Failed to update role');
     } finally {
       setUpdatingRoleId(null);
     }
   };
 
-  const handleDeleteUser = async (u: UserRow) => {
+  const handleMove = async (u: AdminUserRow, groupId: number | null) => {
+    if ((u.group_id ?? null) === groupId) return;
+    setMembershipBusyId(u.id);
+    try {
+      await setUserMembership(u.id, { group_id: groupId });
+      const dest = groupId == null ? 'Unassigned' : groups.find((g) => g.id === groupId)?.name ?? 'group';
+      await refetchUsers();
+      notifySuccess('Membership updated', `${u.email} moved to ${dest}.`);
+    } catch (err) {
+      notifyError(err instanceof Error ? err.message : 'Failed to move user');
+    } finally {
+      setMembershipBusyId(null);
+    }
+  };
+
+  const handleRank = async (u: AdminUserRow, rank: GroupRole) => {
+    if ((u.group_role === 'lead' ? 'lead' : 'member') === rank) return;
+    setMembershipBusyId(u.id);
+    try {
+      await setUserMembership(u.id, { group_id: u.group_id, group_role: rank });
+      await refetchUsers();
+      notifySuccess('Rank updated', `${u.email} is now ${rank}.`);
+    } catch (err) {
+      notifyError(err instanceof Error ? err.message : 'Failed to change rank');
+    } finally {
+      setMembershipBusyId(null);
+    }
+  };
+
+  const handleDeleteUser = async (u: AdminUserRow) => {
     const ok = window.confirm(
       `Permanently delete account ${u.email}? They can register again with the same email.`,
     );
@@ -166,26 +270,29 @@ export default function AdminUserManagementPage() {
     try {
       await deleteUser(u.id);
       setUsers((prev) => prev.filter((row) => row.id !== u.id));
-      notifications.show({
-        title: 'User deleted',
-        message: `${u.email} was removed.`,
-        color: 'green',
-        icon: <IconCheck size={18} />,
-      });
+      notifySuccess('User deleted', `${u.email} was removed.`);
     } catch (err) {
-      notifications.show({
-        title: 'Could not delete user',
-        message: err instanceof Error ? err.message : 'Delete failed',
-        color: 'red',
-        icon: <IconAlertCircle size={18} />,
-      });
+      notifyError(err instanceof Error ? err.message : 'Delete failed');
     } finally {
       setDeletingUserId(null);
     }
   };
 
+  const renderGroupBadge = (u: AdminUserRow) => (
+    <Group gap={6} wrap='nowrap'>
+      <Badge variant='light' color={u.group_id == null ? 'gray' : 'grape'}>
+        {u.group_name ?? 'Unassigned'}
+      </Badge>
+      {u.group_role === 'lead' && (
+        <Badge size='xs' color='grape' variant='filled'>
+          Lead
+        </Badge>
+      )}
+    </Group>
+  );
+
   return (
-    <Container size='md' py={{ base: 'md', sm: 'xl' }} px={{ base: 'xs', sm: 'md' }}>
+    <Container size='lg' py={{ base: 'md', sm: 'xl' }} px={{ base: 'xs', sm: 'md' }}>
       <Stack gap='lg'>
         <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
           <Stack gap='lg'>
@@ -193,8 +300,8 @@ export default function AdminUserManagementPage() {
               <Title order={1}>User Management</Title>
               <Text size='sm' c='dimmed' mt='xs'>
                 Promote a user to admin by email (or invite new users). Only admins can
-                access this page and change user roles. Staff have the same app access as
-                admins but cannot manage users.
+                access this page and change user roles or group membership. Staff have the same
+                app access as admins but cannot manage users.
               </Text>
             </div>
 
@@ -245,6 +352,63 @@ export default function AdminUserManagementPage() {
           </Stack>
         </Paper>
 
+        {/* Unassigned strays — quick view of everyone with no group. */}
+        <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder data-testid='unassigned-users-section'>
+          <Title order={2} size='h3'>
+            <Group gap='xs'>
+              <IconUserQuestion size={20} />
+              Unassigned users ({unassignedUsers.length})
+            </Group>
+          </Title>
+          <Text size='sm' c='dimmed' mt='xs' mb='md'>
+            Users not in any group. New community members land here; a stray staff/admin without a
+            group is easy to spot and can be moved into one in a single step.
+          </Text>
+          {usersLoading ? (
+            <Center py='md'>
+              <Loader />
+            </Center>
+          ) : unassignedUsers.length === 0 ? (
+            <Text size='sm' c='dimmed'>
+              Everyone is assigned to a group.
+            </Text>
+          ) : (
+            <Table.ScrollContainer minWidth={620}>
+              <Table striped highlightOnHover verticalSpacing='sm'>
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>Email</Table.Th>
+                    <Table.Th style={{ width: 110 }}>Role</Table.Th>
+                    <Table.Th style={{ width: 190 }}>Move to group</Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {unassignedUsers.map((u) => (
+                    <Table.Tr key={u.id}>
+                      <Table.Td>{u.email}</Table.Td>
+                      <Table.Td>
+                        <Badge variant='light' color={ROLE_BADGE_COLOR[u.role]}>
+                          {ROLE_LABEL[u.role]}
+                        </Badge>
+                      </Table.Td>
+                      <Table.Td>
+                        <MembershipControls
+                          user={u}
+                          groups={groups}
+                          busy={membershipBusyId === u.id}
+                          isSelf={u.id === currentUser?.id}
+                          onMove={handleMove}
+                          onRank={handleRank}
+                        />
+                      </Table.Td>
+                    </Table.Tr>
+                  ))}
+                </Table.Tbody>
+              </Table>
+            </Table.ScrollContainer>
+          )}
+        </Paper>
+
         <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
           <Title order={2} size='h3'>
             <Group gap='xs'>
@@ -254,8 +418,9 @@ export default function AdminUserManagementPage() {
           </Title>
           <Text size='sm' c='dimmed' mt='xs' mb='md'>
             Change a user&apos;s role: Community (default), Staff (admin-like, no user
-            management), Admin (full access including this page). Delete removes the account so
-            the same email can register again (you cannot delete yourself or the last admin).
+            management), Admin (full access including this page). Use <strong>Group</strong> to move a
+            user into any group in one step and set their rank (Member / Lead). Delete removes the
+            account so the same email can register again (you cannot delete yourself or the last admin).
           </Text>
           {usersLoading ? (
             <Center py='xl'>
@@ -266,61 +431,68 @@ export default function AdminUserManagementPage() {
               {usersByRole.map(({ role: roleKey, list }) => (
                 <Stack key={roleKey} gap='xs'>
                   <Group gap='xs'>
-                    <Badge
-                      color={ROLE_BADGE_COLOR[roleKey]}
-                      size='lg'
-                      variant='light'
-                    >
+                    <Badge color={ROLE_BADGE_COLOR[roleKey]} size='lg' variant='light'>
                       {ROLE_LABEL[roleKey]} ({list.length})
                     </Badge>
                   </Group>
+                  {/* The per-role <Table> must stay a direct sibling of the badge <Group> above:
+                      staff-and-user-management.spec.ts selects it via
+                      //table[preceding-sibling::*[1][contains(.,'Staff (')]]. Don't wrap it. */}
                   {list.length === 0 ? (
                     <Text size='sm' c='dimmed'>
                       No users with this role.
                     </Text>
                   ) : (
-                    <Table striped highlightOnHover style={{ tableLayout: 'fixed' }}>
+                    <Table striped highlightOnHover verticalSpacing='sm'>
                       <Table.Thead>
                         <Table.Tr>
-                          <Table.Th style={{ width: '36%' }}>Email</Table.Th>
-                          <Table.Th style={{ width: '26%' }}>Name</Table.Th>
-                          <Table.Th style={{ width: 180 }}>Change role</Table.Th>
-                          <Table.Th style={{ width: 100 }}> </Table.Th>
+                          <Table.Th>Email</Table.Th>
+                          <Table.Th style={{ width: 150 }}>Name</Table.Th>
+                          <Table.Th style={{ width: 150 }}>Change role</Table.Th>
+                          <Table.Th style={{ width: 190 }}>Group</Table.Th>
+                          <Table.Th style={{ width: 90 }}> </Table.Th>
                         </Table.Tr>
                       </Table.Thead>
                       <Table.Tbody>
                         {list.map((u) => (
                           <Table.Tr key={u.id}>
-                            <Table.Td style={{ width: '40%' }}>{u.email}</Table.Td>
-                            <Table.Td style={{ width: '30%' }}>{u.name || '—'}</Table.Td>
-                            <Table.Td style={{ width: 180, verticalAlign: 'middle' }}>
+                            <Table.Td>{u.email}</Table.Td>
+                            <Table.Td>{u.name || '—'}</Table.Td>
+                            <Table.Td>
                               <Group gap='xs' wrap='nowrap' align='center'>
                                 <Select
                                   size='xs'
-                                  w={140}
+                                  w={130}
                                   data={ROLE_OPTIONS}
                                   value={u.role}
-                                  onChange={(v) =>
-                                    v && handleRoleChange(u.id, v as UserRole)
-                                  }
+                                  allowDeselect={false}
+                                  onChange={(v) => v && handleRoleChange(u.id, v as UserRole)}
                                   disabled={updatingRoleId === u.id}
                                 />
-                                {updatingRoleId === u.id && (
-                                  <Loader size='xs' />
-                                )}
+                                {updatingRoleId === u.id && <Loader size='xs' />}
                               </Group>
                             </Table.Td>
-                            <Table.Td style={{ width: 100, verticalAlign: 'middle' }}>
+                            <Table.Td>
+                              <Stack gap={6}>
+                                {renderGroupBadge(u)}
+                                <MembershipControls
+                                  user={u}
+                                  groups={groups}
+                                  busy={membershipBusyId === u.id}
+                                  isSelf={u.id === currentUser?.id}
+                                  onMove={handleMove}
+                                  onRank={handleRank}
+                                />
+                              </Stack>
+                            </Table.Td>
+                            <Table.Td>
                               <Button
                                 size='xs'
                                 variant='subtle'
                                 color='red'
                                 leftSection={<IconTrash size={14} />}
                                 loading={deletingUserId === u.id}
-                                disabled={
-                                  deletingUserId !== null ||
-                                  u.id === currentUser?.id
-                                }
+                                disabled={deletingUserId !== null || u.id === currentUser?.id}
                                 onClick={() => handleDeleteUser(u)}
                               >
                                 Delete

--- a/frontend/src/pages/AdminUserManagementPage.tsx
+++ b/frontend/src/pages/AdminUserManagementPage.tsx
@@ -409,7 +409,7 @@ export default function AdminUserManagementPage() {
           )}
         </Paper>
 
-        <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
+        <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder data-testid='users-by-role-section'>
           <Title order={2} size='h3'>
             <Group gap='xs'>
               <IconUsers size={20} />

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -196,13 +196,22 @@ export default function LoginPage({
       } else {
         // Login
         const response = await apiLogin({ email, password });
-        setUserLogin(response.user);
-        const needsVerification = !isEmailVerified(response.user);
+        // The login response is identity-only; enrich with group membership (used by the
+        // Groups / My Team nav + create-sheet gate) so it is present without a page reload.
+        let sessionUser = response.user;
+        try {
+          const fullUser = await getCurrentUser();
+          if (fullUser) sessionUser = fullUser;
+        } catch {
+          // Keep the identity-only user; group-aware UI populates on the next load.
+        }
+        setUserLogin(sessionUser);
+        const needsVerification = !isEmailVerified(sessionUser);
         notifications.show({
           title: 'Successfully logged in!',
           message: needsVerification
             ? 'Please verify your email to access all features.'
-            : `Welcome back, ${response.user.name || response.user.email}!`,
+            : `Welcome back, ${sessionUser.name || sessionUser.email}!`,
           color: 'green',
           icon: <IconCheck size={18} />,
         });

--- a/frontend/src/pages/TeamLeadManagementPage.tsx
+++ b/frontend/src/pages/TeamLeadManagementPage.tsx
@@ -1,0 +1,396 @@
+import {
+  Container,
+  Title,
+  Text,
+  Stack,
+  Paper,
+  TextInput,
+  Button,
+  Loader,
+  Center,
+  Table,
+  Badge,
+  Group,
+  Alert,
+  Tooltip,
+  ActionIcon,
+} from '@mantine/core';
+import { useState, useEffect, useCallback } from 'react';
+import {
+  IconUsersGroup,
+  IconAlertCircle,
+  IconCheck,
+  IconArrowUp,
+  IconArrowDown,
+  IconDoorExit,
+  IconUserPlus,
+  IconMapPin,
+  IconCrown,
+} from '@tabler/icons-react';
+import { useUser } from '../hooks/useUser';
+import { useNavigate } from 'react-router-dom';
+import { notifications } from '@mantine/notifications';
+import {
+  getMyGroup,
+  claimMember,
+  setMemberRank,
+  releaseMember,
+  isTeamLead,
+  isAdminRole,
+  ApiError,
+} from '../services/api';
+import type { GroupMember, MyGroupResponse } from '../services/api';
+import type { UserRole, GroupRole } from '../types/User';
+
+const ROLE_LABEL: Record<UserRole, string> = {
+  admin: 'Admin',
+  staff: 'Staff',
+  community: 'Community',
+};
+
+const ROLE_BADGE_COLOR: Record<UserRole, string> = {
+  admin: 'red',
+  staff: 'orange',
+  community: 'blue',
+};
+
+/** Ladder position: community(0) → staff member(1) → staff lead(2). Admin(3) is off the ladder. */
+function rankIndex(role: UserRole, groupRole: GroupRole): number {
+  if (role === 'community') return 0;
+  if (role === 'staff') return groupRole === 'lead' ? 2 : 1;
+  return 3;
+}
+
+const notifyError = (message: string) =>
+  notifications.show({ title: 'Error', message, color: 'red', icon: <IconAlertCircle size={18} /> });
+
+const notifySuccess = (title: string, message: string) =>
+  notifications.show({ title, message, color: 'green', icon: <IconCheck size={18} /> });
+
+export default function TeamLeadManagementPage() {
+  const { role, authChecked, user: currentUser } = useUser();
+  const navigate = useNavigate();
+
+  const allowed = isTeamLead(currentUser) || isAdminRole(role);
+
+  const [data, setData] = useState<MyGroupResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notALead, setNotALead] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [claimEmail, setClaimEmail] = useState('');
+  const [claiming, setClaiming] = useState(false);
+  const [actionBusyId, setActionBusyId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!authChecked) return;
+    if (!allowed) navigate('/');
+  }, [authChecked, allowed, navigate]);
+
+  const loadGroup = useCallback(() => {
+    setLoading(true);
+    setLoadError(null);
+    getMyGroup()
+      .then((res) => {
+        setData(res);
+        setNotALead(false);
+      })
+      .catch((err: unknown) => {
+        // Admins (and anyone not a staff lead) get 403 from /api/lead — show the empty state.
+        if (err instanceof ApiError && err.status === 403) {
+          setNotALead(true);
+          setData(null);
+        } else {
+          setLoadError(err instanceof Error ? err.message : 'Failed to load your group');
+        }
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (!authChecked || !allowed) return;
+    loadGroup();
+  }, [authChecked, allowed, loadGroup]);
+
+  if (!authChecked) {
+    return (
+      <Center py='xl'>
+        <Loader size='lg' />
+      </Center>
+    );
+  }
+  if (!allowed) return null;
+
+  const handleClaim = async () => {
+    const targetEmail = claimEmail.trim();
+    if (!targetEmail) return;
+    setClaiming(true);
+    try {
+      const res = await claimMember(targetEmail);
+      notifySuccess('Member claimed', `${res.user.email} joined your group.`);
+      setClaimEmail('');
+      loadGroup();
+    } catch (err) {
+      // Surfaces "Only unassigned community users can be claimed" (400) and not-found (404).
+      notifyError(err instanceof Error ? err.message : 'Failed to claim member');
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  const handleRank = async (m: GroupMember, action: 'promote' | 'demote') => {
+    setActionBusyId(m.id);
+    try {
+      await setMemberRank(m.id, action);
+      notifySuccess('Rank updated', `${m.email} ${action === 'promote' ? 'promoted' : 'demoted'}.`);
+      loadGroup();
+    } catch (err) {
+      notifyError(err instanceof Error ? err.message : 'Failed to change rank');
+    } finally {
+      setActionBusyId(null);
+    }
+  };
+
+  const handleRelease = async (m: GroupMember) => {
+    if (!window.confirm(`Release ${m.email} back to Unassigned? Staff are dropped to community.`)) return;
+    setActionBusyId(m.id);
+    try {
+      await releaseMember(m.id);
+      notifySuccess('Member released', `${m.email} moved to Unassigned.`);
+      loadGroup();
+    } catch (err) {
+      notifyError(err instanceof Error ? err.message : 'Failed to release member');
+    } finally {
+      setActionBusyId(null);
+    }
+  };
+
+  return (
+    <Container size='md' py={{ base: 'md', sm: 'xl' }} px={{ base: 'xs', sm: 'md' }}>
+      <Stack gap='lg'>
+        <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
+          <div>
+            <Group gap='xs'>
+              <IconUsersGroup size={26} />
+              <Title order={1}>My Team</Title>
+            </Group>
+            <Text size='sm' c='dimmed' mt='xs'>
+              As a Team Lead you manage your own group: claim unassigned community members, walk a
+              member up or down the ladder (community ↔ staff ↔ lead), and release members back to
+              Unassigned. You can only act within your own group.
+            </Text>
+          </div>
+        </Paper>
+
+        {loading ? (
+          <Center py='xl'>
+            <Loader size='lg' />
+          </Center>
+        ) : notALead ? (
+          <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
+            <Alert icon={<IconAlertCircle size={18} />} color='blue' title='No group to lead'>
+              <Text size='sm'>
+                You are an admin, not a Team Lead of a specific group. Manage groups, members, and
+                Team Leads from the admin pages instead.
+              </Text>
+              <Group gap='sm' mt='md'>
+                <Button size='xs' variant='light' onClick={() => navigate('/admin/groups')}>
+                  Group Management
+                </Button>
+                <Button size='xs' variant='light' onClick={() => navigate('/admin/users')}>
+                  User Management
+                </Button>
+              </Group>
+            </Alert>
+          </Paper>
+        ) : loadError ? (
+          <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
+            <Alert icon={<IconAlertCircle size={18} />} color='red' title='Error'>
+              {loadError}
+            </Alert>
+          </Paper>
+        ) : data ? (
+          <>
+            <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
+              <Group justify='space-between' align='flex-start' gap='sm'>
+                <div>
+                  <Group gap='xs'>
+                    <Title order={2} size='h3'>
+                      {data.group.name}
+                    </Title>
+                    <Badge variant='light' color={data.group.scope === 'global' ? 'teal' : 'indigo'}>
+                      {data.group.scope}
+                    </Badge>
+                  </Group>
+                  <Text size='sm' c='dimmed' mt={4}>
+                    {data.members.length} member{data.members.length === 1 ? '' : 's'}
+                  </Text>
+                </div>
+              </Group>
+              {data.group.scope === 'scoped' && (
+                <Stack gap={6} mt='md'>
+                  <Group gap='xs'>
+                    <IconMapPin size={16} />
+                    <Text size='sm' fw={500}>
+                      Areas
+                    </Text>
+                  </Group>
+                  {data.areas.length === 0 ? (
+                    <Text size='sm' c='dimmed'>
+                      No areas assigned yet — ask an admin to assign areas on the Groups page.
+                    </Text>
+                  ) : (
+                    <Group gap='xs'>
+                      {data.areas.map((a) => (
+                        <Badge key={a} variant='outline' color='indigo'>
+                          {a}
+                        </Badge>
+                      ))}
+                    </Group>
+                  )}
+                </Stack>
+              )}
+            </Paper>
+
+            <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
+              <Title order={2} size='h3'>
+                <Group gap='xs'>
+                  <IconUserPlus size={20} />
+                  Claim a member
+                </Group>
+              </Title>
+              <Text size='sm' c='dimmed' mt='xs' mb='md'>
+                Add an existing <strong>unassigned community</strong> user to your group by email.
+                They join as a plain member.
+              </Text>
+              <Group align='flex-end' gap='sm' wrap='nowrap'>
+                <TextInput
+                  label='Email'
+                  placeholder='member@example.com'
+                  type='email'
+                  value={claimEmail}
+                  onChange={(e) => setClaimEmail(e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleClaim();
+                  }}
+                  style={{ flex: 1 }}
+                  disabled={claiming}
+                />
+                <Button
+                  leftSection={<IconUserPlus size={16} />}
+                  onClick={handleClaim}
+                  loading={claiming}
+                  disabled={!claimEmail.trim()}
+                >
+                  Claim
+                </Button>
+              </Group>
+            </Paper>
+
+            <Paper shadow='sm' p={{ base: 'md', sm: 'xl' }} radius='md' withBorder>
+              <Title order={2} size='h3'>
+                <Group gap='xs'>
+                  <IconUsersGroup size={20} />
+                  Members
+                </Group>
+              </Title>
+              <Table.ScrollContainer minWidth={640} mt='md'>
+                <Table striped highlightOnHover verticalSpacing='sm'>
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>Email</Table.Th>
+                      <Table.Th style={{ width: 140 }}>Name</Table.Th>
+                      <Table.Th style={{ width: 160 }}>Rank</Table.Th>
+                      <Table.Th style={{ width: 150 }}> </Table.Th>
+                    </Table.Tr>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {data.members.map((m) => {
+                      const isSelf = m.id === currentUser?.id;
+                      const isAdmin = m.role === 'admin';
+                      const idx = rankIndex(m.role, m.group_role);
+                      const busy = actionBusyId === m.id;
+                      const canPromote = !isSelf && !isAdmin && idx < 2;
+                      const canDemote = !isSelf && !isAdmin && idx > 0;
+                      const canRelease = !isSelf && !isAdmin;
+                      return (
+                        <Table.Tr key={m.id}>
+                          <Table.Td>
+                            <Group gap={6} wrap='nowrap'>
+                              {m.email}
+                              {isSelf && (
+                                <Badge size='xs' variant='light' color='gray'>
+                                  you
+                                </Badge>
+                              )}
+                            </Group>
+                          </Table.Td>
+                          <Table.Td>{m.name || '—'}</Table.Td>
+                          <Table.Td>
+                            <Group gap={6} wrap='nowrap'>
+                              <Badge variant='light' color={ROLE_BADGE_COLOR[m.role]}>
+                                {ROLE_LABEL[m.role]}
+                              </Badge>
+                              {m.group_role === 'lead' && (
+                                <Badge
+                                  size='xs'
+                                  color='grape'
+                                  variant='filled'
+                                  leftSection={<IconCrown size={10} />}
+                                >
+                                  Lead
+                                </Badge>
+                              )}
+                            </Group>
+                          </Table.Td>
+                          <Table.Td>
+                            <Group gap={4} wrap='nowrap' justify='flex-end'>
+                              <Tooltip label='Promote' withArrow>
+                                <ActionIcon
+                                  variant='subtle'
+                                  color='green'
+                                  aria-label={`Promote ${m.email}`}
+                                  disabled={!canPromote || busy}
+                                  loading={busy}
+                                  onClick={() => handleRank(m, 'promote')}
+                                >
+                                  <IconArrowUp size={16} />
+                                </ActionIcon>
+                              </Tooltip>
+                              <Tooltip label='Demote' withArrow>
+                                <ActionIcon
+                                  variant='subtle'
+                                  color='orange'
+                                  aria-label={`Demote ${m.email}`}
+                                  disabled={!canDemote || busy}
+                                  onClick={() => handleRank(m, 'demote')}
+                                >
+                                  <IconArrowDown size={16} />
+                                </ActionIcon>
+                              </Tooltip>
+                              <Tooltip label='Release to Unassigned' withArrow>
+                                <ActionIcon
+                                  variant='subtle'
+                                  color='red'
+                                  aria-label={`Release ${m.email}`}
+                                  disabled={!canRelease || busy}
+                                  onClick={() => handleRelease(m)}
+                                >
+                                  <IconDoorExit size={16} />
+                                </ActionIcon>
+                              </Tooltip>
+                            </Group>
+                          </Table.Td>
+                        </Table.Tr>
+                      );
+                    })}
+                  </Table.Tbody>
+                </Table>
+              </Table.ScrollContainer>
+            </Paper>
+          </>
+        ) : null}
+      </Stack>
+    </Container>
+  );
+}

--- a/frontend/src/pages/TeamLeadManagementPage.tsx
+++ b/frontend/src/pages/TeamLeadManagementPage.tsx
@@ -295,7 +295,7 @@ export default function TeamLeadManagementPage() {
                 </Group>
               </Title>
               <Table.ScrollContainer minWidth={640} mt='md'>
-                <Table striped highlightOnHover verticalSpacing='sm'>
+                <Table striped highlightOnHover verticalSpacing='sm' data-testid='team-members-table'>
                   <Table.Thead>
                     <Table.Tr>
                       <Table.Th>Email</Table.Th>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -27,6 +27,20 @@ export {
   deleteUser,
   isStaffRole,
   isAdminRole,
+  isTeamLead,
+  isGlobalScope,
+  isScopedUser,
+  getGroups,
+  createGroup,
+  updateGroup,
+  deleteGroup,
+  setGroupAreas,
+  setUserMembership,
+  getMyGroup,
+  claimMember,
+  setMemberRank,
+  releaseMember,
+  ApiError,
 } from './api/auth';
 export { fetchCommunityGameState, saveCommunityGameState } from './api/communityGame';
 export { getBackupWindow, type BackupWindow } from './api/backup';
@@ -44,6 +58,13 @@ export type {
   InvitationDetails,
   PromoteToAdminResponse,
   GetUsersResponse,
+  AdminUserRow,
+  Group,
+  GroupBase,
+  GroupMember,
+  MyGroupResponse,
+  SetMembershipBody,
+  MemberRankAction,
 } from './api/auth';
 
 export {

--- a/frontend/src/services/api/auth.ts
+++ b/frontend/src/services/api/auth.ts
@@ -8,6 +8,7 @@ import {
   setToken,
   removeToken,
 } from './config';
+import type { GroupRole, GroupScope, UserGroup } from '../../types/User';
 
 /** community (default) | staff (admin-like, no user management) | admin (full) */
 export type UserRole = 'community' | 'staff' | 'admin';
@@ -18,7 +19,19 @@ export interface User {
   name: string | null;
   role: UserRole;
   email_verified?: boolean;
+  /** Resolved group membership (null/absent = unassigned). Present on /auth/me + /auth/validate. */
+  group?: UserGroup | null;
+  /** Membership rank within the group; 'lead' marks a Team Lead (staff only). */
+  group_role?: GroupRole;
+  /** Assigned area path prefixes (empty for global-scope groups and unassigned users). */
+  areas?: string[];
 }
+
+/** Anything carrying the membership fields — accepts both the API `User` and the store `UserInfo`. */
+type MembershipLike =
+  | { role?: UserRole; group?: UserGroup | null; group_role?: GroupRole }
+  | null
+  | undefined;
 
 /** True if user can access turtle records, release, sheets, review (staff or admin). */
 export function isStaffRole(role: string | undefined): role is UserRole {
@@ -28,6 +41,24 @@ export function isStaffRole(role: string | undefined): role is UserRole {
 /** True only for full admin (user management, offline backup download). */
 export function isAdminRole(role: string | undefined): boolean {
   return role === 'admin';
+}
+
+/** True for a staff user acting as a Team Lead (staff + group_role 'lead'). */
+export function isTeamLead(u: MembershipLike): boolean {
+  return u?.role === 'staff' && u?.group_role === 'lead';
+}
+
+/**
+ * True when the user has full, unscoped access: no group at all, or a global-scope group
+ * (Operations / Primary). Scoped Sub-Area members are the only ones this returns false for.
+ */
+export function isGlobalScope(u: MembershipLike): boolean {
+  return !u?.group || u.group.scope === 'global';
+}
+
+/** True for a staff/admin user who belongs to a scoped (Sub-Area) group. */
+export function isScopedUser(u: MembershipLike): boolean {
+  return (u?.role === 'staff' || u?.role === 'admin') && !!u?.group && u.group.scope === 'scoped';
 }
 
 export interface AuthResponse {
@@ -249,9 +280,21 @@ export const promoteToAdmin = async (
 };
 
 // Get all users (admin only)
+export interface AdminUserRow {
+  id: number;
+  email: string;
+  name: string | null;
+  role: UserRole;
+  created_at: string;
+  /** Group membership (null = Unassigned). */
+  group_id: number | null;
+  group_role: GroupRole;
+  group_name: string | null;
+}
+
 export interface GetUsersResponse {
   success: boolean;
-  users: Array<{ id: number; email: string; name: string | null; role: UserRole; created_at: string }>;
+  users: AdminUserRow[];
 }
 
 export const getUsers = async (): Promise<GetUsersResponse> => {
@@ -295,5 +338,217 @@ export const deleteUser = async (
     throw new Error(error.error || 'Failed to delete user');
   }
 
+  return await response.json();
+};
+
+// ---------------------------------------------------------------------------
+// Groups (admin only) — /api/admin/groups
+// ---------------------------------------------------------------------------
+
+/** A group row from the list endpoint (includes derived areas + member count). */
+export interface Group {
+  id: number;
+  name: string;
+  scope: GroupScope;
+  /** Non-null for the seeded system groups ('operations' / 'primary'); null for Sub-Areas. */
+  system_key: string | null;
+  areas: string[];
+  member_count: number;
+  created_at: string;
+}
+
+/** Base group returned by create/update (no derived areas/member_count). */
+export interface GroupBase {
+  id: number;
+  name: string;
+  scope: GroupScope;
+  system_key: string | null;
+}
+
+/** An error carrying the HTTP status, so callers can branch on 403/409 etc. */
+export class ApiError extends Error {
+  status: number;
+  /** Present on a 409 delete-group conflict. */
+  memberCount?: number;
+  constructor(message: string, status: number, memberCount?: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.memberCount = memberCount;
+  }
+}
+
+export const getGroups = async (): Promise<{ success: boolean; groups: Group[] }> => {
+  const response = await apiRequest('/admin/groups', { method: 'GET' });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to load groups');
+  }
+  return await response.json();
+};
+
+export const createGroup = async (
+  name: string,
+  scope: GroupScope = 'scoped',
+): Promise<{ success: boolean; group: GroupBase }> => {
+  const response = await apiRequest('/admin/groups', {
+    method: 'POST',
+    body: JSON.stringify({ name, scope }),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to create group');
+  }
+  return await response.json();
+};
+
+export const updateGroup = async (
+  id: number,
+  changes: { name?: string; scope?: GroupScope },
+): Promise<{ success: boolean; group: GroupBase }> => {
+  const response = await apiRequest(`/admin/groups/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(changes),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to update group');
+  }
+  return await response.json();
+};
+
+/** Delete a group. A 409 (non-empty group) surfaces the member count so the UI can prompt a reassign. */
+export const deleteGroup = async (
+  id: number,
+): Promise<{ success: boolean; message: string }> => {
+  const response = await apiRequest(`/admin/groups/${id}`, { method: 'DELETE' });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    if (response.status === 409 && typeof error.member_count === 'number') {
+      const n = error.member_count as number;
+      throw new ApiError(`${n} member${n === 1 ? '' : 's'} — reassign first`, 409, n);
+    }
+    throw new ApiError(error.error || 'Failed to delete group', response.status);
+  }
+  return await response.json();
+};
+
+export const setGroupAreas = async (
+  id: number,
+  areas: string[],
+): Promise<{ success: boolean; areas: string[] }> => {
+  const response = await apiRequest(`/admin/groups/${id}/areas`, {
+    method: 'PUT',
+    body: JSON.stringify({ areas }),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to save areas');
+  }
+  return await response.json();
+};
+
+// ---------------------------------------------------------------------------
+// Membership (admin only) — one-step stray-user correction
+// ---------------------------------------------------------------------------
+
+export interface SetMembershipBody {
+  group_id: number | null;
+  group_role?: GroupRole;
+}
+
+export const setUserMembership = async (
+  userId: number,
+  body: SetMembershipBody,
+): Promise<{
+  success: boolean;
+  user: { id: number; email: string; role: UserRole; group_id: number | null; group_role: GroupRole };
+}> => {
+  const response = await apiRequest(`/admin/users/${userId}/membership`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to update membership');
+  }
+  return await response.json();
+};
+
+// ---------------------------------------------------------------------------
+// Team Lead (staff leads only) — /api/lead
+// ---------------------------------------------------------------------------
+
+export interface GroupMember {
+  id: number;
+  email: string;
+  name: string | null;
+  role: UserRole;
+  group_role: GroupRole;
+  created_at: string;
+}
+
+export interface MyGroupResponse {
+  success: boolean;
+  group: { id: number; name: string; scope: GroupScope; system_key: string | null };
+  areas: string[];
+  members: GroupMember[];
+}
+
+/** The lead's own group. Throws an {@link ApiError} with status 403 when the caller is not a lead. */
+export const getMyGroup = async (): Promise<MyGroupResponse> => {
+  const response = await apiRequest('/lead/group', { method: 'GET' });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new ApiError(error.error || 'Failed to load your group', response.status);
+  }
+  return await response.json();
+};
+
+export const claimMember = async (
+  email: string,
+): Promise<{
+  success: boolean;
+  user: { id: number; email: string; role: UserRole; group_id: number; group_role: GroupRole };
+}> => {
+  const response = await apiRequest('/lead/members/claim', {
+    method: 'POST',
+    body: JSON.stringify({ email }),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to claim member');
+  }
+  return await response.json();
+};
+
+export type MemberRankAction = 'promote' | 'demote';
+
+export const setMemberRank = async (
+  userId: number,
+  action: MemberRankAction,
+): Promise<{
+  success: boolean;
+  user: { id: number; email: string; role: UserRole; group_role: GroupRole };
+}> => {
+  const response = await apiRequest(`/lead/members/${userId}/rank`, {
+    method: 'PATCH',
+    body: JSON.stringify({ action }),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to change rank');
+  }
+  return await response.json();
+};
+
+export const releaseMember = async (
+  userId: number,
+): Promise<{ success: boolean; message: string }> => {
+  const response = await apiRequest(`/lead/members/${userId}`, { method: 'DELETE' });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to release member');
+  }
   return await response.json();
 };

--- a/frontend/src/store/slices/userSlice.ts
+++ b/frontend/src/store/slices/userSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import { type UserRole } from '../../types/User';
+import { type UserRole, type GroupRole, type UserGroup } from '../../types/User';
 
 export interface UserInfo {
   id: number;
@@ -7,6 +7,12 @@ export interface UserInfo {
   name: string | null;
   role: UserRole;
   email_verified?: boolean;
+  /** Resolved group membership (null/absent = unassigned). */
+  group?: UserGroup | null;
+  /** Membership rank within the group; 'lead' marks a Team Lead (staff only). */
+  group_role?: GroupRole;
+  /** Assigned area path prefixes (empty for global-scope groups and unassigned users). */
+  areas?: string[];
 }
 
 interface UserState {

--- a/frontend/src/types/User.ts
+++ b/frontend/src/types/User.ts
@@ -1,2 +1,19 @@
 /** community (default) | staff (admin-like, no user management) | admin (full) */
 export type UserRole = 'community' | 'staff' | 'admin';
+
+/** Group scope: global (Operations/Primary — unscoped access) | scoped (Sub-Area, area-limited). */
+export type GroupScope = 'global' | 'scoped';
+
+/** Membership rank within a group; 'lead' marks a Team Lead (staff only). */
+export type GroupRole = 'member' | 'lead';
+
+/**
+ * A user's resolved group membership (null = unassigned). Mirrors the auth backend's
+ * MembershipContext.group shape on the enriched /auth/me and /auth/validate payloads.
+ */
+export interface UserGroup {
+  id: number;
+  name: string;
+  scope: GroupScope;
+  system_key: string | null;
+}

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -8,6 +8,10 @@ const STAFF_EMAIL = process.env.E2E_STAFF_EMAIL ?? 'staff@test.com';
 const STAFF_PASSWORD = process.env.E2E_STAFF_PASSWORD ?? 'testpassword123';
 const COMMUNITY_EMAIL = process.env.E2E_COMMUNITY_EMAIL ?? 'community@test.com';
 const COMMUNITY_PASSWORD = process.env.E2E_COMMUNITY_PASSWORD ?? 'testpassword123';
+const TEAMLEAD_EMAIL = process.env.E2E_TEAMLEAD_EMAIL ?? 'teamlead@test.com';
+const TEAMLEAD_PASSWORD = process.env.E2E_TEAMLEAD_PASSWORD ?? 'testpassword123';
+const SCOPED_STAFF_EMAIL = process.env.E2E_SCOPED_STAFF_EMAIL ?? 'scoped-staff@test.com';
+const SCOPED_STAFF_PASSWORD = process.env.E2E_SCOPED_STAFF_PASSWORD ?? 'testpassword123';
 
 /** About / Contact / Feedback live in the app footer (not the header drawer). */
 export async function clickFooterNav(
@@ -88,6 +92,31 @@ export async function loginAsStaff(page: Page): Promise<void> {
   await page.goto('/login');
   await page.getByLabel('Email').fill(STAFF_EMAIL);
   await page.getByLabel('Password').fill(STAFF_PASSWORD);
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await page.waitForURL('/', { timeout: 10000 });
+  await expect(page.getByTestId('role-badge')).toHaveText(/Staff/);
+}
+
+/**
+ * Login as a staff Team Lead (staff role + group_role 'lead' of the seeded KansasTeam).
+ * Asserts the Staff role badge and the presence of the Team Lead badge (which only renders once the
+ * enriched membership is loaded).
+ */
+export async function loginAsTeamLead(page: Page): Promise<void> {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(TEAMLEAD_EMAIL);
+  await page.getByLabel('Password').fill(TEAMLEAD_PASSWORD);
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await page.waitForURL('/', { timeout: 10000 });
+  await expect(page.getByTestId('role-badge')).toHaveText(/Staff/);
+  await expect(page.getByTestId('team-lead-badge')).toBeVisible();
+}
+
+/** Login as a scoped (Sub-Area) staff member — staff role, member rank in the seeded KansasTeam. */
+export async function loginAsScopedStaff(page: Page): Promise<void> {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(SCOPED_STAFF_EMAIL);
+  await page.getByLabel('Password').fill(SCOPED_STAFF_PASSWORD);
   await page.getByRole('button', { name: 'Sign In' }).click();
   await page.waitForURL('/', { timeout: 10000 });
   await expect(page.getByTestId('role-badge')).toHaveText(/Staff/);

--- a/frontend/tests/e2e/staff-and-user-management.spec.ts
+++ b/frontend/tests/e2e/staff-and-user-management.spec.ts
@@ -45,7 +45,11 @@ test.describe('Staff role and User Management', () => {
     // Use dedicated role-test user so community@test.com is never mutated (other tests expect Community badge)
     const roleTestEmail =
       process.env.E2E_ROLE_TEST_EMAIL ?? 'role-test-community@test.com';
-    let row = page.locator('table tbody tr').filter({ hasText: roleTestEmail });
+    // Scope to the "All users by role" section — an unassigned user also appears in the
+    // separate "Unassigned users" quick-view table, so an unscoped `table tbody tr` would
+    // match two rows. The role Select lives only in this section.
+    const byRole = page.getByTestId('users-by-role-section');
+    let row = byRole.locator('tbody tr').filter({ hasText: roleTestEmail });
     await expect(row).toBeVisible({ timeout: 10000 });
 
     const roleTrigger = () => row.getByRole('combobox').or(row.locator('input')).first();
@@ -82,7 +86,7 @@ test.describe('Staff role and User Management', () => {
       ).toBeVisible({
         timeout: 15000,
       });
-      row = page.locator('table tbody tr').filter({ hasText: roleTestEmail });
+      row = byRole.locator('tbody tr').filter({ hasText: roleTestEmail });
     }
 
     // Change to Staff and assert row appears in Staff section

--- a/frontend/tests/e2e/staff-groups-management.spec.ts
+++ b/frontend/tests/e2e/staff-groups-management.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect } from '@playwright/test';
+import type { Page, Route } from '@playwright/test';
+import { loginAsAdmin, loginAsStaff, loginAsTeamLead, loginAsScopedStaff } from './fixtures';
+
+// Both flows below mutate the single seeded unassigned-community user
+// (unassigned@test.com): the group flow moves it into a group and back out; the
+// team-lead flow claims/promotes/demotes/releases it. They MUST NOT run
+// concurrently (fullyParallel would otherwise race them across workers on the same
+// user), so the mutating tests share one `serial` describe — guaranteeing they run
+// in order on a single worker and each restores the user before the next begins.
+// The redirect tests touch no shared state and stay in their own parallel-safe block.
+
+const UNASSIGNED_USER = process.env.E2E_UNASSIGNED_EMAIL ?? 'unassigned@test.com';
+const TEAMLEAD_EMAIL = process.env.E2E_TEAMLEAD_EMAIL ?? 'teamlead@test.com';
+const SCOPED_STAFF_EMAIL = process.env.E2E_SCOPED_STAFF_EMAIL ?? 'scoped-staff@test.com';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL ?? 'admin@test.com';
+const GLOBAL_STAFF_EMAIL = process.env.E2E_STAFF_EMAIL ?? 'staff@test.com';
+
+/** The seeded scoped group the team lead runs. */
+const TEAM_GROUP_NAME = 'KansasTeam';
+
+/** A deterministic area list so the assignment step never depends on the live backend's data dir. */
+const MOCK_AREAS = ['Kansas/Topeka', 'Nebraska/Lincoln'];
+const AREA_TO_ASSIGN = MOCK_AREAS[0];
+
+async function mockLocations(page: Page): Promise<void> {
+  const handler = async (route: Route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, locations: MOCK_AREAS }),
+      });
+    } else {
+      await route.continue();
+    }
+  };
+  await page.route('**/api/locations**', handler);
+  await page.route('**/locations', handler);
+}
+
+test.describe('Staff groups — access redirects', () => {
+  test('Staff is redirected from Group Management to home', async ({ page }) => {
+    await loginAsStaff(page);
+    await page.goto('/admin/groups');
+    await expect(page).toHaveURL('/');
+  });
+
+  test('Scoped staff (non-lead) is redirected from My Team to home', async ({ page }) => {
+    await loginAsScopedStaff(page);
+    await page.goto('/admin/my-team');
+    await expect(page).toHaveURL('/');
+  });
+});
+
+// Serial: these two tests mutate the same seeded user and must not overlap.
+test.describe.serial('Staff groups — management flows', () => {
+  test('Admin creates a scoped group, assigns an area, moves a user in, and cannot delete it while non-empty', async ({
+    page,
+  }) => {
+    // Wide viewport keeps nav in the header and tables un-scrolled; avoids flaky drawer interactions.
+    await page.setViewportSize({ width: 1440, height: 900 });
+    page.on('dialog', (dialog) => dialog.accept());
+    await mockLocations(page);
+
+    await loginAsAdmin(page);
+
+    const groupName = `E2E-Team-${Date.now()}`;
+
+    // --- Create a scoped Sub-Area group ------------------------------------------------
+    await page.goto('/admin/groups');
+    await expect(page.getByRole('heading', { name: 'Group Management' })).toBeVisible();
+
+    await page.getByLabel('Create a Sub-Area group').fill(groupName);
+    const createResp = page.waitForResponse(
+      (r) => r.url().includes('/admin/groups') && r.request().method() === 'POST',
+    );
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+    expect((await createResp).ok()).toBeTruthy();
+
+    // Group row + its area card should now exist.
+    await expect(page.locator('tr', { hasText: groupName })).toBeVisible();
+    const areaCard = page.getByTestId(`area-card-${groupName}`);
+    await expect(areaCard).toBeVisible();
+
+    // --- Assign an area from the (mocked) locations list -------------------------------
+    await areaCard.locator('input:not([type="hidden"])').first().click();
+    await page.getByRole('option', { name: AREA_TO_ASSIGN }).click();
+    const areasResp = page.waitForResponse(
+      (r) => /\/admin\/groups\/\d+\/areas/.test(r.url()) && r.request().method() === 'PUT',
+    );
+    await areaCard.getByRole('button', { name: 'Save areas' }).click();
+    expect((await areasResp).ok()).toBeTruthy();
+
+    // --- Move an unassigned user into the group via User Management --------------------
+    await page.goto('/admin/users');
+    const unassignedSection = page.getByTestId('unassigned-users-section');
+    await expect(unassignedSection).toBeVisible();
+    const moveSelect = unassignedSection.getByLabel(`Move ${UNASSIGNED_USER} to a group`);
+    await moveSelect.click();
+    const moveResp = page.waitForResponse(
+      (r) => /\/admin\/users\/\d+\/membership/.test(r.url()) && r.request().method() === 'PATCH',
+    );
+    await page.getByRole('option', { name: groupName }).click();
+    expect((await moveResp).ok()).toBeTruthy();
+
+    // --- Member count updates to 1 ----------------------------------------------------
+    await page.goto('/admin/groups');
+    await expect(page.getByTestId(`group-members-${groupName}`)).toHaveText('1');
+
+    // --- Delete is blocked while the group has members --------------------------------
+    await page.getByRole('button', { name: `Delete ${groupName}` }).click();
+    await expect(page.getByText(/reassign first/i)).toBeVisible();
+    // Group still present.
+    await expect(page.locator('tr', { hasText: groupName })).toBeVisible();
+
+    // --- Cleanup: release the user, then delete the now-empty group -------------------
+    await page.goto('/admin/users');
+    const backSelect = page.getByLabel(`Move ${UNASSIGNED_USER} to a group`);
+    await backSelect.click();
+    const backResp = page.waitForResponse(
+      (r) => /\/admin\/users\/\d+\/membership/.test(r.url()) && r.request().method() === 'PATCH',
+    );
+    await page.getByRole('option', { name: 'Unassigned' }).click();
+    expect((await backResp).ok()).toBeTruthy();
+
+    await page.goto('/admin/groups');
+    const delResp = page.waitForResponse(
+      (r) => /\/admin\/groups\/\d+$/.test(r.url()) && r.request().method() === 'DELETE',
+    );
+    await page.getByRole('button', { name: `Delete ${groupName}` }).click();
+    expect((await delResp).ok()).toBeTruthy();
+    await expect(page.locator('tr', { hasText: groupName })).toHaveCount(0);
+  });
+
+  test('Team lead sees only their own group and can claim, promote, and demote a member', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    page.on('dialog', (dialog) => dialog.accept());
+
+    await loginAsTeamLead(page);
+    await page.goto('/admin/my-team');
+
+    // --- Own group + members only -----------------------------------------------------
+    await expect(page.getByRole('heading', { name: 'My Team' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: TEAM_GROUP_NAME })).toBeVisible();
+    await expect(page.getByText(SCOPED_STAFF_EMAIL, { exact: true })).toBeVisible();
+    await expect(page.getByText(TEAMLEAD_EMAIL, { exact: true })).toBeVisible();
+    // A lead never sees other groups' members (Primary staff) or admins. Exact match so
+    // 'staff@test.com' does not substring-match 'scoped-staff@test.com'.
+    await expect(page.getByText(ADMIN_EMAIL, { exact: true })).toHaveCount(0);
+    await expect(page.getByText(GLOBAL_STAFF_EMAIL, { exact: true })).toHaveCount(0);
+
+    // --- Claim an unassigned community user ------------------------------------------
+    await page.getByLabel('Email').fill(UNASSIGNED_USER);
+    const claimResp = page.waitForResponse(
+      (r) => r.url().includes('/lead/members/claim') && r.request().method() === 'POST',
+    );
+    await page.getByRole('button', { name: 'Claim', exact: true }).click();
+    expect((await claimResp).ok()).toBeTruthy();
+
+    const memberRow = page.locator('tr', { hasText: UNASSIGNED_USER });
+    await expect(memberRow).toBeVisible();
+    await expect(memberRow.getByText('Community', { exact: true })).toBeVisible();
+
+    // --- Promote up the ladder (community -> staff) ----------------------------------
+    const promoteResp = page.waitForResponse(
+      (r) => /\/lead\/members\/\d+\/rank/.test(r.url()) && r.request().method() === 'PATCH',
+    );
+    await page.getByRole('button', { name: `Promote ${UNASSIGNED_USER}` }).click();
+    expect((await promoteResp).ok()).toBeTruthy();
+    await expect(
+      page.locator('tr', { hasText: UNASSIGNED_USER }).getByText('Staff', { exact: true }),
+    ).toBeVisible();
+
+    // --- Demote back (staff -> community) --------------------------------------------
+    const demoteResp = page.waitForResponse(
+      (r) => /\/lead\/members\/\d+\/rank/.test(r.url()) && r.request().method() === 'PATCH',
+    );
+    await page.getByRole('button', { name: `Demote ${UNASSIGNED_USER}` }).click();
+    expect((await demoteResp).ok()).toBeTruthy();
+    await expect(
+      page.locator('tr', { hasText: UNASSIGNED_USER }).getByText('Community', { exact: true }),
+    ).toBeVisible();
+
+    // --- Cleanup: release the claimed user back to Unassigned ------------------------
+    const releaseResp = page.waitForResponse(
+      (r) => /\/lead\/members\/\d+$/.test(r.url()) && r.request().method() === 'DELETE',
+    );
+    await page.getByRole('button', { name: `Release ${UNASSIGNED_USER}` }).click();
+    expect((await releaseResp).ok()).toBeTruthy();
+    await expect(page.locator('tr', { hasText: UNASSIGNED_USER })).toHaveCount(0);
+  });
+});

--- a/frontend/tests/e2e/staff-groups-management.spec.ts
+++ b/frontend/tests/e2e/staff-groups-management.spec.ts
@@ -14,7 +14,45 @@ const UNASSIGNED_USER = process.env.E2E_UNASSIGNED_EMAIL ?? 'unassigned@test.com
 const TEAMLEAD_EMAIL = process.env.E2E_TEAMLEAD_EMAIL ?? 'teamlead@test.com';
 const SCOPED_STAFF_EMAIL = process.env.E2E_SCOPED_STAFF_EMAIL ?? 'scoped-staff@test.com';
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL ?? 'admin@test.com';
+const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD ?? 'testpassword123';
 const GLOBAL_STAFF_EMAIL = process.env.E2E_STAFF_EMAIL ?? 'staff@test.com';
+const AUTH_API = process.env.E2E_AUTH_URL ?? 'http://localhost:3001/api';
+
+/**
+ * Force the shared seeded user back to community + Unassigned, and drop any leftover
+ * E2E-Team-* groups, via the admin API. Both flows below need the user to START as an
+ * unassigned community member; a prior interrupted run could leave it in a group. This
+ * makes the suite idempotent against a persistent (non-reseeded) backend.
+ */
+async function resetSharedState(request: import('@playwright/test').APIRequestContext): Promise<void> {
+  const login = await request.post(`${AUTH_API}/auth/login`, {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+  });
+  const token = (await login.json()).token as string;
+  const headers = { Authorization: `Bearer ${token}` };
+
+  const users = (await (await request.get(`${AUTH_API}/admin/users`, { headers })).json()).users as Array<{
+    id: number;
+    email: string;
+  }>;
+  const target = users.find((u) => u.email === UNASSIGNED_USER);
+  if (target) {
+    await request.patch(`${AUTH_API}/admin/users/${target.id}/membership`, {
+      headers,
+      data: { group_id: null },
+    });
+    await request.patch(`${AUTH_API}/admin/users/${target.id}/role`, {
+      headers,
+      data: { role: 'community' },
+    });
+  }
+
+  const groups = (await (await request.get(`${AUTH_API}/admin/groups`, { headers })).json())
+    .groups as Array<{ id: number; name: string }>;
+  for (const g of groups.filter((g) => /^E2E-Team-/.test(g.name))) {
+    await request.delete(`${AUTH_API}/admin/groups/${g.id}`, { headers });
+  }
+}
 
 /** The seeded scoped group the team lead runs. */
 const TEAM_GROUP_NAME = 'KansasTeam';
@@ -55,6 +93,13 @@ test.describe('Staff groups — access redirects', () => {
 
 // Serial: these two tests mutate the same seeded user and must not overlap.
 test.describe.serial('Staff groups — management flows', () => {
+  // Idempotent precondition: start each flow with the shared user unassigned + community
+  // and no leftover E2E groups, so a re-run against a persistent backend is deterministic.
+  test.beforeEach(async ({ request }) => {
+    await resetSharedState(request);
+  });
+
+
   test('Admin creates a scoped group, assigns an area, moves a user in, and cannot delete it while non-empty', async ({
     page,
   }) => {
@@ -96,6 +141,9 @@ test.describe.serial('Staff groups — management flows', () => {
     await page.goto('/admin/users');
     const unassignedSection = page.getByTestId('unassigned-users-section');
     await expect(unassignedSection).toBeVisible();
+    // Scope the Move Select to its section: Mantine gives the portaled options listbox the
+    // same aria-label as the input, so a page-level getByLabel would match both. The listbox
+    // portals to document.body (outside this section), so scoping resolves to the input alone.
     const moveSelect = unassignedSection.getByLabel(`Move ${UNASSIGNED_USER} to a group`);
     await moveSelect.click();
     const moveResp = page.waitForResponse(
@@ -115,8 +163,12 @@ test.describe.serial('Staff groups — management flows', () => {
     await expect(page.locator('tr', { hasText: groupName })).toBeVisible();
 
     // --- Cleanup: release the user, then delete the now-empty group -------------------
+    // The user is now in the group, so their Move Select is in the "by role" section (not
+    // Unassigned). Scope to it so getByLabel doesn't also match the portaled options listbox.
     await page.goto('/admin/users');
-    const backSelect = page.getByLabel(`Move ${UNASSIGNED_USER} to a group`);
+    const backSelect = page
+      .getByTestId('users-by-role-section')
+      .getByLabel(`Move ${UNASSIGNED_USER} to a group`);
     await backSelect.click();
     const backResp = page.waitForResponse(
       (r) => /\/admin\/users\/\d+\/membership/.test(r.url()) && r.request().method() === 'PATCH',
@@ -143,14 +195,20 @@ test.describe.serial('Staff groups — management flows', () => {
     await page.goto('/admin/my-team');
 
     // --- Own group + members only -----------------------------------------------------
+    // Scope to the members table: the lead's own email also renders in the nav header, so a
+    // page-level exact getByText for TEAMLEAD_EMAIL would match twice.
     await expect(page.getByRole('heading', { name: 'My Team' })).toBeVisible();
     await expect(page.getByRole('heading', { name: TEAM_GROUP_NAME })).toBeVisible();
-    await expect(page.getByText(SCOPED_STAFF_EMAIL, { exact: true })).toBeVisible();
-    await expect(page.getByText(TEAMLEAD_EMAIL, { exact: true })).toBeVisible();
+    const membersTable = page.getByTestId('team-members-table');
+    // Presence by row: the lead's own row carries a "you" badge in the email cell, so an
+    // exact getByText on the email would miss it. Row hasText tolerates the badge; the full
+    // emails are unambiguous per row.
+    await expect(membersTable.locator('tr').filter({ hasText: SCOPED_STAFF_EMAIL })).toBeVisible();
+    await expect(membersTable.locator('tr').filter({ hasText: TEAMLEAD_EMAIL })).toBeVisible();
     // A lead never sees other groups' members (Primary staff) or admins. Exact match so
     // 'staff@test.com' does not substring-match 'scoped-staff@test.com'.
-    await expect(page.getByText(ADMIN_EMAIL, { exact: true })).toHaveCount(0);
-    await expect(page.getByText(GLOBAL_STAFF_EMAIL, { exact: true })).toHaveCount(0);
+    await expect(membersTable.getByText(ADMIN_EMAIL, { exact: true })).toHaveCount(0);
+    await expect(membersTable.getByText(GLOBAL_STAFF_EMAIL, { exact: true })).toHaveCount(0);
 
     // --- Claim an unassigned community user ------------------------------------------
     await page.getByLabel('Email').fill(UNASSIGNED_USER);


### PR DESCRIPTION
## Summary

Third stage of the staff-management overhaul (stacked series 3/4 — **based on `feat/staff-groups-enforcement` (#265)**, retargets down the stack as each base merges). First frontend PR; surfaces the group system built in stages 1-2. Additive — with only Operations/Primary present the UI simply lists them.

- **Group Management page** (`/admin/groups`, admin-only): list groups (scope, live member count, system tag), create/rename/scope-flip Sub-Area groups (Operations locked global; Primary flippable), delete (blocked while non-empty with a "reassign first" message; system groups never deletable), and assign each scoped group its area prefixes from the backend location list.
- **User Management**: a Group column + a one-step **Move to group** control on every row (any group or Unassigned, with a Member/Lead rank picker) for stray-user correction, plus a dedicated **Unassigned users** section.
- **My Team page** (`/admin/my-team`, leads + admins): a lead views their own group and members, claims an Unassigned community user, walks a member community ↔ staff ↔ lead within their group, and releases to Unassigned. Non-lead admins get a pointer to the Groups/User pages.
- **Nav + session**: "Groups" (admin) and "My Team" (lead) entries, a Team Lead badge, and the enriched `/auth/me` populating `group`/`group_role`/`areas` into the store on mount and after password login.
- **Carry-over from stage 2**: the "+ Create New Sheet" affordance is hidden from scoped members (the endpoint 403s them).

### Review

A pre-merge adversarial UI review (five lenses) found **no merge blockers**; three fixes were applied from its findings: the membership Group/Rank controls are now **self-guarded** (an admin can no longer demote themselves into a revoked-token wedge — mirrors the existing Delete self-guard); a **refetch error keeps the last-known user list** instead of blanking every table under a stale success toast; and the two management E2E flows were merged into **one serial spec** so they can't race on the single seeded unassigned user (`fullyParallel` would otherwise run them on separate workers). Two low, transient "user not yet loaded" UX findings were left as-is (backend enforces; they self-heal on the next `/auth/me`).

Verified: `npm run build` (tsc + vite) clean, ESLint clean on changed files, 20 E2E tests parse across the 5 browser projects. No backend/auth-backend/lockfile churn.

Closes #266