### PR TITLE
Make the permanent turtle dataset undeletable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The permanent turtle dataset is now undeletable by the app.** A new `turtle_manager/safe_fs.py` guard treats any *turtle folder* (one holding a `plastron/`, `carapace/`, or legacy `ref_data/` reference directory) — and every `State/`, `State/Location/`, combo-sheet (`NebraskaCPBS/`), or `Incidental Places/` directory that *contains* one at any depth, including community turtle folders under `Community_Uploads/` — as protected: it may be moved, renamed, or archived, but never deleted, by an admin or by accident. Legitimate deletes are unaffected (temp files, `.pt` tensors, `Review_Queue` packets, staged files, and the reference-swap archive-then-remove all keep working). The guard fails closed: a path it cannot prove safe (any error while probing) is treated as protected. Archived / merged-away turtles are moved into a new `data/_Archive/` area, which is excluded from both the location dropdowns and the matching index so they stop being matched.
+
+### Changed
+
+- **Merges and new-turtle rollbacks are now reversible — they archive instead of delete.** Merging a duplicate turtle moves the absorbed (secondary) folder into `data/_Archive/…` instead of `rmtree`-ing it, so a mistaken merge can be recovered. A new-turtle approval that then fails its Google Sheets sync now *archives* the just-created folder (with a guard so it only ever touches a folder that approval created) rather than destroying it on a transient outage. Deleting a single curated additional image is now a **soft-delete** — the image moves into the turtle's `Deleted/` folder (recoverable, listed by the existing deleted-images view) instead of an irreversible remove.
+- **The backend reset scripts fail closed on the dataset.** `reset_complete_backend.py` and `clear_uploads.py` route their folder deletes through the guard, so they refuse to destroy turtle folders (including community turtle folders) and print a clear message pointing at the override. Wiping the dataset now requires an explicit, clearly-named opt-in — `--force-destroy-dataset` (or `FORCE_DESTROY_DATASET=1`) — which exists only on these CLI tools and is never reachable from any HTTP path.
+
 ## [2.0.22] - 2026-07-10 — Carapace quick check opened to staff
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **The permanent turtle dataset is now undeletable by the app.** A new `turtle_manager/safe_fs.py` guard treats any *turtle folder* (one holding a `plastron/`, `carapace/`, or legacy `ref_data/` reference directory) — and every `State/`, `State/Location/`, combo-sheet (`NebraskaCPBS/`), or `Incidental Places/` directory that *contains* one at any depth, including community turtle folders under `Community_Uploads/` — as protected: it may be moved, renamed, or archived, but never deleted, by an admin or by accident. Legitimate deletes are unaffected (temp files, `.pt` tensors, `Review_Queue` packets, staged files, and the reference-swap archive-then-remove all keep working). The guard fails closed: a path it cannot prove safe (any error while probing) is treated as protected. Archived / merged-away turtles are moved into a new `data/_Archive/` area, which is excluded from both the location dropdowns and the matching index so they stop being matched.
-
-### Changed
-
-- **Merges and new-turtle rollbacks are now reversible — they archive instead of delete.** Merging a duplicate turtle moves the absorbed (secondary) folder into `data/_Archive/…` instead of `rmtree`-ing it, so a mistaken merge can be recovered. A new-turtle approval that then fails its Google Sheets sync now *archives* the just-created folder (with a guard so it only ever touches a folder that approval created) rather than destroying it on a transient outage. Deleting a single curated additional image is now a **soft-delete** — the image moves into the turtle's `Deleted/` folder (recoverable, listed by the existing deleted-images view) instead of an irreversible remove.
-- **The backend reset scripts fail closed on the dataset.** `reset_complete_backend.py` and `clear_uploads.py` route their folder deletes through the guard, so they refuse to destroy turtle folders (including community turtle folders) and print a clear message pointing at the override. Wiping the dataset now requires an explicit, clearly-named opt-in — `--force-destroy-dataset` (or `FORCE_DESTROY_DATASET=1`) — which exists only on these CLI tools and is never reachable from any HTTP path.
-
 ## [2.0.22] - 2026-07-10 — Carapace quick check opened to staff
 
 ### Changed

--- a/backend/merge_turtle.py
+++ b/backend/merge_turtle.py
@@ -4,7 +4,7 @@ merge_turtle.py — merge SOURCE turtle folder into TARGET turtle folder.
 Usage (inside the container, from /app):
     python merge_turtle.py <source_id> <target_id> [--execute]
 
-Default is dry-run. Pass --execute to actually move/delete files.
+Default is dry-run. Pass --execute to actually move/archive files.
 
 What it does:
   - Moves plastron/carapace reference images to target's Other Plastrons/
@@ -12,7 +12,7 @@ What it does:
   - Merges additional_images/ date-folders into target
   - Merges find_metadata.json (target wins on conflicts)
   - Deletes source .pt tensors (stale after merge)
-  - Deletes source folder
+  - Archives the source folder (moved under data/_Archive/, recoverable — never deleted)
 
 After running with --execute, restart the backend so the VRAM cache is rebuilt:
     docker restart turtleproject-backend-1
@@ -23,6 +23,12 @@ import json
 import os
 import shutil
 import sys
+
+# Import the shared archive primitive without pulling in turtle_manager's
+# package __init__ (which loads SuperPoint/torch). safe_fs is pure; putting the
+# turtle_manager/ dir on sys.path lets us import it standalone.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), 'turtle_manager'))
+from safe_fs import archive_turtle_folder
 
 
 IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.webp'}
@@ -76,10 +82,11 @@ def delete_file(path: str, dry_run: bool) -> None:
         os.remove(path)
 
 
-def delete_tree(path: str, dry_run: bool) -> None:
-    print(f'  RMDIR {path}')
+def archive_tree(path: str, dry_run: bool, base_dir: str) -> None:
+    print(f'  ARCHIVE {path}')
     if not dry_run:
-        shutil.rmtree(path)
+        dest = archive_turtle_folder(path, base_dir)
+        print(f'       ->  {dest}')
 
 
 # ---------------------------------------------------------------------------
@@ -197,7 +204,7 @@ def main() -> None:
     parser.add_argument('source_id', help='Biology ID of the turtle to absorb, e.g. U521')
     parser.add_argument('target_id', help='Biology ID of the turtle to merge into, e.g. M521')
     parser.add_argument('--execute', action='store_true',
-                        help='Actually move/delete files (default is dry-run)')
+                        help='Actually migrate images and archive the source folder (default is dry-run)')
     args = parser.parse_args()
 
     dry_run = not args.execute
@@ -234,8 +241,8 @@ def main() -> None:
     merge_find_metadata(src_dir, target_dir, dry_run)
     print()
 
-    print(f'--- remove source folder ---')
-    delete_tree(src_dir, dry_run)
+    print(f'--- archive source folder ---')
+    archive_tree(src_dir, dry_run, base_dir)
     print()
 
     if dry_run:

--- a/backend/routes/review.py
+++ b/backend/routes/review.py
@@ -18,6 +18,7 @@ from image_utils import UploadImageError
 from upload_rate_limit import upload_rate_limit_ok, upload_rate_limit_response
 from upload_validation import ingest_saved_upload
 from turtle_manager import canonical_new_turtle_folder_id  # re-exported for callers/tests
+from turtle_manager.safe_fs import guarded_rmtree
 from sheets.migration import generate_primary_id as gen_primary_id  # pure (no network)
 from routes.upload import find_image_for_pt  # case-insensitive .pt→image sibling lookup
 from general_locations_catalog import (
@@ -324,11 +325,13 @@ def register_review_routes(app):
         if not query_image:
             return jsonify({'error': 'No uploaded image found in packet'}), 400
 
-        # Clear old candidates
+        # Clear old candidates. candidate_matches holds copied reference thumbnails,
+        # never a turtle folder, so the guard passes — but route it through anyway
+        # so a future path bug fails closed instead of destroying turtle data.
         import shutil
         candidates_dir = os.path.join(packet_dir, 'candidate_matches')
         if os.path.isdir(candidates_dir):
-            shutil.rmtree(candidates_dir)
+            guarded_rmtree(candidates_dir, manager_service.manager.base_dir)
         os.makedirs(candidates_dir, exist_ok=True)
 
         # Run matching with the chosen photo_type

--- a/backend/scripts/clear_uploads.py
+++ b/backend/scripts/clear_uploads.py
@@ -8,10 +8,39 @@ Clear all uploaded data from the server
 import sys as _sys, os as _os
 _sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
 _sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))  # scripts/ for ingest_common etc.
