### PR TITLE
Scoped match flow + read-only fallback (4/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.3] - 2026-07-21 — Scoped match flow + read-only fallback
+
 ### Added
 
 - **Scoped match flow + read-only fallback (frontend)**: the photo-match experience now honours a scoped Sub-Area staff member's assigned areas end-to-end. The **"Which location to test against?"** dropdown lists only the states/locations the member's group owns (an owned area, anything under it, or the parent sheet of an owned sub-area), while **"Community Turtles only"** and **"All locations"** always remain — selecting "All locations" is permitted and simply yields a backend-forced, scope-limited result. When a match set includes turtles outside the member's areas (a forced/expanded scope, or a matcher fallback pulling in distant turtles), the match page enters a clearly-marked **read-only** mode: a warning banner explains why, every write control (Save to Sheets & Confirm, Create New Turtle, Cross-check Carapace, replace-reference, add-photos) is disabled, each out-of-scope candidate card is badged "Outside your areas", and each gated handler also short-circuits before any network call. The read-only carapace quick check surfaces the same banner, and the Review Queue applies the same treatment to any visible-but-flagged out-of-scope packet. This is UX only — the backend independently 403s any out-of-scope write, so the guarantees do not depend on the client. **Global members (Operations admins, Primary staff) are completely unaffected**: they keep the full dropdown and a fully editable match page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Scoped match flow + read-only fallback (frontend)**: the photo-match experience now honours a scoped Sub-Area staff member's assigned areas end-to-end. The **"Which location to test against?"** dropdown lists only the states/locations the member's group owns (an owned area, anything under it, or the parent sheet of an owned sub-area), while **"Community Turtles only"** and **"All locations"** always remain — selecting "All locations" is permitted and simply yields a backend-forced, scope-limited result. When a match set includes turtles outside the member's areas (a forced/expanded scope, or a matcher fallback pulling in distant turtles), the match page enters a clearly-marked **read-only** mode: a warning banner explains why, every write control (Save to Sheets & Confirm, Create New Turtle, Cross-check Carapace, replace-reference, add-photos) is disabled, each out-of-scope candidate card is badged "Outside your areas", and each gated handler also short-circuits before any network call. The read-only carapace quick check surfaces the same banner, and the Review Queue applies the same treatment to any visible-but-flagged out-of-scope packet. This is UX only — the backend independently 403s any out-of-scope write, so the guarantees do not depend on the client. **Global members (Operations admins, Primary staff) are completely unaffected**: they keep the full dropdown and a fully editable match page.
+
 ## [2.1.2] - 2026-07-21 — Staff group management UI
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -265,6 +265,14 @@ Staff are organized into **groups**. Two system groups are seeded — **Operatio
 
 Scoped Sub-Area staff cannot create new Google Sheets tabs (a new tab defines a new area), so the "+ Create New Sheet" option is hidden for them; global staff and admins keep it.
 
+**Scoped matching (photo upload + review).** The match experience adapts to a scoped member's areas:
+
+- The **"Which location to test against?"** dropdown on the photo-upload screen only lists the states/locations the member's group owns (an owned area, anything under it, or the parent sheet of an owned sub-area). **"Community Turtles only"** and **"All locations"** always remain — picking "All locations" is allowed, but the backend then forces the search back to the member's areas and flags the result as *scope-expanded*.
+- When a match result includes turtles outside the member's areas (an out-of-scope/All-Locations request that was forced back to scope, or a matcher fallback that pulled in distant turtles), the match page switches to a **read-only** mode: a yellow banner explains why, every save/approve/create/cross-check/replace-reference control is disabled, and each out-of-scope candidate card is badged "Outside your areas". The read-only carapace quick check shows the same banner. This is UX only — the backend independently refuses (403) any write whose target is outside the group's areas, so a scoped member can never save an out-of-scope turtle even if a control were reachable.
+- In the **Review Queue**, out-of-scope packets are already hidden from scoped members by the backend; the rare packet that is visible but flagged scope-expanded gets the same read-only banner and disabled actions.
+
+Global members (Operations admins and Primary staff) see the full dropdown and a fully editable match page exactly as before — every filter and gate is a no-op for them.
+
 ### Community Users
 
 1. **Photo Upload**:

--- a/frontend/src/components/CarapaceQuickCheckResults.tsx
+++ b/frontend/src/components/CarapaceQuickCheckResults.tsx
@@ -14,6 +14,7 @@ import {
 import { IconArrowLeft, IconEyeCheck, IconAlertCircle } from '@tabler/icons-react';
 import { MatchCandidateCard } from '../pages/AdminTurtleMatch/MatchCandidateCard';
 import { TurtleImageComparePair } from './TurtleImageComparePair';
+import { ScopeAlert } from './ScopeAlert';
 import { getImageUrl } from '../services/api';
 import type { QuickCheckMatch } from '../services/api';
 import type { QuickCheckStatus } from '../hooks/useCarapaceQuickCheck';
@@ -26,6 +27,8 @@ interface CarapaceQuickCheckResultsProps {
   matches: QuickCheckMatch[];
   elapsed: number | null;
   selectedIndex: number | null;
+  /** PR-4: results include carapace refs outside the caller's assigned areas. */
+  scopeExpanded?: boolean;
   onSelect: (index: number | null) => void;
   onBack: () => void;
 }
@@ -33,6 +36,11 @@ interface CarapaceQuickCheckResultsProps {
 /** True when the backend found no sibling image for the reference tensor. */
 function hasNoImage(match: QuickCheckMatch): boolean {
   return !match.image_path || match.image_path.endsWith('.pt');
+}
+
+/** PR-4: absent `in_scope` means in scope (global users / legacy). */
+function isOutOfScope(match: QuickCheckMatch): boolean {
+  return match.in_scope === false;
 }
 
 /**
@@ -47,6 +55,7 @@ export function CarapaceQuickCheckResults({
   matches,
   elapsed,
   selectedIndex,
+  scopeExpanded = false,
   onSelect,
   onBack,
 }: CarapaceQuickCheckResultsProps) {
@@ -88,6 +97,7 @@ export function CarapaceQuickCheckResults({
     return (
       <Paper shadow='sm' p='md' radius='md' withBorder>
         <Stack gap='sm'>
+          {scopeExpanded && <ScopeAlert message='This carapace match includes references outside your assigned areas. The quick check is read-only.' />}
           <Group justify='space-between'>
             <Button
               variant='light'
@@ -148,6 +158,9 @@ export function CarapaceQuickCheckResults({
   return (
     <Paper shadow='sm' p='md' radius='md' withBorder>
       <Stack gap='md'>
+        {scopeExpanded && (
+          <ScopeAlert message='These carapace matches include references outside your assigned areas. The quick check is read-only.' />
+        )}
         <Alert icon={<IconEyeCheck size={18} />} color='orange' radius='md'>
           Read-only result — nothing was saved. Click a match to compare side by
           side.
@@ -173,6 +186,7 @@ export function CarapaceQuickCheckResults({
                   confidence={match.confidence}
                   imagePath={hasNoImage(match) ? null : match.image_path}
                   badgeColor='teal'
+                  outOfScope={isOutOfScope(match)}
                   onSelect={() => onSelect(index)}
                 />
               ))}

--- a/frontend/src/components/ScopeAlert.tsx
+++ b/frontend/src/components/ScopeAlert.tsx
@@ -1,0 +1,34 @@
+import { Alert } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+
+interface ScopeAlertProps {
+  /** Override the default read-only explanation. */
+  message?: string;
+  /** Override the default title. */
+  title?: string;
+}
+
+const DEFAULT_TITLE = 'Read-only — outside your assigned areas';
+const DEFAULT_MESSAGE =
+  'These results include turtles outside your assigned areas, so this view is read-only. Saves and approvals are disabled.';
+
+/**
+ * Warning banner shown wherever a scoped (Sub-Area) staff member is looking at a
+ * result set the backend flagged as scope-expanded (`scope_expanded` / a candidate
+ * `in_scope: false`). Shared by the match page, the review queue, and the carapace
+ * quick check. Purely UX — the server enforces scope independently (403s on write).
+ */
+export function ScopeAlert({ message, title }: ScopeAlertProps) {
+  return (
+    <Alert
+      icon={<IconAlertTriangle size={18} />}
+      color="yellow"
+      variant="light"
+      radius="md"
+      title={title ?? DEFAULT_TITLE}
+      data-testid="scope-alert"
+    >
+      {message ?? DEFAULT_MESSAGE}
+    </Alert>
+  );
+}

--- a/frontend/src/hooks/useAdminTurtleMatch.tsx
+++ b/frontend/src/hooks/useAdminTurtleMatch.tsx
@@ -72,6 +72,34 @@ export function useAdminTurtleMatch(
 
   const showDetail = !!(selectedMatch && selectedMatchData);
 
+  // PR-4: a scope-expanded result set (candidates outside the caller's assigned
+  // areas, or an out-of-scope / All-Locations request forced back to the group's
+  // areas) is READ-ONLY. Every write handler short-circuits before its network call
+  // and the views disable their write affordances. The backend 403s independently,
+  // so this is purely UX. Absent flags => editable (global users / legacy payloads).
+  const readOnly = !!matchData?.scopeExpanded;
+
+  const candidateInScope = useCallback(
+    (candidate?: { inScope?: boolean } | string | null): boolean => {
+      if (candidate == null) return true;
+      if (typeof candidate === 'string') {
+        const m = matchData?.matches.find((x) => x.turtle_id === candidate);
+        return m?.inScope ?? true;
+      }
+      return candidate.inScope ?? true;
+    },
+    [matchData],
+  );
+
+  const notifyReadOnly = useCallback(() => {
+    notifications.show({
+      title: 'Read-only',
+      message:
+        'Read-only — results include turtles outside your assigned areas. Saves and approvals are disabled.',
+      color: 'yellow',
+    });
+  }, []);
+
   const refreshPacketItem = useCallback(async () => {
     if (!imageId) return;
     try {
@@ -294,6 +322,10 @@ export function useAdminTurtleMatch(
   };
 
   const handleSaveSheetsData = async (data: TurtleSheetsData, sheetName: string) => {
+    if (readOnly || !candidateInScope(selectedMatch)) {
+      notifyReadOnly();
+      throw new Error('Read-only: results include turtles outside your assigned areas');
+    }
     if (!selectedMatch) throw new Error('No turtle selected');
 
     const match = matchData?.matches.find((m) => m.turtle_id === selectedMatch);
@@ -325,6 +357,10 @@ export function useAdminTurtleMatch(
   };
 
   const handleSaveAndConfirm = async (data: TurtleSheetsData, sheetName: string) => {
+    if (readOnly || !candidateInScope(selectedMatch)) {
+      notifyReadOnly();
+      throw new Error('Read-only: results include turtles outside your assigned areas');
+    }
     if (!selectedMatch || !imageId) throw new Error('Please select a match first');
     if (!matchData?.uploaded_image_path) throw new Error('Missing image path');
 
@@ -392,6 +428,10 @@ export function useAdminTurtleMatch(
     sheetName: string,
     backendLocationPath?: string,
   ) => {
+    if (readOnly) {
+      notifyReadOnly();
+      return;
+    }
     setNewTurtleSheetsData(data);
     setNewTurtleSheetName(sheetName);
     setNewTurtleBackendPath(backendLocationPath);
@@ -426,6 +466,10 @@ export function useAdminTurtleMatch(
     backendPathOverride?: string,
     primaryIdOverride?: string,
   ) => {
+    if (readOnly) {
+      notifyReadOnly();
+      return;
+    }
     const effectiveSheetName = sheetNameOverride || newTurtleSheetName;
     const effectiveSheetsData = sheetsDataOverride || newTurtleSheetsData;
     const effectiveBackendPath = backendPathOverride ?? newTurtleBackendPath;
@@ -548,6 +592,10 @@ export function useAdminTurtleMatch(
   };
 
   const handleCrossCheckCarapace = async () => {
+    if (readOnly) {
+      notifyReadOnly();
+      return;
+    }
     if (!imageId) return;
     setCrossCheckLoading(true);
     const carapaceImg = packetItem?.additional_images?.find((img) => img.type === 'carapace');
@@ -604,6 +652,8 @@ export function useAdminTurtleMatch(
     setReplaceCarapaceReference,
     isMatchFromCommunity,
     showDetail,
+    readOnly,
+    candidateInScope,
     navigate,
     handleSelectMatch,
     handleSaveSheetsData,

--- a/frontend/src/hooks/useCarapaceQuickCheck.ts
+++ b/frontend/src/hooks/useCarapaceQuickCheck.ts
@@ -18,6 +18,10 @@ export function useCarapaceQuickCheck() {
   const [elapsed, setElapsed] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  // PR-4: true when a scoped member's quick check pulled in carapace refs outside
+  // their assigned areas (the read-only flow writes nothing regardless, but the
+  // banner tells them why distant turtles appear). Global users: always false.
+  const [scopeExpanded, setScopeExpanded] = useState(false);
 
   const run = useCallback(async (file: File, matchSheet: string) => {
     setStatus('running');
@@ -25,10 +29,12 @@ export function useCarapaceQuickCheck() {
     setMatches([]);
     setElapsed(null);
     setSelectedIndex(null);
+    setScopeExpanded(false);
     try {
       const response = await quickCheckCarapaceMatch(file, matchSheet);
       setMatches(response.matches ?? []);
       setElapsed(response.elapsed ?? null);
+      setScopeExpanded(response.scope_expanded ?? false);
       setStatus('done');
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Quick check failed.');
@@ -48,6 +54,7 @@ export function useCarapaceQuickCheck() {
     setElapsed(null);
     setError(null);
     setSelectedIndex(null);
+    setScopeExpanded(false);
   }, []);
 
   return {
@@ -58,6 +65,7 @@ export function useCarapaceQuickCheck() {
     elapsed,
     error,
     selectedIndex,
+    scopeExpanded,
     run,
     select,
     reset,

--- a/frontend/src/hooks/usePhotoUpload.tsx
+++ b/frontend/src/hooks/usePhotoUpload.tsx
@@ -228,10 +228,19 @@ export function usePhotoUpload({
                   }),
               }
             : undefined;
+          // Carry the backend scope flags through localStorage — the match page does
+          // not re-fetch, so this is the only channel that survives the navigation.
+          // Absent flags default to in-scope / not-expanded, so a global user's payload
+          // (and any pre-PR-4 stored payload) behaves exactly as before.
+          const scopedMatches = (response.matches || []).map((m) => ({
+            ...m,
+            inScope: m.in_scope ?? true,
+          }));
           const matchData = {
             request_id: response.request_id,
             uploaded_image_path: response.uploaded_image_path || '',
-            matches: response.matches || [], // Empty array if no matches
+            matches: scopedMatches, // Empty array if no matches
+            scopeExpanded: response.scope_expanded ?? false,
             ...(find_metadata_from_upload && Object.keys(find_metadata_from_upload).length > 0 && {
               find_metadata_from_upload,
             }),

--- a/frontend/src/pages/AdminTurtleMatch/AdminTurtleMatchView.tsx
+++ b/frontend/src/pages/AdminTurtleMatch/AdminTurtleMatchView.tsx
@@ -5,9 +5,10 @@ import { MatchDetailView } from './MatchDetailView';
 import { MatchGridView } from './MatchGridView';
 import { NoMatchesView } from './NoMatchesView';
 import { useAdminTurtleMatchContext } from './AdminTurtleMatchContext';
+import { ScopeAlert } from '../../components/ScopeAlert';
 
 export function AdminTurtleMatchView() {
-  const { loading, matchData, showDetail } = useAdminTurtleMatchContext();
+  const { loading, matchData, showDetail, readOnly } = useAdminTurtleMatchContext();
 
   const hasMatches = matchData?.matches && matchData.matches.length > 0;
 
@@ -15,6 +16,8 @@ export function AdminTurtleMatchView() {
     <Container size='xl' py={{ base: 'md', sm: 'xl' }} px={{ base: 'xs', sm: 'md' }}>
       <Stack gap='lg'>
         <AdminTurtleMatchHeader />
+
+        {readOnly && <ScopeAlert />}
 
         {loading ? (
           <Center py='xl'>

--- a/frontend/src/pages/AdminTurtleMatch/MatchCandidateCard.tsx
+++ b/frontend/src/pages/AdminTurtleMatch/MatchCandidateCard.tsx
@@ -16,6 +16,8 @@ type MatchCandidateCardProps = {
   imagePath?: string | null;
   summary?: CandidateSummary;
   badgeColor?: 'blue' | 'teal';
+  /** PR-4: mark this candidate as outside the caller's assigned areas. */
+  outOfScope?: boolean;
   onSelect?: () => void;
 };
 
@@ -27,6 +29,7 @@ export function MatchCandidateCard({
   imagePath,
   summary,
   badgeColor = 'blue',
+  outOfScope = false,
   onSelect,
 }: MatchCandidateCardProps) {
   const showSecondaryId = summary?.primary_id && summary.primary_id !== turtleId;
@@ -108,6 +111,17 @@ export function MatchCandidateCard({
       <Text size='xs' c='dimmed' truncate>
         {location}
       </Text>
+      {outOfScope && (
+        <Badge
+          color='orange'
+          size='xs'
+          variant='light'
+          mt={6}
+          data-testid='candidate-out-of-scope'
+        >
+          Outside your areas
+        </Badge>
+      )}
     </Card>
   );
 }

--- a/frontend/src/pages/AdminTurtleMatch/MatchDetailView.tsx
+++ b/frontend/src/pages/AdminTurtleMatch/MatchDetailView.tsx
@@ -40,6 +40,8 @@ export function MatchDetailView() {
     replaceCarapaceReference,
     setReplaceCarapaceReference,
     isMatchFromCommunity,
+    readOnly,
+    candidateInScope,
     navigate,
     handleSelectMatch,
     handleSaveSheetsData,
@@ -51,6 +53,14 @@ export function MatchDetailView() {
   } = useAdminTurtleMatchContext();
 
   const compareSectionRef = useRef<HTMLDivElement>(null);
+
+  // PR-4: the whole page is read-only when the result set was scope-expanded; a
+  // single candidate can also fall outside scope. Either disables the save path.
+  const candidateOutOfScope = !candidateInScope(selectedMatch);
+  const writeBlocked = readOnly || candidateOutOfScope;
+  const writeBlockedTitle = writeBlocked
+    ? 'Read-only — results include turtles outside your assigned areas'
+    : undefined;
 
   useEffect(() => {
     window.requestAnimationFrame(() => {
@@ -106,9 +116,16 @@ export function MatchDetailView() {
             >
               Back to matches
             </Button>
-            <Badge color='blue' size='lg'>
-              Rank {rank}
-            </Badge>
+            <Group gap='xs'>
+              {candidateOutOfScope && (
+                <Badge color='orange' size='lg' variant='light' data-testid='detail-out-of-scope'>
+                  Outside your areas
+                </Badge>
+              )}
+              <Badge color='blue' size='lg'>
+                Rank {rank}
+              </Badge>
+            </Group>
           </Group>
           <Divider />
 
@@ -207,7 +224,7 @@ export function MatchDetailView() {
               }))}
               requestId={imageId}
               onRefresh={refreshPacketItem}
-              disabled={!!processing}
+              disabled={!!processing || readOnly}
             />
           )}
           {selectedMatch && (
@@ -224,7 +241,7 @@ export function MatchDetailView() {
               turtleId={selectedMatch}
               sheetName={dataPathHintFromMatchLocation(selectedMatchData.location)}
               onRefresh={refreshSelectedMatchImages}
-              disabled={!!processing}
+              disabled={!!processing || readOnly}
             />
           )}
         </Stack>
@@ -237,7 +254,7 @@ export function MatchDetailView() {
             description='The current plastron reference will be archived to loose_images'
             checked={replaceReference}
             onChange={(e) => setReplaceReference(e.currentTarget.checked)}
-            disabled={!!processing}
+            disabled={!!processing || writeBlocked}
           />
           {replaceReference && (
             <Alert icon={<IconAlertTriangle size={16} />} color='orange' radius='md'>
@@ -251,7 +268,7 @@ export function MatchDetailView() {
               description='The current carapace reference will be archived'
               checked={replaceCarapaceReference}
               onChange={(e) => setReplaceCarapaceReference(e.currentTarget.checked)}
-              disabled={!!processing}
+              disabled={!!processing || writeBlocked}
             />
           )}
           {replaceCarapaceReference && (
@@ -287,7 +304,8 @@ export function MatchDetailView() {
             variant='subtle'
             leftSection={<IconPlus size={16} />}
             onClick={handleCreateNewTurtle}
-            disabled={processing}
+            disabled={processing || readOnly}
+            title={readOnly ? writeBlockedTitle : undefined}
           >
             Create New Turtle Instead
           </Button>
@@ -297,7 +315,8 @@ export function MatchDetailView() {
             </Button>
             <Button
               onClick={handleCombinedButtonClick}
-              disabled={!selectedMatch || processing}
+              disabled={!selectedMatch || processing || writeBlocked}
+              title={writeBlockedTitle}
               loading={processing}
               leftSection={<IconCheck size={16} />}
             >

--- a/frontend/src/pages/AdminTurtleMatch/MatchGridView.tsx
+++ b/frontend/src/pages/AdminTurtleMatch/MatchGridView.tsx
@@ -23,10 +23,16 @@ export function MatchGridView() {
     crossCheckResults,
     crossCheckLoading,
     candidateSummaries,
+    readOnly,
+    candidateInScope,
     handleSelectMatch,
     handleCreateNewTurtle,
     handleCrossCheckCarapace,
   } = useAdminTurtleMatchContext();
+
+  const readOnlyTitle = readOnly
+    ? 'Read-only — results include turtles outside your assigned areas'
+    : undefined;
 
   if (!matchData) return null;
 
@@ -99,6 +105,8 @@ export function MatchGridView() {
                 variant='light'
                 loading={crossCheckLoading}
                 onClick={handleCrossCheckCarapace}
+                disabled={readOnly}
+                title={readOnlyTitle}
               >
                 Cross-check Carapace
               </Button>
@@ -122,6 +130,8 @@ export function MatchGridView() {
             variant='light'
             leftSection={<IconPlus size={16} />}
             onClick={handleCreateNewTurtle}
+            disabled={readOnly}
+            title={readOnlyTitle}
           >
             Create New Turtle
           </Button>
@@ -152,6 +162,7 @@ export function MatchGridView() {
                   confidence={match.confidence}
                   imagePath={match.file_path}
                   summary={candidateSummaries[candidateSummaryKey(match.turtle_id, match.location || '')]}
+                  outOfScope={!candidateInScope(match)}
                   onSelect={() => handleSelectMatch(match.turtle_id)}
                 />
               ))}

--- a/frontend/src/pages/AdminTurtleMatch/utils.ts
+++ b/frontend/src/pages/AdminTurtleMatch/utils.ts
@@ -1,10 +1,24 @@
 import type { PhotoType, TurtleMatch } from '../../services/api';
 
+/**
+ * A match candidate as stored in localStorage. Extends the API {@link TurtleMatch}
+ * with the camelCase scope flag mapped from the API's per-candidate `in_scope`
+ * (PR-4). Absent `inScope` = in scope (global users / legacy stored payloads).
+ */
+export interface StoredMatchCandidate extends TurtleMatch {
+  inScope?: boolean;
+}
+
 export interface MatchData {
   request_id: string;
   uploaded_image_path: string;
-  matches: TurtleMatch[];
+  matches: StoredMatchCandidate[];
   photo_type?: PhotoType;
+  /**
+   * Mapped from the API's top-level `scope_expanded` (PR-4). When true the whole
+   * match page is read-only. Absent/false = fully editable (as before PR-4).
+   */
+  scopeExpanded?: boolean;
 }
 
 export type CrossCheckMatch = {

--- a/frontend/src/pages/AdminTurtleRecords/ReviewQueueTab.tsx
+++ b/frontend/src/pages/AdminTurtleRecords/ReviewQueueTab.tsx
@@ -37,6 +37,7 @@ import { DeleteQueueItemModal } from './DeleteQueueItemModal';
 import { AdditionalImagesSection } from '../../components/AdditionalImagesSection';
 import { useAdminTurtleRecordsContext } from './AdminTurtleRecordsContext';
 import { TurtleImageComparePair } from '../../components/TurtleImageComparePair';
+import { ScopeAlert } from '../../components/ScopeAlert';
 
 export function ReviewQueueTab() {
   const compareSectionRef = useRef<HTMLDivElement>(null);
@@ -85,6 +86,12 @@ export function ReviewQueueTab() {
   const location = selectedItem?.metadata.location || '';
   const fullSheetName =
     state && location ? `${state}/${location}` : state || location || null;
+
+  // PR-4: PR-2 already server-filters the queue for scoped members, so out-of-scope
+  // packets rarely reach here. If one that IS visible was flagged scope-expanded at
+  // upload time, treat its detail view as read-only (banner + disabled write actions).
+  // The backend 403s these writes independently — this is defensive UX only.
+  const itemReadOnly = !!selectedItem?.metadata?.scope_expanded;
 
   const isAdminUpload = (requestId: string | undefined) =>
     Boolean(requestId?.startsWith('admin_'));
@@ -246,10 +253,14 @@ export function ReviewQueueTab() {
               size='sm'
               leftSection={<IconTrash size={16} />}
               onClick={(e) => onOpenDeleteModal(selectedItem, e)}
+              disabled={itemReadOnly}
+              title={itemReadOnly ? 'Read-only — this item is outside your assigned areas' : undefined}
             >
               Delete this upload
             </Button>
           </Group>
+
+          {itemReadOnly && <ScopeAlert />}
 
           {loadingTurtleData && selectedCandidate && (
             <div
@@ -305,6 +316,8 @@ export function ReviewQueueTab() {
                       size='sm'
                       variant='filled'
                       color={matchingConfirm === 'trash' ? 'red' : 'blue'}
+                      disabled={itemReadOnly}
+                      title={itemReadOnly ? 'Read-only — this item is outside your assigned areas' : undefined}
                       onClick={async () => {
                         const action = matchingConfirm;
                         setMatchingConfirm(null);
@@ -356,15 +369,15 @@ export function ReviewQueueTab() {
                 <Stack gap='xs'>
                   <Text fw={500} size='sm'>Community upload — review the photo and proceed when ready.</Text>
                   <Group gap='sm'>
-                    <Button size='sm' variant='filled' onClick={() => setMatchingConfirm('match')}>
+                    <Button size='sm' variant='filled' onClick={() => setMatchingConfirm('match')} disabled={itemReadOnly} title={itemReadOnly ? 'Read-only — this item is outside your assigned areas' : undefined}>
                       Proceed with matching
                     </Button>
                     {selectedItem.additional_images?.some(img => img.type === 'plastron') && (
-                      <Button size='sm' variant='filled' color='grape' onClick={() => setMatchingConfirm('crosscheck')}>
+                      <Button size='sm' variant='filled' color='grape' onClick={() => setMatchingConfirm('crosscheck')} disabled={itemReadOnly} title={itemReadOnly ? 'Read-only — this item is outside your assigned areas' : undefined}>
                         Cross-check with plastron
                       </Button>
                     )}
-                    <Button size='sm' variant='filled' color='red' leftSection={<IconTrash size={14} />} onClick={() => setMatchingConfirm('trash')}>
+                    <Button size='sm' variant='filled' color='red' leftSection={<IconTrash size={14} />} onClick={() => setMatchingConfirm('trash')} disabled={itemReadOnly} title={itemReadOnly ? 'Read-only — this item is outside your assigned areas' : undefined}>
                       Delete
                     </Button>
                   </Group>
@@ -388,6 +401,8 @@ export function ReviewQueueTab() {
                       size='sm'
                       variant='light'
                       loading={crossCheckLoading}
+                      disabled={itemReadOnly}
+                      title={itemReadOnly ? 'Read-only — this item is outside your assigned areas' : undefined}
                       onClick={async () => {
                         setCrossCheckLoading(true);
                         try {
@@ -754,7 +769,7 @@ export function ReviewQueueTab() {
                 }))}
                 requestId={selectedItem.request_id}
                 onRefresh={() => refreshQueueItem(selectedItem.request_id)}
-                disabled={!!processing || selectedItem.match_search_pending === true}
+                disabled={!!processing || itemReadOnly || selectedItem.match_search_pending === true}
               />
               {selectedCandidate && (
                 <AdditionalImagesSection
@@ -774,7 +789,7 @@ export function ReviewQueueTab() {
                     const res = await getTurtleImages(selectedCandidate, fullSheetName);
                     setSelectedCandidateTurtleImages(res);
                   }}
-                  disabled={!!processing}
+                  disabled={!!processing || itemReadOnly}
                 />
               )}
             </Stack>
@@ -851,14 +866,16 @@ export function ReviewQueueTab() {
                     variant='subtle'
                     leftSection={<IconPlus size={16} />}
                     onClick={onCreateNewTurtle}
-                    disabled={!!processing}
+                    disabled={!!processing || itemReadOnly}
+                    title={itemReadOnly ? 'Read-only — this item is outside your assigned areas' : undefined}
                   >
                     Create New Turtle Instead
                   </Button>
                   <Button
                     onClick={onCombinedButtonClick}
                     loading={processing === selectedItem.request_id}
-                    disabled={processing === selectedItem.request_id}
+                    disabled={processing === selectedItem.request_id || itemReadOnly}
+                    title={itemReadOnly ? 'Read-only — this item is outside your assigned areas' : undefined}
                     leftSection={<IconCheck size={16} />}
                   >
                     Save to Sheets & Approve Match
@@ -887,6 +904,8 @@ export function ReviewQueueTab() {
                     leftSection={<IconPlus size={16} />}
                     onClick={onCreateNewTurtle}
                     variant='light'
+                    disabled={itemReadOnly}
+                    title={itemReadOnly ? 'Read-only — this item is outside your assigned areas' : undefined}
                   >
                     Create New Turtle
                   </Button>
@@ -908,6 +927,8 @@ export function ReviewQueueTab() {
                     leftSection={<IconPlus size={16} />}
                     onClick={onCreateNewTurtle}
                     variant='light'
+                    disabled={itemReadOnly}
+                    title={itemReadOnly ? 'Read-only — this item is outside your assigned areas' : undefined}
                   >
                     Create New Turtle
                   </Button>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -35,7 +35,7 @@ import { MAX_RAW_FILE_BYTES } from '../utils/uploadConstants';
 import { dropzoneRejectionMessage } from '../utils/uploadErrorMessages';
 import { useUser } from '../hooks/useUser';
 import { usePhotoUpload } from '../hooks/usePhotoUpload';
-import { isStaffRole } from '../services/api/auth';
+import { isStaffRole, isScopedUser } from '../services/api/auth';
 import { PreviewCard } from '../components/PreviewCard';
 import { CarapaceQuickCheckResults } from '../components/CarapaceQuickCheckResults';
 import { useCarapaceQuickCheck } from '../hooks/useCarapaceQuickCheck';
@@ -62,6 +62,23 @@ import {
 
 const MATCH_ALL_VALUE = '__all__';
 const SYSTEM_FOLDERS = ['Community_Uploads', 'Review_Queue', 'Incidental_Finds', 'Incidental Places', 'benchmarks'];
+
+/**
+ * Mirrors the backend `area_covers` / `scope_allows_sheet` prefix rule (PR-4): a
+ * scope option is visible to a scoped Sub-Area member when it equals an owned area,
+ * sits under one, OR is a parent of one — so a `Kansas/Topeka` owner still sees the
+ * top-level `Kansas` entry (selecting it narrows to their sub-area, editable). Global
+ * users bypass this entirely.
+ */
+function areaAllowsOption(areas: string[], option: string): boolean {
+  const opt = option.trim();
+  if (!opt) return false;
+  return areas.some((raw) => {
+    const area = (raw || '').trim();
+    if (!area) return false;
+    return opt === area || opt.startsWith(area + '/') || area.startsWith(opt + '/');
+  });
+}
 
 function isComboboxItemGroup(x: ComboboxData[number]): x is ComboboxItemGroup {
   return typeof x === 'object' && x !== null && 'group' in x && 'items' in x;
@@ -90,7 +107,7 @@ function flattenMatchScopeOptions(data: ComboboxData): ComboboxItem[] {
 export default function HomePage() {
   const dispatch = useAppDispatch();
   const pendingRewards = useAppSelector((s) => s.communityGame.pendingRewards);
-  const { role, isLoggedIn, authChecked } = useUser();
+  const { role, isLoggedIn, authChecked, user } = useUser();
   const isStaff = isStaffRole(role);
   const quickCheck = useCarapaceQuickCheck();
   const carapaceMode = isStaff && quickCheck.enabled;
@@ -217,12 +234,24 @@ export default function HomePage() {
     );
     const options: ComboboxItem[] = [];
 
+    // Scoped Sub-Area members only get the states/locations their group owns; the
+    // predicate is a no-op for global users, so their list is byte-identical to
+    // before. Community_Uploads and the explicit "All locations" entry are ALWAYS
+    // kept — selecting "All locations" now yields a read-only, scope-expanded result
+    // (enforced by the backend) rather than being blocked client-side.
+    const scoped = isScopedUser(user);
+    const ownedAreas = scoped ? (user?.areas ?? []) : [];
+    const optionAllowed = (opt: string) => !scoped || areaAllowsOption(ownedAreas, opt);
+
     for (const state of orderedStates) {
-      const stateLocations = Array.from(byState.get(state) ?? []).sort((a, b) =>
-        a.localeCompare(b, undefined, { sensitivity: 'base' }),
-      );
+      const stateLocations = Array.from(byState.get(state) ?? [])
+        .filter((loc) => optionAllowed(loc))
+        .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+      // Show the state when the state itself is in scope OR any of its sub-locations
+      // are (a Kansas/Topeka owner sees "Kansas" even though "Kansas" ≠ their area).
+      if (!optionAllowed(state) && stateLocations.length === 0) continue;
       options.push({ value: state, label: state });
-      // Only expand sub-locations when a state has multiple locations.
+      // Only expand sub-locations when more than one is available.
       // Single-location states (e.g. NebraskaCPBS with just CPBS) don't
       // need a redundant child entry — the state-level prefix match covers it.
       if (stateLocations.length > 1) {
@@ -235,7 +264,7 @@ export default function HomePage() {
     options.push({ value: 'Community_Uploads', label: 'Community Turtles only' });
     options.push({ value: MATCH_ALL_VALUE, label: 'All locations (everything)' });
     return options;
-  }, [availableLocations]);
+  }, [availableLocations, user]);
 
   const matchScopeOptions = useMemo((): ComboboxData => {
     const canonical = canonicalMatchScopeOptions;
@@ -633,6 +662,7 @@ export default function HomePage() {
               matches={quickCheck.matches}
               elapsed={quickCheck.elapsed}
               selectedIndex={quickCheck.selectedIndex}
+              scopeExpanded={quickCheck.scopeExpanded}
               onSelect={quickCheck.select}
               onBack={handleQuickCheckExit}
             />

--- a/frontend/src/services/api/auth.ts
+++ b/frontend/src/services/api/auth.ts
@@ -49,16 +49,22 @@ export function isTeamLead(u: MembershipLike): boolean {
 }
 
 /**
- * True when the user has full, unscoped access: no group at all, or a global-scope group
- * (Operations / Primary). Scoped Sub-Area members are the only ones this returns false for.
+ * True when the user has full, unscoped access. Mirrors the backend rule
+ * (`is_global = role=='admin' OR group.scope=='global'`, backend/auth.py): an admin
+ * is ALWAYS global regardless of group, plus anyone with no group or a global-scope
+ * group (Operations / Primary). Only a non-admin in a scoped Sub-Area group is false.
  */
 export function isGlobalScope(u: MembershipLike): boolean {
-  return !u?.group || u.group.scope === 'global';
+  return u?.role === 'admin' || !u?.group || u.group.scope === 'global';
 }
 
-/** True for a staff/admin user who belongs to a scoped (Sub-Area) group. */
+/**
+ * True for a member who is actually confined to a scoped (Sub-Area) group — i.e. NOT
+ * global. Admins are never scoped (they are global server-side even inside a scoped
+ * group), so this is effectively a non-admin staff user in a scoped group.
+ */
 export function isScopedUser(u: MembershipLike): boolean {
-  return (u?.role === 'staff' || u?.role === 'admin') && !!u?.group && u.group.scope === 'scoped';
+  return !isGlobalScope(u) && !!u?.group && u.group.scope === 'scoped';
 }
 
 export interface AuthResponse {

--- a/frontend/src/services/api/turtle/types.ts
+++ b/frontend/src/services/api/turtle/types.ts
@@ -6,6 +6,12 @@ export interface TurtleMatch {
   confidence: number;
   file_path: string;
   filename: string;
+  /**
+   * Scoped-group flag (PR-4): true when this candidate's location is within the
+   * caller's assigned areas. Absent for global users and legacy payloads — callers
+   * MUST treat absent as in-scope.
+   */
+  in_scope?: boolean;
 }
 
 export type PhotoType = 'plastron' | 'carapace' | 'unclassified';
@@ -16,6 +22,12 @@ export interface UploadPhotoResponse {
   matches?: TurtleMatch[];
   uploaded_image_path?: string;
   photo_type?: PhotoType;
+  /**
+   * Scoped-group flag (PR-4): true when the match result set was expanded beyond the
+   * caller's areas (out-of-scope candidates, or an out-of-scope / All-Locations
+   * request forced back to scope). Always false / absent for global users.
+   */
+  scope_expanded?: boolean;
   message: string;
 }
 
@@ -27,12 +39,16 @@ export interface QuickCheckMatch {
   score: number;
   /** May still be a `.pt` path when no sibling image exists — treat as "no image". */
   image_path: string;
+  /** Scoped-group flag (PR-4): absent = in scope (see {@link TurtleMatch.in_scope}). */
+  in_scope?: boolean;
 }
 
 export interface QuickCheckResponse {
   success: boolean;
   photo_type: 'carapace';
   matches: QuickCheckMatch[];
+  /** Scoped-group flag (PR-4): see {@link UploadPhotoResponse.scope_expanded}. */
+  scope_expanded?: boolean;
   elapsed: number;
 }
 
@@ -83,6 +99,13 @@ export interface ReviewQueueItem {
     digital_flag_lat?: number;
     digital_flag_lon?: number;
     digital_flag_source?: 'gps' | 'manual';
+    /**
+     * Scoped-group flag (PR-4): persisted at admin/staff upload time. True when this
+     * packet's match set was expanded beyond the uploader's areas — the review-queue
+     * detail view treats such an item as read-only. Absent for community uploads and
+     * for global uploaders.
+     */
+    scope_expanded?: boolean;
   };
   /** Microhabitat / condition photos uploaded with this find */
   additional_images?: AdditionalImage[];

--- a/frontend/tests/e2e/scoped-group-matching.spec.ts
+++ b/frontend/tests/e2e/scoped-group-matching.spec.ts
@@ -1,0 +1,276 @@
+import { test, expect } from '@playwright/test';
+import type { Page, Route } from '@playwright/test';
+import {
+  loginAsScopedStaff,
+  loginAsStaff,
+  grantLocationPermission,
+  getTestImageBuffer,
+  clickUploadPhotoButton,
+} from './fixtures';
+
+/**
+ * Scoped-group match flow (PR-4).
+ *
+ * These read-only tests never mutate a shared seeded user — they only log in
+ * (seeded `scoped-staff@test.com` in KansasTeam / area `Kansas/Topeka`, and the
+ * global `staff@test.com`) and drive the match UI, so they are parallel-safe and
+ * need no `serial` block.
+ *
+ * The upload+match is MOCKED (route-fulfilled), the way `admin-match.spec.ts` mocks
+ * its match data: a real photo match against the VRAM cache is heavy and its
+ * `scope_expanded` / per-candidate `in_scope` flags depend on live group areas +
+ * data-dir contents, which would make the assertions nondeterministic. The scope
+ * *dropdown* test, by contrast, relies on the REAL enriched `/auth/me` (so the
+ * seeded scoped user's `areas` drive the filtering) and only mocks `/api/locations`.
+ */
+
+const SCOPE_SELECT = 'input[placeholder="Select state or location"]';
+
+/** Mock GET /api/locations with the given folder list (state + State/Location paths). */
+async function mockLocations(page: Page, locations: string[]): Promise<void> {
+  const body = JSON.stringify({ success: true, locations });
+  const handler = async (route: Route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body });
+    } else {
+      await route.continue();
+    }
+  };
+  await page.route('**/api/locations', handler);
+  await page.route('**/api/locations**', handler);
+}
+
+/**
+ * Mock the admin/staff upload + the follow-up review-packet / sheets reads so the
+ * match page renders deterministically. `scopeExpanded` / candidate `in_scope`
+ * drive the read-only behaviour under test.
+ */
+async function mockMatchFlow(
+  page: Page,
+  opts: {
+    requestId: string;
+    scopeExpanded: boolean;
+    match: { turtle_id: string; location: string; in_scope: boolean };
+  },
+): Promise<void> {
+  const { requestId, scopeExpanded, match } = opts;
+
+  await page.route('**/api/upload**', async (route) => {
+    if (route.request().method() !== 'POST') return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        request_id: requestId,
+        uploaded_image_path: `Review_Queue/${requestId}/query.jpg`,
+        photo_type: 'plastron',
+        scope_expanded: scopeExpanded,
+        matches: [
+          {
+            turtle_id: match.turtle_id,
+            location: match.location,
+            confidence: 0.82,
+            file_path: '',
+            filename: '',
+            in_scope: match.in_scope,
+          },
+        ],
+        message: 'Uploaded',
+      }),
+    });
+  });
+
+  await page.route(`**/api/review-queue/${requestId}`, async (route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        item: {
+          request_id: requestId,
+          uploaded_image: `Review_Queue/${requestId}/query.jpg`,
+          metadata: { photo_type: 'plastron', scope_expanded: scopeExpanded },
+          additional_images: [],
+          candidates: [],
+          status: 'matched',
+          photo_type: 'plastron',
+        },
+      }),
+    });
+  });
+
+  // Sheets reads fired by the match page (candidate summaries + on card-select) and
+  // the available-sheets list. Benign fixed responses keep the flow deterministic.
+  await page.route('**/api/sheets/sheets**', async (route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, sheets: ['Kansas', 'NebraskaCPBS'] }),
+    });
+  });
+  await page.route('**/api/sheets/turtle/**', async (route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        exists: true,
+        data: {
+          primary_id: 'T1000000001',
+          id: match.turtle_id,
+          name: 'Scope E2E Turtle',
+          sheet_name: match.location.split('/')[0],
+          general_location: match.location.split('/').slice(1).join('/') || match.location,
+        },
+      }),
+    });
+  });
+}
+
+async function uploadPhoto(page: Page, name: string): Promise<void> {
+  const fileInput = page.locator('input[type="file"]:not([capture])').first();
+  await fileInput.setInputFiles({ name, mimeType: 'image/png', buffer: getTestImageBuffer() });
+  await page.waitForSelector('button:has-text("Upload Photo")', { timeout: 5000 });
+  await clickUploadPhotoButton(page);
+}
+
+async function openScopeOptions(page: Page): Promise<string[]> {
+  const select = page.locator(SCOPE_SELECT);
+  await expect(select).toBeVisible({ timeout: 15_000 });
+  await select.click();
+  await page.getByRole('option').first().waitFor({ state: 'visible', timeout: 10_000 });
+  return page.getByRole('option').allTextContents();
+}
+
+test.describe('Scoped-group match flow', () => {
+  test('Scoped staff: scope dropdown shows only owned areas + Community + All locations', async ({
+    page,
+    isMobile,
+  }) => {
+    // Reading a portaled Mantine Select's options via getByRole('option') is unreliable
+    // on the mobile projects (the option list renders in a portal the mobile viewport
+    // doesn't surface to Playwright — see fixtures.ts selectComboboxOptionByIndex). The
+    // scope-filtering logic is browser-agnostic and fully covered on the desktop projects.
+    test.skip(!!isMobile, 'portaled Select options are not reliably enumerable on mobile');
+    await mockLocations(page, [
+      'Kansas',
+      'Kansas/Topeka',
+      'Kansas/Lawrence',
+      'NebraskaCPBS',
+      'Nebraska/Lincoln',
+    ]);
+    await loginAsScopedStaff(page);
+    await page
+      .getByText('Loading locations…')
+      .waitFor({ state: 'hidden', timeout: 10_000 })
+      .catch(() => {});
+
+    const options = await openScopeOptions(page);
+    const joined = options.join('\n');
+
+    // Owned sheet (area is Kansas/Topeka, so the Kansas sheet is visible).
+    expect(joined).toContain('Kansas');
+    // Always-present shared entries.
+    expect(joined).toContain('Community Turtles only');
+    expect(joined).toContain('All locations');
+    // Out-of-scope states must NOT appear.
+    expect(options.some((o) => /Nebraska/i.test(o))).toBeFalsy();
+  });
+
+  test('Scoped staff: out-of-scope upload → read-only match page (writes disabled)', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    await mockLocations(page, ['Kansas', 'Kansas/Topeka', 'NebraskaCPBS']);
+    await mockMatchFlow(page, {
+      requestId: 'admin_e2e-scoped-oos',
+      scopeExpanded: true,
+      match: { turtle_id: 'F900', location: 'Nebraska', in_scope: false },
+    });
+    await loginAsScopedStaff(page);
+    await grantLocationPermission(page);
+
+    await uploadPhoto(page, 'scoped-oos-e2e.png');
+    await expect(page).toHaveURL(/\/admin\/turtle-match\/admin_e2e-scoped-oos/, { timeout: 30_000 });
+
+    // Read-only banner + out-of-scope candidate badge + disabled Create New Turtle.
+    await expect(page.getByTestId('scope-alert')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('candidate-out-of-scope').first()).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create New Turtle' })).toBeDisabled();
+
+    // Selecting the candidate opens the detail view; the save/confirm write stays disabled.
+    await page.locator('.mantine-Card-root').filter({ hasText: 'F900' }).first().click();
+    await expect(
+      page.getByRole('button', { name: /Save to Sheets & Confirm Match/ }),
+    ).toBeDisabled({ timeout: 15_000 });
+  });
+
+  test('Scoped staff: in-scope upload → editable match page (no banner)', async ({ page }) => {
+    test.setTimeout(60_000);
+    await mockLocations(page, ['Kansas', 'Kansas/Topeka']);
+    await mockMatchFlow(page, {
+      requestId: 'admin_e2e-scoped-inscope',
+      scopeExpanded: false,
+      match: { turtle_id: 'F100', location: 'Kansas/Topeka', in_scope: true },
+    });
+    await loginAsScopedStaff(page);
+    await grantLocationPermission(page);
+
+    await uploadPhoto(page, 'scoped-inscope-e2e.png');
+    await expect(page).toHaveURL(/\/admin\/turtle-match\/admin_e2e-scoped-inscope/, {
+      timeout: 30_000,
+    });
+
+    await expect(page.getByRole('button', { name: 'Create New Turtle' })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId('scope-alert')).toHaveCount(0);
+    await expect(page.getByTestId('candidate-out-of-scope')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Create New Turtle' })).toBeEnabled();
+  });
+
+  test('Global staff: full dropdown + editable match page (regression)', async ({
+    page,
+    isMobile,
+  }) => {
+    test.setTimeout(60_000);
+    await mockLocations(page, ['Kansas', 'Kansas/Topeka', 'NebraskaCPBS', 'Nebraska/Lincoln']);
+    await mockMatchFlow(page, {
+      requestId: 'admin_e2e-global-staff',
+      scopeExpanded: false,
+      match: { turtle_id: 'F200', location: 'NebraskaCPBS', in_scope: true },
+    });
+    await loginAsStaff(page);
+    await page
+      .getByText('Loading locations…')
+      .waitFor({ state: 'hidden', timeout: 10_000 })
+      .catch(() => {});
+
+    // A global member is unfiltered: both states appear. The portaled-option read is
+    // desktop-only (see the scoped dropdown test); on mobile we still exercise the
+    // editable-match-page regression below, which is the load-bearing assertion.
+    if (!isMobile) {
+      const options = await openScopeOptions(page);
+      const joined = options.join('\n');
+      expect(joined).toContain('Kansas');
+      expect(options.some((o) => /Nebraska/i.test(o))).toBeTruthy();
+      // Close the dropdown before uploading.
+      await page.keyboard.press('Escape');
+    }
+
+    await grantLocationPermission(page);
+    await uploadPhoto(page, 'global-staff-e2e.png');
+    await expect(page).toHaveURL(/\/admin\/turtle-match\/admin_e2e-global-staff/, {
+      timeout: 30_000,
+    });
+    await expect(page.getByRole('button', { name: 'Create New Turtle' })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId('scope-alert')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Create New Turtle' })).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## Summary

Final stage of the staff-management overhaul (stacked series 4/4 — **based on `feat/staff-groups-admin-ui` (#267)**, retargets down the stack as each base merges). Wires the stage-2 scope flags into the match UI. Additive — for global members `scope_expanded` is always false and every option remains, so the flow is unchanged.

- **Scoped HomePage dropdown**: a scoped Sub-Area member sees only their owned areas (an owned area, anything under it, or the parent sheet of an owned sub-area), plus **Community Turtles only** and an explicit **All locations** that now yields a read-only result rather than being blocked.
- **Flag plumbing**: the upload / quick-check responses' `scope_expanded` (top-level) and per-candidate `in_scope` are persisted into the stored `MatchData` (`localStorage['match_<id>']`) — the only channel that survives navigation to the match page. Flags default to in-scope / not-expanded, so global and pre-existing payloads behave exactly as today.
- **Read-only match page**: when `scope_expanded`, every write handler short-circuits **before any network call**, the write buttons are disabled, a shared `ScopeAlert` banner explains why, and out-of-scope candidates are badged "Outside your areas". The carapace quick check and the Review Queue apply the same treatment. The backend still 403s any out-of-scope write independently (stage-2 defense in depth).

### Review

A pre-merge adversarial UI review (five lenses) found **no merge blockers**; four fixes were applied from its findings: `isGlobalScope`/`isScopedUser` now mirror the backend rule that **an admin is always global even inside a scoped group** (so a scoped-group admin keeps the full dropdown, not a wrongly-filtered one); the review-queue additional-image sections are disabled under read-only like the match page; the portaled-Select dropdown assertions are guarded off the mobile E2E projects (kept on desktop) to avoid a known Mantine-Select-on-mobile flake; and a docs line over-promising a per-button tooltip was corrected. One low, intended behavior (a scoped user's out-of-scope saved favorite is pruned on load) was left as-is.

Verified: `npm run build` (tsc + vite) clean, ESLint clean on changed files, 20 E2E tests parse across the 5 browser projects. No backend/auth-backend/lockfile churn.

Closes #268