+# turtle_manager/ on path for the pure delete guard (never loads SuperPoint).
+_sys.path.insert(0, _os.path.join(_os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))), 'turtle_manager'))
 import os
 import shutil
 import tempfile
 from pathlib import Path
+
+from safe_fs import guarded_rmtree, UndeletableTurtleDataError
+
+# Bypass the undeletable-dataset guard ONLY when explicitly opted in. CLI only —
+# never wired to any HTTP path.
+FORCE_DESTROY = False
+
+
+def _destroy_tree(path, guard_base):
+    """rmtree that fails closed on protected turtle data unless FORCE_DESTROY.
+
+    Returns True when removed, False when the guard blocked it (message printed).
+    OSErrors propagate to the caller's existing handler.
+    """
+    if FORCE_DESTROY:
+        shutil.rmtree(path)
+        return True
+    try:
+        guarded_rmtree(path, guard_base)
+        return True
+    except UndeletableTurtleDataError:
+        print(
+            f"   🛑 Refusing to delete protected turtle dataset folder: {path}\n"
+            f"      Re-run with --force-destroy-dataset (or env FORCE_DESTROY_DATASET=1) "
+            f"to override -- this PERMANENTLY DESTROYS dataset photos."
+        )
+        return False
 
 
 def clear_all_uploads():
@@ -32,7 +61,8 @@ def clear_all_uploads():
             item_path = os.path.join(review_queue_dir, item)
             try:
                 if os.path.isdir(item_path):
-                    shutil.rmtree(item_path)
+                    if not _destroy_tree(item_path, data_dir):
+                        continue
                     deleted_count += 1
                     print(f"   🗑️  Deleted: {item}")
                 else:
@@ -54,9 +84,12 @@ def clear_all_uploads():
             try:
                 if os.path.isdir(finder_path):
                     # Count files in this directory
-                    file_count = len([f for f in os.listdir(finder_path) 
+                    file_count = len([f for f in os.listdir(finder_path)
                                      if os.path.isfile(os.path.join(finder_path, f))])
-                    shutil.rmtree(finder_path)
+                    # A Community_Uploads turtle folder holds real photos and is
+                    # protected unless --force-destroy-dataset is set.
+                    if not _destroy_tree(finder_path, data_dir):
+                        continue
                     community_count += file_count
                     print(f"   🗑️  Deleted {finder_dir} ({file_count} files)")
             except Exception as e:
@@ -116,11 +149,13 @@ def clear_review_queue_only():
         return
     
     deleted_count = 0
+    guard_base = os.path.join(base_dir, 'data')
     for item in os.listdir(review_queue_dir):
         item_path = os.path.join(review_queue_dir, item)
         try:
             if os.path.isdir(item_path):
-                shutil.rmtree(item_path)
+                if not _destroy_tree(item_path, guard_base):
+                    continue
                 deleted_count += 1
                 print(f"   🗑️  Deleted: {item}")
         except Exception as e:
@@ -130,9 +165,23 @@ def clear_review_queue_only():
 
 
 if __name__ == "__main__":
-    import sys
-    
-    if len(sys.argv) > 1 and sys.argv[1] == '--review-only':
+    import argparse
+    parser = argparse.ArgumentParser(description="Clear uploaded data")
+    parser.add_argument('--review-only', action='store_true',
+                        help='Only clear the Review Queue')
+    parser.add_argument('--force-destroy-dataset', action='store_true',
+                        help='DANGER: bypass the undeletable-dataset guard so '
+                             'Community_Uploads turtle folders are deleted too. Off by default.')
+    args = parser.parse_args()
+
+    FORCE_DESTROY = (
+        args.force_destroy_dataset
+        or os.environ.get('FORCE_DESTROY_DATASET', '').strip().lower() in ('1', 'true', 'yes')
+    )
+    if FORCE_DESTROY:
+        print("⚠️  --force-destroy-dataset set: the turtle-dataset guard is DISABLED.")
+
+    if args.review_only:
         # Only clear review queue
         clear_review_queue_only()
     else:
@@ -142,7 +191,7 @@ if __name__ == "__main__":
         print("   - Community Uploads")
         print("   - Temporary uploaded files")
         print("\n   This does NOT delete official turtle data or trained models.\n")
-        
+
         confirmation = input("Type 'yes' to continue: ")
         if confirmation.lower() == 'yes':
             clear_all_uploads()

--- a/backend/scripts/ingest_rebuild_folder.py
+++ b/backend/scripts/ingest_rebuild_folder.py
@@ -89,6 +89,7 @@ from ingest_common import (
     resolve_backend_path,
 )
 from turtle_manager import BASE_DATA_DIR, DRIVE_LOCATION_TO_BACKEND_PATH
+from turtle_manager.safe_fs import guarded_rmdir, UndeletableTurtleDataError
 
 # Filename parser: "F017 Plastron.jpg", "F017 Plastron 2.JPG",
 # "F017 Carapace.jpg", "F017 Carapace 3.jpg"
@@ -201,8 +202,10 @@ def _migrate_ref_data_to_plastron(turtle_dir: str, ref_stem: str,
                 for leftover in os.listdir(ref_data):
                     if leftover in SKIP_FILES:
                         os.remove(os.path.join(ref_data, leftover))
-                os.rmdir(ref_data)
-            except OSError as e:
+                # Empty ref_data/ is not turtle data → guard passes; a non-empty
+                # one (failed migration) is refused, never destroyed.
+                guarded_rmdir(ref_data)
+            except (OSError, UndeletableTurtleDataError) as e:
                 reporter.warn(f"Could not remove {ref_data}: {e}")
 
     # Always sweep empty loose_images/
@@ -220,8 +223,8 @@ def _migrate_ref_data_to_plastron(turtle_dir: str, ref_stem: str,
                 try:
                     for leftover in os.listdir(loose):
                         os.remove(os.path.join(loose, leftover))
-                    os.rmdir(loose)
-                except OSError as e:
+                    guarded_rmdir(loose)
+                except (OSError, UndeletableTurtleDataError) as e:
                     reporter.warn(f"Could not remove {loose}: {e}")
 
 

--- a/backend/scripts/migrate_misplaced_drive_prefix_folders.py
+++ b/backend/scripts/migrate_misplaced_drive_prefix_folders.py
@@ -15,7 +15,9 @@ turtle folder (has ``plastron/``, ``carapace/``, or legacy ``ref_data/``) for
 each ``drive_key`` in the flat-ingest map, and plans a move to the canonical
 ``data/<State>/<Location>/<turtle_id>/`` path from ``DRIVE_LOCATION_TO_BACKEND_PATH``.
 
-**Does not import** ``turtle_manager`` (avoids loading SuperPoint). Keep the
+Imports only the **pure** ``path_utils`` / ``safe_fs`` modules (the single source
+of truth for the turtle-folder predicate and the undeletable-dataset guard), NOT
+the ``turtle_manager`` package — so SuperPoint/torch is never loaded. Keep the
 ``DRIVE_LOCATION_TO_BACKEND_PATH`` dict in sync with ``turtle_manager.py``.
 
 Usage (dry run — default, prints planned moves only)::
@@ -50,12 +52,19 @@ from __future__ import annotations
 import sys as _sys, os as _os
 _sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
 _sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))  # scripts/ for ingest_common etc.
+# turtle_manager/ on path so the PURE path_utils / safe_fs modules import
+# standalone — WITHOUT triggering turtle_manager/__init__ (which loads SuperPoint).
+_sys.path.insert(0, _os.path.join(_os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))), 'turtle_manager'))
 
 import argparse
 import os
 import shutil
 import sys
 from typing import Dict, List, Optional, Sequence, Tuple
+
+# Single source of truth for the turtle-folder predicate + the delete guard.
+from path_utils import _is_turtle_data_folder
+from safe_fs import guarded_rmdir, UndeletableTurtleDataError
 
 # SYNC: must match turtle_manager.DRIVE_LOCATION_TO_BACKEND_PATH
 DRIVE_LOCATION_TO_BACKEND_PATH: Dict[str, str] = {
@@ -80,19 +89,6 @@ SKIP_TOP_LEVEL_NAMES = frozenset(
         "__pycache__",
     }
 )
-
-
-def _is_turtle_data_folder(path: str) -> bool:
-    """SYNC: same idea as turtle_manager._is_turtle_data_folder."""
-    if not path or not os.path.isdir(path):
-        return False
-    try:
-        return any(
-            os.path.isdir(os.path.join(path, sub))
-            for sub in ("plastron", "carapace", "ref_data")
-        )
-    except OSError:
-        return False
 
 
 def _iter_turtle_dirs_under(wrong_root: str) -> List[str]:
@@ -150,9 +146,12 @@ def _prune_empty_under(root: str) -> int:
     for dirpath, _dirnames, _filenames in os.walk(root, topdown=False):
         try:
             if os.path.isdir(dirpath) and not os.listdir(dirpath):
-                os.rmdir(dirpath)
+                # Empty dirs are never turtle data, so the guard passes; routing
+                # through it means a dir that concurrently became a turtle folder
+                # fails closed (skipped) instead of being removed.
+                guarded_rmdir(dirpath)
                 removed += 1
-        except OSError:
+        except (OSError, UndeletableTurtleDataError):
             continue
     return removed
 
@@ -291,8 +290,9 @@ def main(argv: Optional[List[str]] = None) -> int:
             os.makedirs(os.path.dirname(dest), exist_ok=True)
             if os.path.isdir(dest) and not os.listdir(dest):
                 try:
-                    os.rmdir(dest)
-                except OSError:
+                    # Empty dest → guard passes; fails closed if it isn't.
+                    guarded_rmdir(dest)
+                except (OSError, UndeletableTurtleDataError):
                     pass
             shutil.move(src, dest)
             print(f"OK [{drive_key}] moved to {dest}")

--- a/backend/scripts/reset_complete_backend.py
+++ b/backend/scripts/reset_complete_backend.py
@@ -18,6 +18,40 @@ from pathlib import Path
 base_dir = os.path.dirname(os.path.abspath(__file__))
 turtles_dir = os.path.join(base_dir, "turtles")
 
+# Undeletable-turtle-dataset guard (pure module; never loads SuperPoint).
+# turtle_manager/ sits one level up from this scripts/ dir.
+sys.path.insert(0, os.path.join(os.path.dirname(base_dir), "turtle_manager"))
+from safe_fs import guarded_rmtree, UndeletableTurtleDataError
+
+# Bypass the guard and permanently delete turtle folders ONLY when explicitly
+# opted in via --force-destroy-dataset / FORCE_DESTROY_DATASET=1. This is a CLI
+# tool only — never reachable from any HTTP path.
+FORCE_DESTROY = False
+
+
+def _destroy_tree(path, guard_base):
+    """rmtree that fails closed on protected turtle data unless FORCE_DESTROY.
+
+    Returns True when the tree was removed, False when the guard blocked it (a
+    clear message pointing at the override flag is printed). OSErrors from the
+    underlying rmtree propagate to the caller's existing handler.
+    """
+    if FORCE_DESTROY:
+        shutil.rmtree(path)
+        return True
+    try:
+        guarded_rmtree(path, guard_base)
+        return True
+    except UndeletableTurtleDataError:
+        print(
+            f"   🛑 Refusing to delete protected turtle dataset folder: {path}\n"
+            f"      It holds permanent research data. Re-run with "
+            f"--force-destroy-dataset (or env FORCE_DESTROY_DATASET=1) to override "
+            f"-- this PERMANENTLY DESTROYS the dataset."
+        )
+        return False
+
+
 try:
     from dotenv import load_dotenv
     for env_path in [Path(base_dir) / ".env", Path(base_dir).parent / ".env"]:
@@ -46,8 +80,8 @@ def clear_legacy_django_storage():
     if os.path.isdir(media_dir):
         try:
             print(f"   🗑️  Removing legacy media directory {media_dir}...")
-            shutil.rmtree(media_dir)
-            print("   ✅ Removed legacy media directory")
+            if _destroy_tree(media_dir, os.path.join(base_dir, 'data')):
+                print("   ✅ Removed legacy media directory")
         except OSError as e:
             print(f"   ⚠️  Could not remove media directory: {e}")
     else:
@@ -83,10 +117,12 @@ def clear_official_turtle_data():
         try:
             # Count files before deletion
             file_count = sum([len(files) for r, d, files in os.walk(item_path)])
+
+            # Delete the entire State/Location folder structure — fails closed on
+            # protected turtle data unless --force-destroy-dataset was passed.
+            if not _destroy_tree(item_path, data_dir):
+                continue
             deleted_files += file_count
-            
-            # Delete the entire State/Location folder structure
-            shutil.rmtree(item_path)
             deleted_folders += 1
             print(f"   🗑️  Deleted: {item} ({file_count} files)")
         except Exception as e:
@@ -117,7 +153,10 @@ def clear_uploaded_data():
                 item_path = os.path.join(folder_path, item)
                 try:
                     if os.path.isdir(item_path):
-                        shutil.rmtree(item_path)
+                        # Review_Queue packets pass the guard; a Community_Uploads
+                        # turtle folder (real photos) is protected unless forced.
+                        if not _destroy_tree(item_path, data_dir):
+                            continue
                     else:
                         os.remove(item_path)
                     deleted_count += 1
@@ -312,4 +351,20 @@ def reset_complete_backend():
 
 
 if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Complete backend reset")
+    parser.add_argument(
+        "--force-destroy-dataset",
+        action="store_true",
+        help="DANGER: bypass the undeletable-turtle-dataset guard and permanently "
+             "delete turtle folders (including Community_Uploads turtles). Off by "
+             "default; without it, protected folders are skipped and reported.",
+    )
+    args = parser.parse_args()
+    FORCE_DESTROY = (
+        args.force_destroy_dataset
+        or os.environ.get("FORCE_DESTROY_DATASET", "").strip().lower() in ("1", "true", "yes")
+    )
+    if FORCE_DESTROY:
+        print("⚠️  --force-destroy-dataset set: the turtle-dataset guard is DISABLED.")
     reset_complete_backend()

--- a/backend/tests/test_safe_fs.py
+++ b/backend/tests/test_safe_fs.py
@@ -1,0 +1,383 @@
+"""
+Tests for the undeletable-turtle-dataset guard (turtle_manager/safe_fs.py) and
+the archive-instead-of-delete flows wired through it.
+
+The pure guard tests import ``safe_fs`` standalone (turtle_manager/ appended to
+sys.path) so they never load SuperPoint/torch. The flow tests reuse the
+mocked-brain TurtleManager fixture pattern from the rest of the suite.
+"""
+import importlib
+import json
+import os
+import sys
+import threading
+import time
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# --- import safe_fs standalone (pure; no brain) --------------------------------
+_TM_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "turtle_manager")
+if _TM_DIR not in sys.path:
+    sys.path.append(_TM_DIR)
+import safe_fs  # noqa: E402
+
+# Import the real turtle_manager once at module level so numpy/cv2/torch become
+# resident in the base sys.modules BEFORE the flow fixtures run. The flow fixture
+# reloads turtle_manager inside a patch.dict(sys.modules, ...); if numpy were
+# first imported inside that block it would be evicted on teardown and re-init
+# on the next test, which numpy forbids ("cannot load module more than once").
+import turtle_manager  # noqa: E402,F401
+
+
+def _make_turtle_folder(base, *parts, marker="plastron"):
+    """Create ``base/parts.../<marker>/`` and return the turtle-folder path."""
+    d = os.path.join(base, *parts)
+    os.makedirs(os.path.join(d, marker), exist_ok=True)
+    return d
+
+
+# ==============================================================================
+# Guard unit matrix — assert_not_turtle_data / guarded_rmtree / guarded_rmdir
+# ==============================================================================
+
+class TestGuardMatrix:
+    def _refuse(self, path, base):
+        with pytest.raises(safe_fs.UndeletableTurtleDataError):
+            safe_fs.assert_not_turtle_data(path, base)
+
+    def _allow(self, path, base):
+        safe_fs.assert_not_turtle_data(path, base)  # must not raise
+
+    # (a) a turtle folder itself
+    def test_refuse_turtle_folder(self, tmp_path):
+        base = str(tmp_path)
+        t = _make_turtle_folder(base, "Kansas", "Lawrence", "F004")
+        self._refuse(t, base)
+        with pytest.raises(safe_fs.UndeletableTurtleDataError):
+            safe_fs.guarded_rmtree(t, base)
+        assert os.path.isdir(t)  # untouched by the refused rmtree
+
+    # (b) the location ancestor
+    def test_refuse_location_ancestor(self, tmp_path):
+        base = str(tmp_path)
+        _make_turtle_folder(base, "Kansas", "Lawrence", "F004")
+        self._refuse(os.path.join(base, "Kansas", "Lawrence"), base)
+
+    # (c) the state ancestor
+    def test_refuse_state_ancestor(self, tmp_path):
+        base = str(tmp_path)
+        _make_turtle_folder(base, "Kansas", "Lawrence", "F004")
+        self._refuse(os.path.join(base, "Kansas"), base)
+
+    # (d) a combo-sheet turtle (carapace marker)
+    def test_refuse_combo_sheet_turtle(self, tmp_path):
+        base = str(tmp_path)
+        t = _make_turtle_folder(base, "NebraskaCPBS", "CPBS", "F233", marker="carapace")
+        self._refuse(t, base)
+        # and its combo-sheet ancestor
+        self._refuse(os.path.join(base, "NebraskaCPBS"), base)
+
+    # (e) a community turtle folder (Community_Uploads is NOT exempt)
+    def test_refuse_community_turtle(self, tmp_path):
+        base = str(tmp_path)
+        t = _make_turtle_folder(base, "Community_Uploads", "SheetA", "F900")
+        self._refuse(t, base)
+
+    # legacy ref_data/ marker is protected too
+    def test_refuse_legacy_ref_data_turtle(self, tmp_path):
+        base = str(tmp_path)
+        t = _make_turtle_folder(base, "Kansas", "Topeka", "M010", marker="ref_data")
+        self._refuse(t, base)
+
+    # (f) an empty dir
+    def test_allow_empty_dir(self, tmp_path):
+        base = str(tmp_path)
+        d = os.path.join(base, "EmptyLoc")
+        os.makedirs(d)
+        self._allow(d, base)
+        safe_fs.guarded_rmtree(d, base)
+        assert not os.path.exists(d)
+
+    # (g) a Review_Queue packet (candidate_matches, but no ref marker)
+    def test_allow_review_queue_packet(self, tmp_path):
+        base = str(tmp_path)
+        pkt = os.path.join(base, "Review_Queue", "Req_1")
+        os.makedirs(os.path.join(pkt, "candidate_matches"))
+        self._allow(pkt, base)
+        safe_fs.guarded_rmtree(pkt, base)
+        assert not os.path.exists(pkt)
+
+    # (h) a system-tempdir path (turtle-shaped but outside base) is exempt
+    def test_allow_system_tempdir(self, tmp_path, monkeypatch):
+        base = str(tmp_path / "data")
+        os.makedirs(base)
+        fake_tmp = str(tmp_path / "systmp")
+        turtle_in_tmp = _make_turtle_folder(fake_tmp, "staging_turtle")
+        monkeypatch.setattr(safe_fs.tempfile, "gettempdir", lambda: fake_tmp)
+        # It IS turtle-shaped, but living under the system tempdir and outside the
+        # data root makes it exempt (upload staging).
+        assert safe_fs.is_or_contains_turtle_data(turtle_in_tmp) is True
+        self._allow(turtle_in_tmp, base)
+
+    # (i) an archived turtle folder under _Archive is PROTECTED (it holds real
+    # photos — a rolled-back new turtle can be the sole copy). Only the explicit
+    # --force-destroy-dataset path (which bypasses the guard) may purge _Archive.
+    def test_refuse_archived_turtle(self, tmp_path):
+        base = str(tmp_path)
+        arch_turtle = _make_turtle_folder(base, "_Archive", "20260722_old", "F1")
+        self._refuse(arch_turtle, base)
+
+    # guarded_rmdir: empty allowed, non-empty turtle refused
+    def test_guarded_rmdir_semantics(self, tmp_path):
+        base = str(tmp_path)
+        empty = os.path.join(base, "e")
+        os.makedirs(empty)
+        safe_fs.guarded_rmdir(empty, base)
+        assert not os.path.exists(empty)
+        t = _make_turtle_folder(base, "Kansas", "L", "F004")
+        with pytest.raises(safe_fs.UndeletableTurtleDataError):
+            safe_fs.guarded_rmdir(t, base)
+        assert os.path.isdir(t)
+
+    # fail-closed: an OSError while probing → treated as protected (True)
+    def test_fail_closed_on_oserror(self, tmp_path, monkeypatch):
+        d = tmp_path / "someloc"
+        d.mkdir()  # empty → would normally be False
+
+        def boom(*a, **k):
+            raise OSError("boom")
+
+        monkeypatch.setattr(safe_fs.os, "walk", boom)
+        assert safe_fs.is_or_contains_turtle_data(str(d)) is True
+
+    def test_is_or_contains_variants(self, tmp_path):
+        base = str(tmp_path)
+        t = _make_turtle_folder(base, "Kansas", "Lawrence", "F004")
+        assert safe_fs.is_or_contains_turtle_data(t) is True
+        assert safe_fs.is_or_contains_turtle_data(os.path.dirname(t)) is True
+        assert safe_fs.is_or_contains_turtle_data(os.path.join(base, "Kansas")) is True
+        assert safe_fs.is_or_contains_turtle_data(str(tmp_path / "nope")) is False  # missing
+
+
+# ==============================================================================
+# archive_turtle_folder
+# ==============================================================================
+
+class TestArchive:
+    def test_archive_moves_and_returns_existing_path(self, tmp_path):
+        base = str(tmp_path)
+        t = _make_turtle_folder(base, "Kansas", "Lawrence", "F004")
+        with open(os.path.join(t, "plastron", "F004.pt"), "wb") as f:
+            f.write(b"tensor")
+
+        dest = safe_fs.archive_turtle_folder(t, base)
+
+        assert os.path.isdir(dest)
+        assert os.path.commonpath([dest, os.path.join(base, "_Archive")]) == os.path.join(base, "_Archive")
+        assert not os.path.exists(t)  # original no longer at source
+        assert os.path.isfile(os.path.join(dest, "plastron", "F004.pt"))  # content preserved
+
+    def test_archive_collision_gets_counter_suffix(self, tmp_path, monkeypatch):
+        base = str(tmp_path)
+        # Freeze the timestamp so two archives of the same relpath collide.
+        monkeypatch.setattr(safe_fs.time, "strftime", lambda fmt, *a: "FIXEDTS")
+
+        t1 = _make_turtle_folder(base, "Kansas", "Lawrence", "F004")
+        d1 = safe_fs.archive_turtle_folder(t1, base)
+        t2 = _make_turtle_folder(base, "Kansas", "Lawrence", "F004")
+        d2 = safe_fs.archive_turtle_folder(t2, base)
+
+        assert d1 != d2
+        assert os.path.basename(d2).endswith("__1")
+        assert os.path.isdir(d1) and os.path.isdir(d2)
+
+    def test_archive_rejects_missing_source(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            safe_fs.archive_turtle_folder(str(tmp_path / "does_not_exist"), str(tmp_path))
+
+
+# ==============================================================================
+# Flow tests — merge / rollback / additional-image delete run against tmp folders
+# ==============================================================================
+
+def _make_mock_brain():
+    mock = MagicMock()
+    mock.vram_cache_plastron = []
+    mock.vram_cache_carapace = []
+    mock.process_and_save = MagicMock(return_value=True)
+    mock.add_single_to_vram = MagicMock(return_value=True)
+    mock.load_database_to_vram = MagicMock()
+    mock.extract_query_features = MagicMock(return_value=["fake_feats"])
+    mock.match_against_cache = MagicMock(return_value=[])
+
+    def _filter_vram_cache(keep_fn, photo_type="plastron"):
+        attr = "vram_cache_carapace" if photo_type == "carapace" else "vram_cache_plastron"
+        cache = getattr(mock, attr)
+        kept = [c for c in cache if keep_fn(c)]
+        removed = len(cache) - len(kept)
+        setattr(mock, attr, kept)
+        return removed
+
+    def _evict_from_vram(pt_path, photo_type="plastron"):
+        return _filter_vram_cache(lambda c: c.get("file_path") != pt_path, photo_type)
+
+    mock.filter_vram_cache = MagicMock(side_effect=_filter_vram_cache)
+    mock.evict_from_vram = MagicMock(side_effect=_evict_from_vram)
+    return mock
+
+
+@pytest.fixture()
+def manager(tmp_path):
+    mock_brain = _make_mock_brain()
+    with patch.dict("sys.modules", {
+        "turtles.image_processing": MagicMock(brain=mock_brain),
+        "turtles": MagicMock(),
+    }):
+        with patch("turtle_manager.brain", mock_brain):
+            import turtle_manager
+            importlib.reload(turtle_manager)
+            mgr = turtle_manager.TurtleManager(base_data_dir=str(tmp_path))
+            mgr._mock_brain = mock_brain
+            yield mgr
+            importlib.reload(turtle_manager)
+
+
+def test_merge_archives_secondary_not_deleted(manager, tmp_path):
+    """merge_turtles archives the secondary folder under _Archive/ (not rmtree)."""
+    pri = tmp_path / "Kansas" / "Lawrence" / "T_PRI"
+    (pri / "plastron").mkdir(parents=True)
+    sec = tmp_path / "Kansas" / "Lawrence" / "T_SEC"
+    (sec / "plastron").mkdir(parents=True)
+    (sec / "plastron" / "keep_me.txt").write_text("secondary payload")
+
+    # Neutralize Google Sheets: no service → merge skips all Sheets steps.
+    fake_services = types.ModuleType("services")
+    fake_ms = types.ModuleType("services.manager_service")
+    fake_ms.get_sheets_service = lambda: None
+    with patch.dict(sys.modules, {"services": fake_services, "services.manager_service": fake_ms}):
+        ok, msg = manager.merge_turtles(
+            "T_PRI", "T_SEC",
+            primary_sheet="Kansas/Lawrence", secondary_sheet="Kansas/Lawrence",
+        )
+
+    assert ok, msg
+    assert not sec.exists(), "secondary must be moved out of its original location"
+    archive_root = tmp_path / "_Archive"
+    assert archive_root.is_dir()
+    survivors = list(archive_root.rglob("keep_me.txt"))
+    assert survivors, "secondary folder must be archived (recoverable), not destroyed"
+
+
+def test_rollback_archives_new_turtle(manager, tmp_path):
+    """rollback_new_turtle archives the folder instead of rmtree-ing it."""
+    t = tmp_path / "Kansas" / "Lawrence" / "F050"
+    (t / "plastron").mkdir(parents=True)
+    (t / "plastron" / "F050.pt").write_bytes(b"tensor")
+
+    manager.rollback_new_turtle("F050", "Kansas/Lawrence", photo_type="plastron")
+
+    assert not t.exists()
+    archive_root = tmp_path / "_Archive"
+    assert archive_root.is_dir()
+    assert list(archive_root.rglob("F050.pt")), "rolled-back folder must be archived, not deleted"
+
+
+def test_rollback_missing_folder_is_noop(manager, tmp_path):
+    """Rollback of a folder that doesn't exist creates nothing and doesn't crash."""
+    manager.rollback_new_turtle("F999", "Kansas/Lawrence", photo_type="plastron")
+    assert not (tmp_path / "_Archive").exists()
+
+
+def test_additional_image_delete_is_soft_delete(manager, tmp_path):
+    """remove_additional_image_from_turtle moves the image under Deleted/, not os.remove."""
+    tdir = tmp_path / "Kansas" / "Lawrence" / "F004"
+    (tdir / "plastron").mkdir(parents=True)
+    date_dir = tdir / "additional_images" / "2026-07-22"
+    date_dir.mkdir(parents=True)
+    img = date_dir / "microhabitat_1_2026-07-22_photo.jpg"
+    img.write_bytes(b"\xff\xd8image")
+    (date_dir / "manifest.json").write_text(
+        json.dumps([{"filename": img.name, "type": "microhabitat"}])
+    )
+
+    ok, err = manager.remove_additional_image_from_turtle(
+        "F004", img.name, sheet_name="Kansas/Lawrence"
+    )
+
+    assert ok, err
+    assert not img.exists(), "original image must be moved, not left in place"
+    moved = tdir / "Deleted" / "additional_images" / "2026-07-22" / img.name
+    assert moved.is_file(), "image must be soft-deleted under Deleted/ (recoverable)"
+    # manifest entry removed
+    assert json.loads((date_dir / "manifest.json").read_text()) == []
+
+
+def test_additional_image_soft_delete_preserves_labels(manager, tmp_path):
+    """Regression: the image's tags must FOLLOW it into Deleted/, not be dropped.
+
+    The label migration reads the source manifest, so it must run BEFORE the
+    source entry is pruned — otherwise the labels are gone by the time they'd be
+    copied to the Deleted/ manifest.
+    """
+    from additional_image_labels import read_labels_for_file
+
+    tdir = tmp_path / "Kansas" / "Lawrence" / "F004"
+    (tdir / "plastron").mkdir(parents=True)
+    date_dir = tdir / "additional_images" / "2026-07-22"
+    date_dir.mkdir(parents=True)
+    img = date_dir / "microhabitat_1_2026-07-22_photo.jpg"
+    img.write_bytes(b"\xff\xd8image")
+    (date_dir / "manifest.json").write_text(
+        json.dumps([{"filename": img.name, "type": "microhabitat", "labels": ["shell rot", "mud"]}])
+    )
+
+    ok, err = manager.remove_additional_image_from_turtle(
+        "F004", img.name, sheet_name="Kansas/Lawrence"
+    )
+    assert ok, err
+
+    deleted_dir = tdir / "Deleted" / "additional_images" / "2026-07-22"
+    assert (deleted_dir / img.name).is_file()
+    # The tags followed the image into Deleted/ (this fails if the source entry
+    # is pruned before migration).
+    assert read_labels_for_file(str(deleted_dir), img.name) == ["shell rot", "mud"]
+    # And the source manifest no longer references the moved file.
+    assert json.loads((date_dir / "manifest.json").read_text()) == []
+
+
+def test_archived_turtle_not_resolved(manager, tmp_path):
+    """A live turtle resolves to its live folder, never to an archived copy.
+
+    An archived folder is named "<ts>_State__Location__F###", whose basename
+    endswith "_F###" and would otherwise be matched by the id resolver.
+    """
+    live = tmp_path / "Kansas" / "Lawrence" / "F077"
+    (live / "plastron").mkdir(parents=True)
+    archived = tmp_path / "_Archive" / "20260722T000000Z_Kansas__Lawrence__F077" / "plastron"
+    archived.mkdir(parents=True)
+
+    resolved = manager._get_turtle_folder("F077", "Kansas/Lawrence")
+    assert resolved is not None
+    assert "_Archive" not in resolved
+    assert os.path.normcase(os.path.abspath(resolved)) == os.path.normcase(str(live))
+
+
+def test_archive_excluded_from_locations_and_index(manager, tmp_path):
+    """_Archive is excluded from get_all_locations() and pruned from the VRAM index."""
+    live = tmp_path / "Kansas" / "Lawrence" / "F004" / "plastron"
+    live.mkdir(parents=True)
+    (live / "F004.pt").write_bytes(b"tensor")
+    arch = tmp_path / "_Archive" / "20260722_gone" / "plastron"
+    arch.mkdir(parents=True)
+    (arch / "F004.pt").write_bytes(b"tensor")
+
+    manager.refresh_database_index()
+    indexed_paths = [entry[0] for entry in manager.db_index]
+    assert any("F004.pt" in p and "_Archive" not in p for p in indexed_paths)
+    assert not any("_Archive" in p for p in indexed_paths), "archived .pt must not match"
+
+    locations = manager.get_all_locations()
+    assert "_Archive" not in locations
+    assert not any(str(loc).startswith("_Archive") for loc in locations)

--- a/backend/turtle_manager/additional_images_mixin.py
+++ b/backend/turtle_manager/additional_images_mixin.py
@@ -348,7 +348,9 @@ class TurtleAdditionalImagesMixin:
         if not q and not kind_filter:
             return []
 
-        skip_top = {'Review_Queue', 'benchmarks'}
+        # Skip system areas AND _Archive: an archived (merged-away / rolled-back)
+        # turtle's additional_images must not resurface in the curated-image search.
+        skip_top = {'Review_Queue', 'benchmarks', '_Archive'}
         # Names that mark "this manifest is inside a turtle's data area".
         # The turtle dir is one path component above the first such name we
         # encounter walking down from base_dir.
@@ -468,16 +470,44 @@ class TurtleAdditionalImagesMixin:
         def try_delete(target_dir):
             file_path = os.path.join(target_dir, filename)
             if os.path.isfile(file_path):
+                # Soft-delete: move the curated research image into
+                # {turtle_dir}/Deleted/<original_rel_path> (mirrors
+                # deletion_mixin.soft_delete_turtle_image) so it stays recoverable
+                # via list_deleted_turtle_images, instead of an irreversible remove.
+                rel = os.path.relpath(file_path, turtle_dir)
+                dest = os.path.join(turtle_dir, 'Deleted', rel)
+                if os.path.exists(dest):
+                    # Collision in Deleted/ — suffix a ms stamp to preserve history.
+                    stem, ext = os.path.splitext(dest)
+                    dest = f"{stem}_{int(time.time() * 1000)}{ext}"
+                # Hard-remove only a companion .pt (additional images normally have
+                # none, but mirror soft_delete so a stale .pt never dangles).
+                companion_pt = os.path.splitext(file_path)[0] + '.pt'
+                if os.path.isfile(companion_pt):
+                    try:
+                        os.remove(companion_pt)
+                    except OSError:
+                        pass
+                try:
+                    os.makedirs(os.path.dirname(dest), exist_ok=True)
+                    shutil.move(file_path, dest)
+                except OSError:
+                    return False
+                # Tags follow the image into Deleted/ BEFORE the source manifest
+                # entry is pruned — migrate reads the label from the source manifest,
+                # so pruning the entry first would drop the labels instead of moving
+                # them (it also clears the source entry's labels itself).
+                migrate_labels_to_archive(
+                    os.path.dirname(file_path), os.path.basename(file_path),
+                    os.path.dirname(dest), os.path.basename(dest),
+                )
+                # Now drop the moved file's entry from the source manifest.
                 manifest_path = os.path.join(target_dir, 'manifest.json')
                 if os.path.isfile(manifest_path):
                     with open(manifest_path, 'r') as f: manifest = json.load(f)
                     new_manifest = [e for e in manifest if e.get('filename') != filename]
                     with open(manifest_path, 'w') as f: json.dump(new_manifest, f, indent=4)
-                try:
-                    os.remove(file_path)
-                    return True
-                except OSError:
-                    return False
+                return True
             return False
 
         if try_delete(additional_dir): return True, None

--- a/backend/turtle_manager/folder_resolver_mixin.py
+++ b/backend/turtle_manager/folder_resolver_mixin.py
@@ -120,6 +120,10 @@ class TurtleFolderResolverMixin:
         try:
             for walk_root in walk_roots:
                 for root, dirs, files in os.walk(walk_root):
+                    # Never resolve a turtle from an archived or soft-deleted copy:
+                    # an archived folder is named "<ts>_State__Location__F###", whose
+                    # basename endswith "_F###" and would otherwise match tid F###.
+                    dirs[:] = [d for d in dirs if d not in ('_Archive', 'Deleted')]
                     if _basename_matches_turtle_id(os.path.basename(root), tid):
                         add_candidate(root)
         except OSError:
@@ -134,6 +138,7 @@ class TurtleFolderResolverMixin:
                 and self.base_dir not in walk_roots):
             try:
                 for root, dirs, files in os.walk(self.base_dir):
+                    dirs[:] = [d for d in dirs if d not in ('_Archive', 'Deleted')]
                     if _basename_matches_turtle_id(os.path.basename(root), tid):
                         add_candidate(root)
             except OSError:

--- a/backend/turtle_manager/manager.py
+++ b/backend/turtle_manager/manager.py
@@ -262,6 +262,10 @@ class TurtleManager(TurtleReferenceMixin, TurtleDeletionMixin, TurtleReviewMixin
             # (if any lingered across an older format) never enter the index.
             if 'Deleted' in dirs:
                 dirs.remove('Deleted')
+            # Prune _Archive/ (archived merge-secondary / rolled-back turtles):
+            # an archived turtle must STOP matching, exactly like Deleted/.
+            if '_Archive' in dirs:
+                dirs.remove('_Archive')
             # Determine photo_type from the directory name
             dir_name = os.path.basename(root)
             if dir_name in ("plastron", "ref_data"):
@@ -295,7 +299,7 @@ class TurtleManager(TurtleReferenceMixin, TurtleDeletionMixin, TurtleReviewMixin
 
     # Folders that should never appear in user-facing location dropdowns
     SYSTEM_FOLDERS = {"Review_Queue", "Community_Uploads",
-                      "Incidental Places", "benchmarks"}
+                      "Incidental Places", "benchmarks", "_Archive"}
 
     def get_all_locations(self):
         """

--- a/backend/turtle_manager/merge_mixin.py
+++ b/backend/turtle_manager/merge_mixin.py
@@ -11,6 +11,7 @@ import shutil
 import time
 
 from .path_utils import _find_image_in_dir, _IMAGE_EXTENSIONS
+from .safe_fs import archive_turtle_folder
 
 try:
     from turtles.image_processing import brain
@@ -467,12 +468,14 @@ class TurtleMergeMixin:
                     print(f"   ⚠️ Could not delete secondary Sheets row: {e}")
                     return False, f"Merge partially applied: Sheets deletion failed ({e}). Secondary folder was NOT removed."
 
-            # 11. Remove secondary folder
+            # 11. Archive secondary folder — delete becomes reversible. The merge
+            # is complete and the secondary Sheets row is gone, but the secondary
+            # folder is preserved under _Archive/ instead of being destroyed.
             try:
-                shutil.rmtree(secondary_dir)
-                print(f"   🗑️ Removed secondary folder: {secondary_dir}")
-            except OSError as e:
-                print(f"   ⚠️ Could not remove secondary folder: {e}")
+                archived_to = archive_turtle_folder(secondary_dir, self.base_dir)
+                print(f"   🗄️ Archived secondary folder → {archived_to}")
+            except (OSError, shutil.Error) as e:
+                print(f"   ⚠️ Could not archive secondary folder: {e}")
 
             # 12. Refresh database index
             self.refresh_database_index()

--- a/backend/turtle_manager/review_mixin.py
+++ b/backend/turtle_manager/review_mixin.py
@@ -25,6 +25,7 @@ from .path_utils import (
     DRIVE_STATE_NAME_MAP, LOCATION_NAME_MAP,
     _resolve_drive_state_name, _resolve_drive_location_name,
 )
+from .safe_fs import archive_turtle_folder, guarded_rmtree
 
 try:
     from turtles.image_processing import brain
@@ -589,7 +590,9 @@ class TurtleReviewMixin:
         """Remove a processed packet directory or temp file."""
         if packet_dir and os.path.exists(packet_dir):
             try:
-                shutil.rmtree(packet_dir)
+                # Review_Queue packets carry no turtle folder, so the guard passes;
+                # routing through it fails closed if a path bug ever aimed here.
+                guarded_rmtree(packet_dir, self.base_dir)
                 print(f"🗑️ Queue Item {request_id or 'unknown'} deleted (Processed).")
             except Exception as e:
                 print(f"⚠️ Error deleting packet: {e}")
@@ -604,19 +607,35 @@ class TurtleReviewMixin:
                     print(f"⚠️ Error deleting temp file: {e}")
 
     def rollback_new_turtle(self, turtle_id, location, photo_type="plastron"):
-        """Roll back a new turtle creation — removes folder from disk and evicts from VRAM cache."""
+        """Roll back a new turtle creation — archives the folder and evicts it from VRAM.
+
+        The folder is *archived* (moved under ``_Archive/``), never destroyed: a
+        transient Sheets outage must not permanently delete a freshly-created —
+        possibly already-populated — turtle folder. A pre-existing-folder guard
+        ensures we only ever touch a folder this approval created: the target must
+        resolve safely under ``base_dir`` and its basename must match
+        ``turtle_id``. (A populated pre-existing turtle cannot reach here anyway —
+        ``_process_single_turtle`` returns ``'skipped'`` when a reference already
+        exists, so the approval aborts before the Sheets sync that triggers this
+        rollback.)
+        """
         parts = [p.strip() for p in location.split('/') if p.strip()]
         if len(parts) >= 2:
-            turtle_dir = os.path.join(self.base_dir, parts[0], parts[1], turtle_id)
+            turtle_dir = _resolved_path_under_base(self.base_dir, parts[0], parts[1], turtle_id)
+        elif parts:
+            turtle_dir = _resolved_path_under_base(self.base_dir, parts[0], turtle_id)
         else:
-            turtle_dir = os.path.join(self.base_dir, parts[0], turtle_id) if parts else None
+            turtle_dir = None
 
-        if turtle_dir and os.path.exists(turtle_dir):
+        if (turtle_dir and os.path.isdir(turtle_dir)
+                and _basename_matches_turtle_id(os.path.basename(turtle_dir), turtle_id)):
             try:
-                shutil.rmtree(turtle_dir)
-                print(f"🔙 Rolled back turtle folder: {turtle_dir}")
-            except Exception as e:
+                archived_to = archive_turtle_folder(turtle_dir, self.base_dir)
+                print(f"🔙 Rolled back new turtle → archived to {archived_to}")
+            except (OSError, shutil.Error) as e:
                 print(f"⚠️ Failed to roll back turtle folder: {e}")
+        elif turtle_dir and os.path.exists(turtle_dir):
+            print(f"⚠️ Rollback skipped: {turtle_dir} is not a folder this approval created")
 
         # Evict from VRAM cache (check both new 'plastron' and legacy 'ref_data' paths)
         subdirs_to_check = ['carapace'] if photo_type == 'carapace' else ['plastron', 'ref_data']
@@ -637,7 +656,7 @@ class TurtleReviewMixin:
             if not packet_dir or not os.path.exists(packet_dir) or not os.path.isdir(packet_dir):
                 return False, "Request not found"
             try:
-                shutil.rmtree(packet_dir)
+                guarded_rmtree(packet_dir, self.base_dir)
                 print(f"🗑️ Queue Item {request_id} deleted (Rejected/Discarded).")
                 return True, "Deleted"
             except Exception as e:

--- a/backend/turtle_manager/safe_fs.py
+++ b/backend/turtle_manager/safe_fs.py
@@ -1,0 +1,224 @@
+"""
+safe_fs — make the permanent turtle dataset undeletable by the app.
+
+The on-disk turtle dataset is a permanent research asset. A directory is
+protected when it IS a *turtle folder* (holds a ``plastron/``, ``carapace/`` or
+legacy ``ref_data/`` reference subdir) OR when it *contains* such a folder at any
+depth (a ``State/``, ``State/Location/``, combo-sheet ``NebraskaCPBS/`` or
+``Incidental Places/`` directory). Protected folders may be moved, renamed, or
+archived (delete-becomes-reversible) — never destroyed, even by an admin, and
+never by accident.
+
+Legitimate deletes keep working untouched: temp files, ``.pt`` tensors,
+``Review_Queue`` packets, staged files, and the reference-swap
+archive-then-remove all operate on non-turtle-data paths (or on exempt transient
+areas) and are unaffected.
+
+Pure module: no Flask, no brain/VRAM, no Sheets. It reuses the leaf predicate
+``path_utils._is_turtle_data_folder`` so there is a single source of truth for
+"is this a turtle folder". It can be imported either as ``turtle_manager.safe_fs``
+(package context) or, by standalone scripts that must avoid loading SuperPoint,
+as a top-level ``safe_fs`` (with ``turtle_manager/`` on ``sys.path``).
+"""
+import os
+import re
+import shutil
+import tempfile
+import time
+
+try:
+    from .path_utils import _is_turtle_data_folder
+except ImportError:  # standalone import (scripts put turtle_manager/ on sys.path)
+    from path_utils import _is_turtle_data_folder
+
+
+# Absolute default data dir, resolved exactly the way TurtleManager does it:
+# safe_fs.py lives in backend/turtle_manager/, so two dirnames up + 'data' is
+# backend/data. Callers with their own base (the manager passes self.base_dir;
+# tests pass tmp_path) override via the base_dir argument, so this default only
+# matters for standalone scripts operating on the real data tree.
+BASE_DATA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'data'
+)
+
+# Directory name for archived (delete-becomes-reversible) turtle folders.
+ARCHIVE_DIR_NAME = '_Archive'
+
+# Transient / derived areas under the data root whose contents are legitimately
+# deletable even if a stray marker made them look like turtle data:
+#   - Review_Queue  : community/admin upload packets (candidate_matches, etc.)
+#   - benchmarks    : runtime benchmark logs
+# NOTE: Community_Uploads and 'Incidental Places' are deliberately NOT exempt —
+# their turtle folders hold real reference photos and stay protected. _Archive is
+# ALSO NOT exempt: it holds whole archived turtle folders (a rolled-back new
+# turtle can be the sole copy of its photos), so archived data is protected like
+# the live dataset — it can only be purged via the explicit --force-destroy-dataset
+# path (which bypasses the guard entirely), never by a routine reset or an
+# accidental guarded delete.
+_EXEMPT_RELATIVE_AREAS = ('Review_Queue', 'benchmarks')
+
+
+class UndeletableTurtleDataError(Exception):
+    """Raised when a delete would destroy a protected turtle-data folder."""
+
+
+def _raise(err):
+    """os.walk onerror hook: re-raise so a mid-walk scandir failure fails closed."""
+    raise err
+
+
+def _norm_real(path):
+    """realpath + normcase so containment compares consistently on Windows and Linux.
+
+    normcase is a no-op on Linux (case-sensitive, matching production) and
+    lowercases + normalizes separators on Windows (local dev), mirroring how the
+    rest of the backend compares data paths.
+    """
+    return os.path.normcase(os.path.realpath(path))
+
+
+def _is_within(path, ancestor):
+    """True if ``path`` is ``ancestor`` or resolves to somewhere underneath it."""
+    try:
+        p = _norm_real(path)
+        a = _norm_real(ancestor)
+    except OSError:
+        return False
+    if p == a:
+        return True
+    try:
+        return os.path.commonpath([p, a]) == a
+    except (ValueError, OSError):
+        return False
+
+
+def is_or_contains_turtle_data(path):
+    """True if ``path`` IS a turtle folder or CONTAINS one at any depth.
+
+    Fail closed: any race / ``OSError`` while probing is treated as "cannot prove
+    this is safe to delete" and returns True. The walk exits early on the first
+    turtle folder found (so guarding a populated ``State/`` tree is cheap), does
+    not follow directory symlinks (``followlinks=False`` prevents symlink loops),
+    tracks visited real paths as a second loop guard, and re-raises any scandir
+    error via ``onerror`` so a partial listing never masks protected data.
+    """
+    if not path:
+        return True  # cannot prove safe → protect
+    try:
+        if not os.path.isdir(path):
+            # A missing dir has nothing to protect; a file is guarded by its own
+            # callers (soft-delete / .pt removal), never by this folder predicate.
+            return False
+    except OSError:
+        return True
+    seen = set()
+    try:
+        for root, dirs, files in os.walk(path, onerror=_raise, followlinks=False):
+            try:
+                if _is_turtle_data_folder(root):
+                    return True
+                rp = os.path.realpath(root)
+            except OSError:
+                return True
+            if rp in seen:
+                dirs[:] = []
+                continue
+            seen.add(rp)
+    except OSError:
+        return True
+    return False
+
+
+def _is_exempt(path, base_dir=None):
+    """True for paths the guard must let through even if flagged as turtle data.
+
+    Exempt: the system tempdir (upload staging), and (relative to ``base_dir``)
+    ``Review_Queue``, ``benchmarks`` and ``_Archive``. ``base_dir`` defaults to
+    the module ``BASE_DATA_DIR``.
+
+    The tempdir exemption applies only *outside* the data root. In production the
+    data root (``/app/data``) and the system tempdir (``/tmp``) are disjoint, so
+    this is a no-op there. It matters only when the data root itself sits under
+    the tempdir — which is exactly how tests build a fake base (``tmp_path`` lives
+    under ``/tmp``): the dataset stays protected, while genuine staging files
+    outside it stay deletable.
+    """
+    base = base_dir if base_dir is not None else BASE_DATA_DIR
+    if _is_within(path, tempfile.gettempdir()) and not _is_within(path, base):
+        return True
+    for area in _EXEMPT_RELATIVE_AREAS:
+        if _is_within(path, os.path.join(base, area)):
+            return True
+    return False
+
+
+def assert_not_turtle_data(path, base_dir=None):
+    """Raise ``UndeletableTurtleDataError`` if deleting ``path`` would lose turtle data."""
+    if is_or_contains_turtle_data(path) and not _is_exempt(path, base_dir):
+        raise UndeletableTurtleDataError(str(path))
+
+
+def guarded_rmtree(path, base_dir=None):
+    """``shutil.rmtree`` that refuses to destroy a protected turtle-data folder."""
+    assert_not_turtle_data(path, base_dir)
+    shutil.rmtree(path)
+
+
+def guarded_rmdir(path, base_dir=None):
+    """``os.rmdir`` (empty dirs only) that still refuses a protected turtle folder.
+
+    Removing an empty directory is not data loss, so it is allowed (an empty dir
+    is not turtle data). A non-empty turtle folder is refused by the assert; any
+    other non-empty dir is refused by ``os.rmdir`` itself.
+    """
+    assert_not_turtle_data(path, base_dir)
+    os.rmdir(path)
+
+
+def _sanitized_relpath(src_abs, base):
+    """Filesystem-safe token for the source's path relative to ``base``."""
+    try:
+        rel = os.path.relpath(src_abs, base)
+    except ValueError:
+        rel = os.path.basename(src_abs)
+    if rel.startswith('..') or os.path.isabs(rel):
+        rel = os.path.basename(src_abs)
+    flat = rel.replace('\\', '/').replace('/', '__')
+    safe = re.sub(r'[^A-Za-z0-9._-]+', '_', flat).strip('_')
+    return safe or 'turtle'
+
+
+def archive_turtle_folder(src, base_dir=None):
+    """Move a turtle folder into ``<base>/_Archive/<UTC timestamp>_<relpath>/``.
+
+    This is the "delete becomes reversible" primitive used in place of
+    ``shutil.rmtree`` on turtle folders (merge secondary removal, new-turtle
+    rollback, the merge CLI). Returns the destination path. The ``_Archive`` root
+    is created lazily. A name collision (e.g. a concurrent archive of a
+    same-named path in the same second) gets a ``__N`` counter suffix, so the
+    move never clobbers or nests into an existing archive under the threaded
+    server. No shared mutable module state is used.
+
+    ``base_dir`` defaults to the module ``BASE_DATA_DIR``; callers inside the
+    manager pass ``self.base_dir`` so an archive always lands under the same data
+    root the folder came from (critical for tests using a temp base dir).
+    """
+    base = base_dir if base_dir is not None else BASE_DATA_DIR
+    src_abs = os.path.abspath(src)
+    if not os.path.isdir(src_abs):
+        raise FileNotFoundError(f"archive_turtle_folder: source is not a directory: {src}")
+
+    archive_root = os.path.join(base, ARCHIVE_DIR_NAME)
+    os.makedirs(archive_root, exist_ok=True)
+
+    ts = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
+    base_name = f"{ts}_{_sanitized_relpath(src_abs, base)}"
+    dest = os.path.join(archive_root, base_name)
+    counter = 1
+    while os.path.exists(dest):
+        dest = os.path.join(archive_root, f"{base_name}__{counter}")
+        counter += 1
+
+    shutil.move(src_abs, dest)
+    print(f"🗄️ Archived turtle folder → {dest}")
+    return dest


### PR DESCRIPTION
## Summary

The on-disk turtle dataset (`data/<State>/<Location>/<TurtleID>/` with `plastron`/`carapace`/`ref_data`, plus combo-sheet, community, and Incidental turtle folders) is the **permanent research dataset**. It must be **undeletable by the app** — movable and renamable only, never deletable, even by an admin, never by accident.

An audit found it was **not** undeletable: `POST /api/turtles/merge` hard-deleted the entire secondary turtle folder (the one data-loss path on the live admin surface); approval rollback `rmtree`d the just-created folder on a Sheets outage; a single additional-image delete hard-removed a curated research image with no soft-delete; and the reset CLIs could wipe the whole dataset behind only an interactive prompt. There was no guard — deletes were raw `rmtree`/`remove` across ~20 files.

## What this does

- **`turtle_manager/safe_fs.py`** — `assert_not_turtle_data(path)` refuses any path that **is, contains (at any depth), or sits at the depth of** a turtle folder; exempt only the transient areas (system tempdir, `Review_Queue` packets, `benchmarks`). Fails closed on any probe error. Plus `guarded_rmtree`/`guarded_rmdir` wrappers and `archive_turtle_folder()` which **moves** a folder into `_Archive/` rather than deleting it.
- **Delete → archive-move** for the three turtle-folder `rmtree` sites (merge secondary, approval rollback, merge CLI) — those operations become **reversible**.
- **Single additional-image delete → `Deleted/` soft-delete** (recoverable), with the image's tags migrated along with it.
- **Reset scripts fail closed** — they refuse to touch turtle data unless an explicit, off-HTTP `--force-destroy-dataset` / `FORCE_DESTROY_DATASET=1` override is set; the interactive prompt is unchanged.
- **`_Archive` is protected like the live dataset** (a rolled-back turtle can be the sole copy of its photos) and is excluded from the match index, the location list, the additional-image search, and turtle-id resolution — so archived turtles neither match nor resurface.
- Legitimate deletes are untouched: temp files, `.pt` tensors, `Review_Queue` packets, staged files, and the reference-swap archive-then-remove.

Deleting a **General Location** was already safe (it moves folders / refuses when turtles exist; no `rmtree`) — unchanged.

Backend-only and independent of the staff-groups PR stack (#263–#269). **Release number deferred** to merge time to avoid colliding with that stack's v2.1.0–v2.1.3.

### Review

A pre-merge adversarial bypass hunt (four lenses) found **no guard bypass** — the core promise holds. Five secondary findings from introducing `_Archive` were fixed: `_Archive` is now protected (was deletable by a non-force reset), archived turtles no longer resurface in the additional-image search or id resolution, the additional-image soft-delete now preserves tags (they were being dropped before migration), and the merge-CLI help text was corrected. Regression tests added for each.

Verified: backend unit suite **275 passing** (252 baseline + 23 new safe_fs/flow tests), `import app` clean, no frontend/auth-backend/lockfile churn.

Closes #271